### PR TITLE
book.toml: add cname entry

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,4 @@ language = "en"
 multilingual = false
 src = "src"
 title = "LinuxBoot"
+cname = "book.linuxboot.org"


### PR DESCRIPTION
We kept losing the CNAME file. Apparently this is needed.
See https://rust-lang.github.io/mdBook/format/configuration/renderers.html

Signed-off-by: Daniel Maslowski <info@orangecms.org>
