### PR TITLE
Toc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ background on the different aspects of LinuxBoot.
 
 |Chapter|&emsp; &emsp;Title|
 |:-----:|:--------------|
-| [1](TOC/README.md)|&emsp; &emsp;Overview and Table of Contents|
-| [2](ntroduction/README.md)|&emsp; &emsp;LinuxBoot Introduction|
+| [1](README.md)|&emsp; &emsp;Overview and Table of Contents|
+| [2](intro/README.md)|&emsp; &emsp;LinuxBoot Introduction|
 | [3](components/README.md)|&emsp; &emsp;LinuxBoot Components|
 | [4](u-root/README.md)|&emsp; &emsp;All about u-root|
-| 5|&emsp; &emsp;Implementing LinuxBoot|
-| [6](Glossary/README.md)|&emsp; &emsp;Glossary|
+| [5](implementation/README.md)|&emsp; &emsp;Implementing LinuxBoot|
+| [6](glossary/README.md)|&emsp; &emsp;Glossary|
 
 ## Acknowledgments
 


### PR DESCRIPTION
There was a typo in the TOC entry for the link to the Implementation section. This fixes the typo.