### PR TITLE
u-root: fix footnotes and code snippet, set up link checker

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,6 +24,8 @@ jobs:
           mdbook-version: "0.4.48"
           use-mermaid: true
           mermaid-version: "0.15.0"
+          use-linkcheck: true
+          linkcheck-version: "0.7.7"
 
       - name: Install mdbook-mermaid
         run: mdbook-mermaid install

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ prepare:
 	cargo install mdbook
 	cargo install mdbook-mermaid
 	mdbook-mermaid install
+	cargo install mdbook-linkcheck

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ For more details, please refer to the mdBook documentation.
 Some pages render diagrams using [mermaid.js](https://mermaid.js.org/), which is
 preprocessed with [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid).
 
+To check that all links are still available, [mdbook-linkcheck](
+https://github.com/Michael-F-Bryan/mdbook-linkcheck) also runs in CI.
+
 For convenience, the `Makefile` lets you set up and run the environment:
 
 ```sh

--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,8 @@ cname = "book.linuxboot.org"
 git-repository-url = "https://github.com/linuxboot/book"
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
+[output.linkcheck]
+
 [preprocessor]
 
 [preprocessor.mermaid]

--- a/src/components.md
+++ b/src/components.md
@@ -1,6 +1,6 @@
 ## LinuxBoot Components
 
-![image](../images/LinuxBoot-components.svg)
+![image](./images/LinuxBoot-components.svg)
 
 LinuxBoot consists of the following components:
 
@@ -30,7 +30,7 @@ kernel and add some patches that are needed.
 #### Initial RAM filesystem  (initramfs)
 
 When Linux boots it needs a root file system that provides boot and startup
-utilities. LinuxBoot uses [u-root](../glossary) to create an
+utilities. LinuxBoot uses [u-root](./glossary.md) to create an
 initramfs for this purpose.
 
 

--- a/src/implementation.md
+++ b/src/implementation.md
@@ -23,7 +23,7 @@ UEFI has three sections:
 DXE process is very complex; some systems have 750 DXEs.
 
 LinuxBoot replaces most of the UEFI software with Linux. LinuxBoot has an
-initramfs provided by [u-root](../u-root.md).
+initramfs provided by [u-root](./u-root.md).
 
 The above are stored inside a flash filesystem (FFS) inside a region of flash
 on your motherboard (the BIOS region). Another important region of flash is the

--- a/src/intro.md
+++ b/src/intro.md
@@ -79,7 +79,7 @@ filesystem used for LinuxBoot is based on u-root standard utilities written in
 Go. The following diagram shows the current state of the UEFI boot process and
 what is planned for the transition to LinuxBoot.
 
-[![comparison of UEFI boot and LinuxBoot](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)
+[![comparison of UEFI boot and LinuxBoot](./images/UEFI-versus-LinuxBoot.svg)](./images/UEFI-versus-LinuxBoot.svg)
 
 ## Benefits of using the Go user-space environment and compiler
 

--- a/src/u-root.md
+++ b/src/u-root.md
@@ -26,8 +26,8 @@ in their security.
 ## U-root and embedded systems
 
 Embedding kernels and root file systems in BIOS flash is a common technique for
-gaining boot time performance and platform customization[^25][^14][^23]. Almost
-all new firmware includes a multiprocess operating system with a full
+gaining boot time performance and platform customization[^25] [^14] [^23].
+Almost all new firmware includes a multiprocess operating system with a full
 complement of file systems, network drivers, and protocol stacks, all contained
 in an embedded file system. In some cases, the kernel is only booted long
 enough to boot another kernel. In others, the kernel that is booted and the
@@ -44,7 +44,7 @@ connected. Network connected systems face a far more challenging security
 environment than even a few years ago. In response to the many successful
 attacks against shell interpreters[^11] and C programs[^8], we have started to
 look at using a more secure, modern language in embedded root file systems,
-namely, Go[^21][^16].
+namely, Go[^21] [^16].
 
 Go is a new systems programming language created by Google. Go has strong
 typing; language level support for concurrency; inter-process communication via
@@ -72,10 +72,10 @@ because firmware is designed to be as invisible as possible. Firmware is
 extremely complex; UEFI is roughly equivalent in size and capability to a Unix
 kernel. Firmware is usually closed and proprietary, with nowhere near the level
 of testing of kernels. These properties make firmware an ideal place for
-so-called advanced persistent threats[^10][^18][^5]. Once an exploit is installed,
-it is almost impossible to remove, since the exploit can inhibit its removal by
-corrupting the firmware update process. The only sure way to mitigate a
-firmware exploit is to destroy the hardware.
+so-called advanced persistent threats[^10] [^18] [^5]. Once an exploit is
+installed, it is almost impossible to remove, since the exploit can inhibit its
+removal by corrupting the firmware update process. The only sure way to mitigate
+a firmware exploit is to destroy the hardware.
 
 U-root is an excellent option for embedded systems. U-root contains only 5
 binaries, 4 of them from the Go toolchain, and the 5th is an init binary. The
@@ -157,7 +157,7 @@ complete set of symlinks. As a final step, init execs `sh`.
 
 There is no `/bin/sh` at this point; the first `sh` found in $PATH is
 `/buildbin/sh`. This is a symlink to `installcommand`. `Installcommand`, once
-started, examines argv[0], which is `sh`, and takes this as instruction to
+started, examines `argv[0]`, which is `sh`, and takes this as instruction to
 build `/src/cmds/sh/.go` into `/bin` and then exec `/bin/sh`. There is no
 difference between starting the first shell and any other program. Hence, part
 of the boot process involves the construction of an installation tool to build
@@ -502,7 +502,7 @@ performance.
 
 ## Embedding kernel and root file systems in flash
 
-The LinuxBIOS project[^14][^1], together with clustermatic[^25], used an embedded
+The LinuxBIOS project[^14] [^1], together with clustermatic[^25], used an embedded
 kernel and simple root file system to manage supercomputing clusters. Due to
 space constraints of 1 MiB or less of flash, clusters embedded only a
 single-processor Linux kernel with a daemon. The daemon was a network


### PR DESCRIPTION
The code snippet looked to the link checker like a link. Multiple footnotes have to be separated by spaces in order to be recognized.