### PR TITLE
Add zh tw support

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+env:
+  # Update the language picker in theme/js/language-picker.js to link new languages.
+  LANGUAGES: zh-TW
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04
@@ -30,11 +34,27 @@ jobs:
       - name: Install mdbook-mermaid
         run: mdbook-mermaid install
 
+      - name: Install mdbook-i18n-helpers
+        run: |
+          cargo install mdbook-i18n-helpers --locked --version 0.3.4
+
       - name: Build
         # linkcheck causes ouput files to end up in html/, so move them to root
         run: |
           mdbook build
           mv book/html/* book/
+
+      - name: Build all translations
+        run: |
+          for po_lang in ${{ env.LANGUAGES }}; do
+            echo "::group::Building $po_lang translation"
+            MDBOOK_BOOK__LANGUAGE=$po_lang \
+            MDBOOK_OUTPUT__HTML__SITE_URL=/linuxboot-book/$po_lang/ \
+            mdbook build -d book/$po_lang
+            rsync -a book/$po_lang/html/ book/$po_lang/
+            rm -r book/$po_lang/html/
+            echo "::endgroup::"
+          done
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ ci/vale/styles/Microsoft/
 ci/vale/styles/proselint/
 ci/vale/styles/RedHat/
 ci/vale/styles/write-good/
-*.js
+mermaid*.js

--- a/book.toml
+++ b/book.toml
@@ -5,6 +5,9 @@ multilingual = false
 src = "src"
 title = "LinuxBoot"
 
+[preprocessor.gettext]
+after = ["links"]
+
 [output.html]
 cname = "book.linuxboot.org"
 git-repository-url = "https://github.com/linuxboot/book"

--- a/book.toml
+++ b/book.toml
@@ -1,17 +1,22 @@
 [book]
 authors = ["LinuxBoot authors"]
-language = "en"
-multilingual = false
 src = "src"
 title = "LinuxBoot"
-
-[preprocessor.gettext]
-after = ["links"]
 
 [output.html]
 cname = "book.linuxboot.org"
 git-repository-url = "https://github.com/linuxboot/book"
-additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = [
+    "theme/css/language-picker.css",
+]
+additional-js = [
+    "mermaid.min.js",
+    "mermaid-init.js",
+    "theme/js/language-picker.js",
+]
+
+[build]
+extra-watch-dirs = ["po"]
 
 [output.linkcheck]
 
@@ -19,3 +24,6 @@ additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
+
+[preprocessor.gettext]
+after = ["links"]

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,0 +1,6497 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: LinuxBoot\n"
+"POT-Creation-Date: 2025-04-28T16:48:12+08:00\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1 src/intro.md:1
+msgid "LinuxBoot Introduction"
+msgstr ""
+
+#: src/SUMMARY.md:2 src/use-cases.md:1
+msgid "Use cases"
+msgstr ""
+
+#: src/SUMMARY.md:3
+msgid "Talks and news coverage"
+msgstr ""
+
+#: src/SUMMARY.md:4 src/components.md:1
+msgid "LinuxBoot Components"
+msgstr ""
+
+#: src/SUMMARY.md:5 src/tools-evaluation.md:1
+msgid "Evaluation of tools"
+msgstr ""
+
+#: src/SUMMARY.md:6 src/u-root.md:1
+msgid "All about u-root"
+msgstr ""
+
+#: src/SUMMARY.md:7 src/u-root-qemu-demo.md:1
+msgid "u-root demo with QEMU"
+msgstr ""
+
+#: src/SUMMARY.md:8
+msgid "LinuxBoot utilities"
+msgstr ""
+
+#: src/SUMMARY.md:9 src/utilities/UEFI_Tool_Kit.md:1
+msgid "UEFI Tool Kit"
+msgstr ""
+
+#: src/SUMMARY.md:10
+msgid "The magical cpu command"
+msgstr ""
+
+#: src/SUMMARY.md:11
+msgid "Device Under Test"
+msgstr ""
+
+#: src/SUMMARY.md:12 src/implementation.md:1
+msgid "Implementing LinuxBoot"
+msgstr ""
+
+#: src/SUMMARY.md:13 src/coreboot.u-root.systemboot/index.md:1
+msgid "LinuxBoot using coreboot, u-root and systemboot"
+msgstr ""
+
+#: src/SUMMARY.md:14 src/glossary.md:1
+msgid "Glossary"
+msgstr ""
+
+#: src/SUMMARY.md:15 src/history.md:1
+msgid "History"
+msgstr ""
+
+#: src/SUMMARY.md:16 src/case_studies/index.md:1
+msgid "Case Studies"
+msgstr ""
+
+#: src/SUMMARY.md:17
+msgid "Ampere study"
+msgstr ""
+
+#: src/SUMMARY.md:18
+msgid "Google study"
+msgstr ""
+
+#: src/SUMMARY.md:19
+msgid "OCP TiogaPass"
+msgstr ""
+
+#: src/SUMMARY.md:20
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: src/intro.md:3
+msgid ""
+"This is the official “LinuxBoot Book” for the LinuxBoot project. The book:"
+msgstr ""
+
+#: src/intro.md:5
+msgid "Describes the LinuxBoot project"
+msgstr ""
+
+#: src/intro.md:6
+msgid "Explains why you would want to use LinuxBoot"
+msgstr ""
+
+#: src/intro.md:7
+msgid "Describes the components that comprise LinuxBoot"
+msgstr ""
+
+#: src/intro.md:8
+msgid "Highlights the differences between other boot processes and LinuxBoot"
+msgstr ""
+
+#: src/intro.md:9
+msgid "Guides you through the steps needed to implement LinuxBoot"
+msgstr ""
+
+#: src/intro.md:11
+msgid "What is LinuxBoot?"
+msgstr ""
+
+#: src/intro.md:13
+msgid ""
+"LinuxBoot is the idea of replacing proprietary or corporate-driven "
+"late-stage boot [firmware](./glossary.md) with the Linux kernel and a "
+"community-based user-space. That idea grew into a project that over the "
+"years includes various initiatives with the overarching goal of moving from "
+"obscure and complex firmware to simpler and open source firmware."
+msgstr ""
+
+#: src/intro.md:19
+msgid ""
+"The LinuxBoot project provides two reference implementations; `linuxboot` "
+"and Heads. The [`linuxboot`](https://github.com/linuxboot/linuxboot) build "
+"system outputs a boot payload consisting of a Linux kernel and an "
+"[initramfs](https://de.wikipedia.org/wiki/Initramfs) that contains a minimal "
+"Golang user-space built using [u-root](https://github.com/u-root/u-root)."
+msgstr ""
+
+#: src/intro.md:25
+msgid ""
+"The Heads build system is more focused on local attestation, TPM DUK "
+"seal/unseal operations, GPG-based security measurement, reproducible builds "
+"and uses BusyBox to provide a much larger suite of Linux tools allowing it "
+"to also be used as a recovery environment."
+msgstr ""
+
+#: src/intro.md:30
+msgid "Many other implementations exist independently of the project:"
+msgstr ""
+
+#: src/intro.md:32
+msgid ""
+"[petitboot](https://github.com/open-power/petitboot) under the OpenPOWER "
+"project originally targeting the PS3"
+msgstr ""
+
+#: src/intro.md:34
+msgid ""
+"[k-boot](https://github.com/BayLibre/k-boot) developed by BayLibre in 2023 "
+"using BusyBox"
+msgstr ""
+
+#: src/intro.md:36
+msgid "[nmbl](https://github.com/rhboot/nmbl-poc) developed by RedHat in 2024"
+msgstr ""
+
+#: src/intro.md:37
+msgid "[ZFSBootMenu](https://docs.zfsbootmenu.org/en/latest)"
+msgstr ""
+
+#: src/intro.md:39
+msgid ""
+"And there is a long history of similar implementations including projects "
+"that are no longer maintained:"
+msgstr ""
+
+#: src/intro.md:42
+msgid ""
+"MILO on Alpha started before 2000 (see [What is "
+"MILO?](https://tldp.org/HOWTO/MILO-HOWTO/what-section.html))"
+msgstr ""
+
+#: src/intro.md:44
+msgid "kboot developed by Werner Almesberger in 2005"
+msgstr ""
+
+#: src/intro.md:46
+msgid ""
+"These projects all attempt to reduce the role of firmware to a small, "
+"fixed-function core whose only purpose is to get a flash-based Linux kernel "
+"started. This “bare essentials” firmware prepares the hardware and starts a "
+"Linux kernel and a user-space environment will run on the machine. Go is the "
+"recommended user-space environment, but is not required."
+msgstr ""
+
+#: src/intro.md:52
+msgid "Why LinuxBoot is needed"
+msgstr ""
+
+#: src/intro.md:54
+msgid ""
+"Sometimes firmware contains drivers and utilities. They can have bugs, or be "
+"unmaintained, which can be a source of problems and security issues. "
+"LinuxBoot replaces proprietary, closed-source, vendor-supplied firmware "
+"drivers with Linux drivers. This enables engineers writing Linux drivers and "
+"engineers writing firmware drivers to focus on one set of drivers. Those "
+"drivers will, as a result, have a larger set of contributors and reviewers, "
+"and because the drivers are part of Linux, standard industry coding "
+"infrastructure can be used to improve them. Finally, because these Linux "
+"drivers are currently being run around the clock at scale, they will have "
+"fewer bugs."
+msgstr ""
+
+#: src/intro.md:64
+msgid "What LinuxBoot does"
+msgstr ""
+
+#: src/intro.md:66
+msgid ""
+"LinuxBoot replaces many Driver Execution Environment (DXE) modules used by "
+"Unified Extensible Firmware Interface (UEFI) and other firmware, "
+"particularly the network stack and file system modules, with Linux "
+"applications."
+msgstr ""
+
+#: src/intro.md:70
+msgid ""
+"LinuxBoot brings up the Linux kernel as a DXE in flash ROM instead of the "
+"UEFI shell. The Linux kernel, with a provided Go based user-space, can then "
+"load the runtime kernel. The LinuxBoot paradigm enables writing traditional "
+"firmware applications such as boot loader, debugging, diagnosis, and error "
+"detection applications as cross-architecture and cross-platform portable "
+"Linux applications."
+msgstr ""
+
+#: src/intro.md:77
+msgid ""
+"When Linux boots it needs a root file system with utilities. One such root "
+"filesystem used for LinuxBoot is based on u-root standard utilities written "
+"in Go. The following diagram shows the current state of the UEFI boot "
+"process and what is planned for the transition to LinuxBoot."
+msgstr ""
+
+#: src/intro.md:82
+msgid ""
+"[![comparison of UEFI boot and "
+"LinuxBoot](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
+msgstr ""
+
+#: src/intro.md:84
+msgid "Benefits of using the Go user-space environment and compiler"
+msgstr ""
+
+#: src/intro.md:86
+msgid ""
+"Go is a systems programming language created by Google. Go has strong "
+"typing, language level support for concurrency, inter-process communication "
+"via channels, runtime type safety and other protective measures, dynamic "
+"allocation and garbage collection, and closures. Go has a package name "
+"notation similar to Java that makes it clear to determine what packages a "
+"given program needs."
+msgstr ""
+
+#: src/intro.md:92
+msgid ""
+"The modern language constructs make Go a much safer language than C. This "
+"safety is critical for network-attached embedded systems, which usually have "
+"network utilities written in C, including web servers, network servers "
+"including `sshd`, and programs that provide access to a command interpreter, "
+"itself written in C. All are proving to be vulnerable to the attack-rich "
+"environment that the Internet has become."
+msgstr ""
+
+#: src/intro.md:99
+msgid ""
+"Even the most skilled programmers can make mistakes that in C can be "
+"unrecoverable, especially on network connected systems. Currently, even the "
+"lowest-level firmware in our PCs, printers, and thermostats is "
+"network-connected. These programming mistakes are either impossible to make "
+"in Go or, if made, are detected at runtime and result in the program exiting."
+msgstr ""
+
+#: src/intro.md:105
+msgid ""
+"The case for using a high-level, safe language like Go in low level embedded "
+"firmware might be stronger than for user programs, because exploits at the "
+"firmware level are nearly impossible to detect and mitigate."
+msgstr ""
+
+#: src/intro.md:109
+msgid ""
+"The challenge to using Go in a storage-constrained environment such as "
+"firmware is that advanced language features lead to big binaries. Even a "
+"date program is about 2 MiB. One Go binary, implementing one function, is "
+"twice as large as a BusyBox binary implementing many functions. Currently, a "
+"typical BIOS FLASH part is 16 MiB. Fitting many Go binaries into a single "
+"BIOS flash part is not practical. The Go compiler is fast and its sheer "
+"speed suggests a solution of having programs compiled only when they are "
+"used. With this approach, you can build a root file system that has almost "
+"no binaries except the Go compiler itself. The compiled programs and "
+"packages can be saved to a RAM-based file system. Another solution is to "
+"compile everything together into one BusyBox-style program. Alternatively, "
+"programs can be fetched over the network, but compiling dynamically with Go "
+"or creating a BusyBox program are the recommended solutions."
+msgstr ""
+
+#: src/intro.md:123
+msgid "Benefits of LinuxBoot with UEFI servers"
+msgstr ""
+
+#: src/intro.md:125
+msgid ""
+"Most server firmware is based on Intel’s Universal Extensible Firmware "
+"Interface (UEFI). LinuxBoot provides the following benefits over UEFI:"
+msgstr ""
+
+#: src/intro.md:128
+msgid "Reliability"
+msgstr ""
+
+#: src/intro.md:130
+msgid ""
+"Improves boot reliability by replacing lightly-tested firmware drivers with "
+"hardened Linux drivers"
+msgstr ""
+
+#: src/intro.md:132
+msgid ""
+"Proven approach for almost 20 years in military, consumer electronics, and "
+"supercomputers – wherever reliability and performance are paramount"
+msgstr ""
+
+#: src/intro.md:134
+msgid ""
+"Fault Tolerance - Linux isolates processes\\*\\* \\*\\*(for example, when "
+"`pxeboot` fails catastrophically, `diskboot` still works afterwards)"
+msgstr ""
+
+#: src/intro.md:137
+msgid "Security"
+msgstr ""
+
+#: src/intro.md:139
+msgid "Move “Ring 0” boot loaders to “Ring 3”"
+msgstr ""
+
+#: src/intro.md:140
+msgid "`pxeboot` and `diskboot` do parsing and other logic in user-space"
+msgstr ""
+
+#: src/intro.md:141
+msgid "Go provides memory safety and type safety"
+msgstr ""
+
+#: src/intro.md:142
+msgid "A buggy parser is much less likely to affect other programs"
+msgstr ""
+
+#: src/intro.md:143
+msgid "Kernel security patches can apply to firmware"
+msgstr ""
+
+#: src/intro.md:145
+msgid "Flexibility"
+msgstr ""
+
+#: src/intro.md:147
+msgid ""
+"Can be used with coreboot, u-boot, OpenPOWER Abstraction Layer (OPAL), "
+"SlimBootLoader, ARM Trusted Firmware (ATF)"
+msgstr ""
+
+#: src/intro.md:149
+msgid ""
+"Can boot multiple operating systems (Linux, Berkeley UNIX (BSD), XEN, "
+"Windows)"
+msgstr ""
+
+#: src/intro.md:151
+msgid "Supports the following server mainboards:"
+msgstr ""
+
+#: src/intro.md:152
+msgid "QEMU emulated Q35 systems"
+msgstr ""
+
+#: src/intro.md:153
+msgid "[Intel S2600WF](https://trmm.net/S2600wf)"
+msgstr ""
+
+#: src/intro.md:154
+msgid "[Dell R630](https://trmm.net/NERF)"
+msgstr ""
+
+#: src/intro.md:155
+msgid "Winterfell Open Compute node"
+msgstr ""
+
+#: src/intro.md:156
+msgid "Leopard Open Compute node"
+msgstr ""
+
+#: src/intro.md:157
+msgid "Tioga Pass Open Compute node"
+msgstr ""
+
+#: src/intro.md:158
+msgid "Monolake Open Compute node (not tested)"
+msgstr ""
+
+#: src/intro.md:160
+msgid "Boot speed"
+msgstr ""
+
+#: src/intro.md:162
+msgid ""
+"Improves boot time by removing unnecessary code; typically makes boot 20 "
+"times faster"
+msgstr ""
+
+#: src/intro.md:165
+msgid "Customization"
+msgstr ""
+
+#: src/intro.md:167
+msgid ""
+"Allows customization of the initramfs runtime to support site-specific needs "
+"(both device drivers as well as custom executables)"
+msgstr ""
+
+#: src/intro.md:170
+msgid "Engineering Productivity"
+msgstr ""
+
+#: src/intro.md:172
+msgid "Write a driver once, not twice"
+msgstr ""
+
+#: src/intro.md:173
+msgid ""
+"Linux is **open, measurable, reproducible, and straightforward to update**"
+msgstr ""
+
+#: src/intro.md:174
+msgid "Linux already has drivers for almost everything"
+msgstr ""
+
+#: src/intro.md:175
+msgid "Kernel Engineers = Firmware Engineers"
+msgstr ""
+
+#: src/intro.md:176
+msgid "Many more Engineers know Linux than know UEFI"
+msgstr ""
+
+#: src/intro.md:177
+msgid "Reduced build time"
+msgstr ""
+
+#: src/intro.md:178
+msgid "**30s** for initramfs"
+msgstr ""
+
+#: src/intro.md:179
+msgid "**15s** for kernel (incremental)"
+msgstr ""
+
+#: src/intro.md:180
+msgid "**~15s** to repack the bios image (using fiano/utk)"
+msgstr ""
+
+#: src/intro.md:181
+msgid "**Total: ~1m** for a new full bios image, ready to be tested"
+msgstr ""
+
+#: src/intro.md:182
+msgid "Testing and debugging"
+msgstr ""
+
+#: src/intro.md:183
+msgid "`diskboot` and `pxeboot` already have unit tests"
+msgstr ""
+
+#: src/intro.md:184
+msgid "Easier to write tests using resources (like network) with Linux"
+msgstr ""
+
+#: src/intro.md:185
+msgid ""
+"Open-source projects such as u-root follow excellent software practices such "
+"as running automated test on each submitted change"
+msgstr ""
+
+#: src/intro.md:187
+msgid "Much easier to debug Go user-space applications"
+msgstr ""
+
+#: src/intro.md:188
+msgid "Test with a kernel in QEMU"
+msgstr ""
+
+#: src/use-cases.md:3
+msgid ""
+"The general concept of using a Linux kernel to boot into an operating system "
+"sounds simple at first glance. The challenges in the details, in part not "
+"only limited to using Linux, are being discussed in this chapter, with ideas "
+"on solving specific problems in the domain of bootloaders."
+msgstr ""
+
+#: src/use-cases.md:8
+msgid "Constrained environments"
+msgstr ""
+
+#: src/use-cases.md:10
+msgid ""
+"Booting a system means dealing with constraints. Those can have either of "
+"two effects: spark creativity or keep you from pursuing a goal. On foot, you "
+"can only reach as far in a day, whereas a vehicle gets you much further. "
+"With LinuxBoot, we want to take the chance to reevaluate contemporary "
+"designs and go beyond."
+msgstr ""
+
+#: src/use-cases.md:16
+msgid ""
+"When it comes to hardware, the vendor would choose the parts for their "
+"product and consider them in their price calculation."
+msgstr ""
+
+#: src/use-cases.md:19
+msgid ""
+"One main constraint is the initial boot source. A System-on-Chip (SoC) "
+"typically starts off with a mask ROM and continues with a simple storage "
+"part, which may range from a SPI flash of a few megabytes up to eMMC or SD "
+"cards of hundreds of megabytes or even gigabytes."
+msgstr ""
+
+#: src/use-cases.md:24
+msgid ""
+"We neglect other storages here that are attached via NVMe, SATA or other "
+"high-speed buses, because those are commonly not supported by mask ROMs. "
+"They are, on the other hand, what a bootloader offers to boot from, as well "
+"as network sources."
+msgstr ""
+
+#: src/use-cases.md:29
+msgid "Embedded devices"
+msgstr ""
+
+#: src/use-cases.md:31
+msgid ""
+"Many devices, nowadays known as IoT (Internet of Things), appliances, or "
+"similar, have a narrow use case. They are meant to perform a specific set of "
+"tasks, and thus can be tailored for it. In hardware terms, that often means "
+"an SoC, a bit of storage, and peripherals. Debug interfaces are reduced or "
+"removed for the final product."
+msgstr ""
+
+#: src/use-cases.md:37
+msgid "Desktop, laptop, workstation and server systems"
+msgstr ""
+
+#: src/use-cases.md:39
+msgid ""
+"At this point, many systems are still based on x86 processors, coming with a "
+"SPI flash on the board. While laptops and desktops mostly have a mere 16 or "
+"32 megabytes to offer, high-end servers and workstations already have 64, "
+"and even a second whole system called the Board Management Controller (BMC), "
+"which has its own firmware and corresponding storage. Designs around those "
+"constraints vary among OEMs."
+msgstr ""
+
+#: src/use-cases.md:46
+msgid ""
+"Note that it need not be that way. Arm based, RISC-V based and other systems "
+"already show that you can expect more, such as booting off eMMC. Laptops and "
+"desktop boards in that range are available as of now, even some servers and "
+"workstations."
+msgstr ""
+
+#: src/use-cases.md:51
+msgid "Single Board Computers (SBCs)"
+msgstr ""
+
+#: src/use-cases.md:53
+msgid ""
+"The SBC market has grown to such a degree that credit card size boards "
+"nowadays comes with both small storage parts that can act as boot sources as "
+"well as PCIe connectors that can hold NVMes of gigabytes and terabytes of "
+"storage. This gives us the opportunity to work out a boot flow that provides "
+"the end user with a very rich environment already early on before the main "
+"operating system is loaded."
+msgstr ""
+
+#: src/talks-news.md:1
+msgid "Coverage"
+msgstr ""
+
+#: src/talks-news.md:3
+msgid "Talks"
+msgstr ""
+
+#: src/talks-news.md:5 src/talks-news.md:39
+msgid "Date"
+msgstr ""
+
+#: src/talks-news.md:5
+msgid "Presenter"
+msgstr ""
+
+#: src/talks-news.md:5 src/talks-news.md:39
+msgid "Title"
+msgstr ""
+
+#: src/talks-news.md:7
+msgid "12/27/2016"
+msgstr ""
+
+#: src/talks-news.md:7 src/talks-news.md:9
+msgid "Trammell Hudson"
+msgstr ""
+
+#: src/talks-news.md:7
+msgid "[Bootstraping a slightly more secure laptop](https://trmm.net/Heads_33c3)"
+msgstr ""
+
+#: src/talks-news.md:8
+msgid "10/27/2017"
+msgstr ""
+
+#: src/talks-news.md:8
+msgid "Ron Minnich"
+msgstr ""
+
+#: src/talks-news.md:8
+msgid ""
+"Replace your exploit-ridden firmware with a Linux kernel "
+"([YouTube](https://www.youtube.com/watch?v=iffTJ1vPCSo), "
+"[slides](https://schd.ws/hosted_files/osseu17/84/Replace%20UEFI%20with%20Linux.pdf))"
+msgstr ""
+
+#: src/talks-news.md:9
+msgid "12/29/2017"
+msgstr ""
+
+#: src/talks-news.md:9
+msgid ""
+"[Bringing Linux back to the server BIOS with "
+"LinuxBoot](https://trmm.net/LinuxBoot_34c3)"
+msgstr ""
+
+#: src/talks-news.md:10
+msgid "09/13/2018"
+msgstr ""
+
+#: src/talks-news.md:10 src/talks-news.md:11
+msgid "Andrea Barberio, David Hendricks"
+msgstr ""
+
+#: src/talks-news.md:10
+msgid ""
+"[Open Source Firmware @ "
+"Facebook](https://www.osfc.io/2018/talks/open-source-firmware-facebook/)"
+msgstr ""
+
+#: src/talks-news.md:11
+msgid "10/02/2018"
+msgstr ""
+
+#: src/talks-news.md:11
+msgid ""
+"[Turning Linux Engineers into Firmware "
+"Engineers](https://2018ocpregionalsummit.sched.com/event/F8ax/turning-linux-engineers-into-firmware-engineers) "
+"([slides](https://insomniac.slackware.it/static/2018_ocp_regional_summit_linuxboot_at_facebook.pdf), "
+"[YouTube](https://www.youtube.com/watch?v=i84df1z6mdI))"
+msgstr ""
+
+#: src/talks-news.md:12
+msgid "06/15/2024"
+msgstr ""
+
+#: src/talks-news.md:12
+msgid "Marta Lewandowska"
+msgstr ""
+
+#: src/talks-news.md:12
+msgid ""
+"[No more boot loader: Please use the kernel "
+"instead](https://pretalx.com/devconf-cz-2024/talk/W3AVCT/)"
+msgstr ""
+
+#: src/talks-news.md:14
+msgid ""
+"[Make Your System Firmware Faster, More Flexible and Reliable with "
+"LinuxBoot](https://www.usenix.org/conference/lisa18/presentation/barberio) "
+"by [David Hendricks](https://github.com/dhendrix) and [Andrea "
+"Barberio](https://github.com/insomniacslk) at [LISA "
+"2018](https://www.usenix.org/conference/lisa18) "
+"([slides](https://insomniac.slackware.it/static/2018_lisa_linuxboot_at_facebook.pdf)) "
+"(2018-10-31)"
+msgstr ""
+
+#: src/talks-news.md:20
+msgid ""
+"[Open Source Firmware - A love "
+"story](https://www.youtube.com/watch?v=xfqKm190dbU) by [Philipp "
+"Deppenwiese](https://cybersecurity.9elements.com) at "
+"[35c3](https://events.ccc.de/congress/2018) "
+"([slides](https://cdn.media.ccc.de/congress/2018/slides-h264-hd/35c3-9778-deu-eng-Open_Source_Firmware_hd-slides.mp4)) "
+"(2018-12-27)"
+msgstr ""
+
+#: src/talks-news.md:25
+msgid ""
+"[Open Source Firmware at "
+"Facebook](https://fosdem.org/2019/schedule/event/open_source_firmware_at_facebook/) "
+"by [David Hendricks](https://github.com/dhendrix) and [Andrea "
+"Barberio](https://github.com/insomniacslk) at [FOSDEM "
+"2019](https://fosdem.org/2019/) "
+"([video](https://video.fosdem.org/2019/K.4.401/open_source_firmware_at_facebook.mp4)) "
+"([slides](https://insomniac.slackware.it/static/2019_fosdem_linuxboot_at_facebook.pdf)) "
+"(2019-02-03)"
+msgstr ""
+
+#: src/talks-news.md:32
+msgid ""
+"[Kexec Evolutions for "
+"LinuxBoot](https://www.osfc.io/2022/talks/kexec-evolutions-for-linuxboot/) "
+"by David Hu at OSFC 2021"
+msgstr ""
+
+#: src/talks-news.md:34
+msgid ""
+"[No more boot loader: Please use the kernel "
+"instead](https://pretalx.com/devconf-cz-2024/talk/W3AVCT/) at 2024 DevConf"
+msgstr ""
+
+#: src/talks-news.md:37
+msgid "News"
+msgstr ""
+
+#: src/talks-news.md:39
+msgid "Website"
+msgstr ""
+
+#: src/talks-news.md:41
+msgid "01/25/2018"
+msgstr ""
+
+#: src/talks-news.md:41
+msgid "Linux Foundation"
+msgstr ""
+
+#: src/talks-news.md:41
+msgid ""
+"[System Statup gets a Boost with new LinuxBoot "
+"project](https://www.linuxfoundation.org/blog/system-startup-gets-a-boost-with-new-linuxboot-project/)"
+msgstr ""
+
+#: src/talks-news.md:42
+msgid "02/15/2018"
+msgstr ""
+
+#: src/talks-news.md:42
+msgid "Linux Journal"
+msgstr ""
+
+#: src/talks-news.md:42
+msgid ""
+"[Linux Journal: FOSS Project Spotlight: "
+"LinuxBoot](https://www.linuxjournal.com/content/foss-project-spotlight-linuxboot/)"
+msgstr ""
+
+#: src/talks-news.md:43
+msgid "03/08/2018"
+msgstr ""
+
+#: src/talks-news.md:43 src/talks-news.md:48
+msgid "LWN"
+msgstr ""
+
+#: src/talks-news.md:43
+msgid "[LWN.net: LinuxBoot: Linux as firmware](https://lwn.net/Articles/748586/)"
+msgstr ""
+
+#: src/talks-news.md:44
+msgid "06/21/2018"
+msgstr ""
+
+#: src/talks-news.md:44 src/talks-news.md:45 src/talks-news.md:47
+msgid "Phoronix"
+msgstr ""
+
+#: src/talks-news.md:44
+msgid ""
+"[Equus WHITEBOX OPEN: A Line Of Coreboot/LinuxBoot-Ready Xeon Scalable "
+"Servers](https://www.phoronix.com/news/Equus-WHITEBOX-OPEN)"
+msgstr ""
+
+#: src/talks-news.md:45
+msgid "02/06/2019"
+msgstr ""
+
+#: src/talks-news.md:45
+msgid ""
+"[At Just Over One Year Old, LinuxBoot Continues Making Inroads At Facebook & "
+"Elsewhere](https://www.phoronix.com/news/LinuxBoot-2019)"
+msgstr ""
+
+#: src/talks-news.md:46
+msgid "03/14/2019"
+msgstr ""
+
+#: src/talks-news.md:46
+msgid "Facebook"
+msgstr ""
+
+#: src/talks-news.md:46
+msgid ""
+"[Facebook's LinuxBoot-powered F-16 high-performance fabric "
+"network](https://code.fb.com/data-center-engineering/f16-minipack/)"
+msgstr ""
+
+#: src/talks-news.md:47
+msgid "03/10/2023"
+msgstr ""
+
+#: src/talks-news.md:47
+msgid ""
+"[Lenovo Begins Supporting LinuxBoot Firmware With "
+"ByteDance](https://www.phoronix.com/news/Lenovo-LinuxBoot-ByteDance)"
+msgstr ""
+
+#: src/talks-news.md:48
+msgid "07/08/2024"
+msgstr ""
+
+#: src/talks-news.md:48
+msgid "[Giving bootloaders the boot with nmbl](https://lwn.net/Articles/979789)"
+msgstr ""
+
+#: src/components.md:3
+msgid "![image](../images/LinuxBoot-components.svg)"
+msgstr ""
+
+#: src/components.md:5
+msgid "LinuxBoot consists of the following components:"
+msgstr ""
+
+#: src/components.md:7 src/components.md:12 src/history.md:3
+msgid "BIOS"
+msgstr ""
+
+#: src/components.md:8 src/components.md:18
+msgid "Linux kernel"
+msgstr ""
+
+#: src/components.md:9
+msgid "u-root -> initramfs"
+msgstr ""
+
+#: src/components.md:14
+msgid ""
+"This does not have to be a specific BIOS; currently LinuxBoot supports UEFI "
+"and [coreboot](https://coreboot.org/)."
+msgstr ""
+
+#: src/components.md:20
+msgid ""
+"LinuxBoot is not intended to be a runtime production kernel; rather, it is "
+"meant to replace specific UEFI functionality using Linux kernel capabilities "
+"and then boot the actual production kernel on the machine. Kernel "
+"configuration files specific to LinuxBoot provide the needed Linux kernel "
+"capabilities without bloating the size of the BIOS with unnecessary drivers."
+msgstr ""
+
+#: src/components.md:26
+msgid ""
+"These config files disable options that are not needed in the LinuxBoot "
+"kernel and add some patches that are needed."
+msgstr ""
+
+#: src/components.md:30
+msgid "Initial RAM filesystem  (initramfs)"
+msgstr ""
+
+#: src/components.md:32
+msgid ""
+"When Linux boots it needs a root file system that provides boot and startup "
+"utilities. LinuxBoot uses [u-root](../glossary) to create an initramfs for "
+"this purpose."
+msgstr ""
+
+#: src/components.md:37
+msgid "What is an initramfs?"
+msgstr ""
+
+#: src/components.md:39
+msgid ""
+"The initramfs is a root file system that is embedded within the firmware "
+"image itself. It is intended to be placed in a flash device along with the "
+"Linux kernel as part of the firmware image for LinuxBoot. The initramfs is "
+"essentially a set of directories bundled into a single cpio archive."
+msgstr ""
+
+#: src/components.md:44
+msgid ""
+"At boot time, the boot loader or firmware (for example, coreboot) loads the "
+"bzImage and initramfs into memory and starts the kernel. The kernel checks "
+"for the presence of the initramfs and, if found, unpacks it, mounts it as "
+"`/` and runs `/init`."
+msgstr ""
+
+#: src/components.md:50
+msgid ""
+"There are many types of initramfs, in this topic we focus on u-root. u-root "
+"is a Go user-space (a set of programs and libraries written in Go that are "
+"used to interact with the kernel). It contains a toolset of standard Linux "
+"applications and commands."
+msgstr ""
+
+#: src/components.md:55
+msgid "u-root can create an initramfs in two different modes:"
+msgstr ""
+
+#: src/components.md:57
+msgid "source mode, which contains:"
+msgstr ""
+
+#: src/components.md:58
+msgid "Go toolchain binaries"
+msgstr ""
+
+#: src/components.md:59
+msgid "A simple shell"
+msgstr ""
+
+#: src/components.md:60
+msgid "Go source for tools to be compiled on the fly by the shell"
+msgstr ""
+
+#: src/components.md:61
+msgid ""
+"Busybox (bb) mode: This is one busybox-like binary comprising all the "
+"requested utilities."
+msgstr ""
+
+#: src/components.md:64
+msgid ""
+"The initramfs provided by u-root implements the toolchain needed to securely "
+"boot the machine from the network, perform identity verification, "
+"communicate with different internal boot-related components, and kexec the "
+"next kernel."
+msgstr ""
+
+#: src/components.md:68
+msgid ""
+"u-root is an open source project hosted on GitHub. Within the u-root "
+"repository, we have executable commands in `cmds` and the packages "
+"containing libraries and implementations in `pkg`."
+msgstr ""
+
+#: src/tools-evaluation.md:3
+msgid "Three general questions guide all software projects:"
+msgstr ""
+
+#: src/tools-evaluation.md:5
+msgid "what exists already? (implementations, tools and build systems)"
+msgstr ""
+
+#: src/tools-evaluation.md:6
+msgid "what needs development? (UIs and such)"
+msgstr ""
+
+#: src/tools-evaluation.md:7
+msgid "what is a good environment? (build + runtime)"
+msgstr ""
+
+#: src/tools-evaluation.md:9
+msgid ""
+"Not only do we want to answer those questions. We also keep track of the "
+"options and decision process in this book in order for readers to make sense."
+msgstr ""
+
+#: src/tools-evaluation.md:12
+msgid ""
+"There are many existing tools already that we can leverage to implement the "
+"idea of using Linux to boot into an operating system."
+msgstr ""
+
+#: src/tools-evaluation.md:15
+msgid "Root filesystem"
+msgstr ""
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+msgid "tool"
+msgstr ""
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+msgid "language"
+msgstr ""
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+msgid "license"
+msgstr ""
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+msgid "usage"
+msgstr ""
+
+#: src/tools-evaluation.md:19
+msgid "[BusyBox](https://busybox.net/)"
+msgstr ""
+
+#: src/tools-evaluation.md:19 src/tools-evaluation.md:20
+#: src/tools-evaluation.md:21 src/tools-evaluation.md:29
+#: src/tools-evaluation.md:30 src/tools-evaluation.md:31
+msgid "C"
+msgstr ""
+
+#: src/tools-evaluation.md:19 src/tools-evaluation.md:29
+#: src/tools-evaluation.md:31
+msgid "GPLv2"
+msgstr ""
+
+#: src/tools-evaluation.md:19 src/history.md:51
+msgid "Heads"
+msgstr ""
+
+#: src/tools-evaluation.md:20
+msgid "[toybox](http://landley.net/toybox)"
+msgstr ""
+
+#: src/tools-evaluation.md:20
+msgid "0BSD"
+msgstr ""
+
+#: src/tools-evaluation.md:20
+msgid "Android"
+msgstr ""
+
+#: src/tools-evaluation.md:21
+msgid "[GNU coreutils](https://www.gnu.org/software/coreutils/)"
+msgstr ""
+
+#: src/tools-evaluation.md:21
+msgid "GPLv3"
+msgstr ""
+
+#: src/tools-evaluation.md:21 src/tools-evaluation.md:23
+msgid "not for LinuxBoot"
+msgstr ""
+
+#: src/tools-evaluation.md:22
+msgid "[u-root](https://u-root.org)"
+msgstr ""
+
+#: src/tools-evaluation.md:22 src/tools-evaluation.md:32
+msgid "Go"
+msgstr ""
+
+#: src/tools-evaluation.md:22 src/tools-evaluation.md:32
+msgid "BSD 3-Clause"
+msgstr ""
+
+#: src/tools-evaluation.md:22
+msgid "ByteDance, Google et al"
+msgstr ""
+
+#: src/tools-evaluation.md:23
+msgid "[uutils/coreutils](http://uutils.github.io/)"
+msgstr ""
+
+#: src/tools-evaluation.md:23 src/tools-evaluation.md:33
+msgid "Rust"
+msgstr ""
+
+#: src/tools-evaluation.md:23
+msgid "MIT"
+msgstr ""
+
+#: src/tools-evaluation.md:25
+msgid "kexec implementations"
+msgstr ""
+
+#: src/tools-evaluation.md:29
+msgid ""
+"[kexec-tools](https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git) "
+"([GitHub mirror](https://github.com/horms/kexec-tools))"
+msgstr ""
+
+#: src/tools-evaluation.md:29
+msgid "Heads, Petitboot"
+msgstr ""
+
+#: src/tools-evaluation.md:30
+msgid "[systemd](https://systemd.io/) (wrapper)"
+msgstr ""
+
+#: src/tools-evaluation.md:30
+msgid "LGPL-2.1+"
+msgstr ""
+
+#: src/tools-evaluation.md:30
+msgid "systemd on UEFI"
+msgstr ""
+
+#: src/tools-evaluation.md:31
+msgid "[kexecboot](https://github.com/kexecboot/kexecboot)"
+msgstr ""
+
+#: src/tools-evaluation.md:31 src/tools-evaluation.md:33
+msgid "?"
+msgstr ""
+
+#: src/tools-evaluation.md:32
+msgid "u-root (CLI+mod)"
+msgstr ""
+
+#: src/tools-evaluation.md:32
+msgid "Google et al"
+msgstr ""
+
+#: src/tools-evaluation.md:33
+msgid "[kexlinux](https://github.com/im-0/kexlinux)"
+msgstr ""
+
+#: src/tools-evaluation.md:33
+msgid "LGPL-3.0+"
+msgstr ""
+
+#: src/u-root.md:3
+msgid ""
+"U-root is an embeddable root file system intended to be placed in a flash "
+"device as part of the firmware image, along with a Linux kernel. The program "
+"source code is installed in the root file system contained in the firmware "
+"flash part and compiled on demand. All the u-root utilities, roughly "
+"corresponding to standard Unix utilities, are written in Go, a modern, "
+"type-safe language with garbage collection and language-level support for "
+"concurrency and inter-process communication."
+msgstr ""
+
+#: src/u-root.md:11
+msgid ""
+"Unlike most embedded root file systems, which consist largely of binaries, "
+"u-root has only 5: an init program and 4 Go compiler binaries. When a "
+"program is first run, it, and any not-yet-built packages it uses are "
+"compiled to a RAM-based file system. The first invocation of a program takes "
+"a fraction of a second, as it is compiled. Packages are only compiled once, "
+"so the slowest build is always the first one, on boot, which takes about 3 "
+"seconds. Subsequent invocations are very fast, usually a millisecond or so."
+msgstr ""
+
+#: src/u-root.md:19
+msgid ""
+"U-root blurs the line between script-based distros such as Perl Linux[^24] "
+"and binary-based distros such as BusyBox[^26]. It has the flexibility of "
+"Perl Linux and the performance of BusyBox. Scripts and builtins are written "
+"in Go, not a shell scripting language. U-root is a new way to package and "
+"distribute file systems for embedded systems, and the use of Go promises a "
+"dramatic improvement in their security."
+msgstr ""
+
+#: src/u-root.md:26
+msgid "U-root and embedded systems"
+msgstr ""
+
+#: src/u-root.md:28
+msgid ""
+"Embedding kernels and root file systems in BIOS flash is a common technique "
+"for gaining boot time performance and platform customization[^25][^14][^23]. "
+"Almost all new firmware includes a multiprocess operating system with a full "
+"complement of file systems, network drivers, and protocol stacks, all "
+"contained in an embedded file system. In some cases, the kernel is only "
+"booted long enough to boot another kernel. In others, the kernel that is "
+"booted and the file system it contains constitute the operational "
+"environment of the device[^15]. These so-called “embedded root file systems” "
+"also contain a set of standard Unix-style programs used for both normal "
+"operation and maintenance. Space on the device is at a premium, so these "
+"programs are usually written in C using the BusyBox toolkit[^26], or in an "
+"interpretive language such as Perl[^24] or Forth. BusyBox in particular has "
+"found wide usage in embedded appliance environments, as the entire root file "
+"system can be contained in under one MiB."
+msgstr ""
+
+#: src/u-root.md:42
+msgid ""
+"Embedded systems, which were once standalone, are now almost always network "
+"connected. Network connected systems face a far more challenging security "
+"environment than even a few years ago. In response to the many successful "
+"attacks against shell interpreters[^11] and C programs[^8], we have started "
+"to look at using a more secure, modern language in embedded root file "
+"systems, namely, Go[^21][^16]."
+msgstr ""
+
+#: src/u-root.md:49
+msgid ""
+"Go is a new systems programming language created by Google. Go has strong "
+"typing; language level support for concurrency; inter-process communication "
+"via channels, a la Occam[^13], Limbo[^17], and Alef[^27]; runtime type "
+"safety and other protective measures; dynamic allocation and garbage "
+"collection; closures; and a package syntax, similar to Java, that makes it "
+"easy to determine what packages a given program needs. The modern language "
+"constructs make Go a much safer language than C. This safety is critical for "
+"network-attached embedded systems, which usually have network utilities "
+"written in C, including web servers, network servers including sshd, and "
+"programs that provide access to a command interpreter, itself written in C. "
+"All are proving to be vulnerable to the attack-rich environment that the "
+"Internet has become. Buffer overflow attacks affecting C-based firmware code "
+"(among other things) in 2015 include GHOST and the so-called FSVariable.c "
+"bug in Intel’s UEFI firmware. Buffer overflows in Intel’s UEFI and Active "
+"Management Technology (AMT) have also been discovered in several versions in "
+"recent years."
+msgstr ""
+
+#: src/u-root.md:65
+msgid ""
+"Both UEFI[^12] and AMT[^4] are embedded operating systems, loaded from flash "
+"that run network-facing software. Attacks against UEFI have been extensively "
+"studied[^9]. Most printers are network-attached and are a very popular "
+"exploitation target[^6]. Firmware is not visible to most users and is "
+"updated much less frequently (if at all) than programs. It is the first "
+"software to run, at power on reset. Exploits in firmware are extremely "
+"difficult to detect, because firmware is designed to be as invisible as "
+"possible. Firmware is extremely complex; UEFI is roughly equivalent in size "
+"and capability to a Unix kernel. Firmware is usually closed and proprietary, "
+"with nowhere near the level of testing of kernels. These properties make "
+"firmware an ideal place for so-called advanced persistent "
+"threats[^10][^18][^5]. Once an exploit is installed, it is almost impossible "
+"to remove, since the exploit can inhibit its removal by corrupting the "
+"firmware update process. The only sure way to mitigate a firmware exploit is "
+"to destroy the hardware."
+msgstr ""
+
+#: src/u-root.md:80
+msgid ""
+"U-root is an excellent option for embedded systems. U-root contains only 5 "
+"binaries, 4 of them from the Go toolchain, and the 5th is an init binary. "
+"The rest of the programs are contained in BIOS flash in source form, "
+"including packages. The search path is arranged so that when a command is "
+"invoked, if it is not in `/bin`, an installer is invoked instead which "
+"compiles the program into `/bin`. If the build succeeds, the command is "
+"executed. This first invocation takes a fraction of a second, depending on "
+"program complexity. After that, the RAM-based, statically linked binaries "
+"run in about a millisecond. Scripts are written in Go, not a shell scripting "
+"language, with two benefits: the shell can be simple, with fewer corner "
+"cases, and the scripting environment is substantially improved since Go is "
+"more powerful than most shell scripting languages, but also less fragile and "
+"less prone to parsing bugs."
+msgstr ""
+
+#: src/u-root.md:93
+msgid "U-root design"
+msgstr ""
+
+#: src/u-root.md:95
+msgid ""
+"The u-root boot image is a build toolchain and a set of programs in source "
+"form. When first used, a program and any needed but not-yet-built packages "
+"are built and installed, typically in a fraction of a second. With later "
+"uses, the binary is executed. The root file system is almost entirely "
+"unformed on boot; `/init` sets up the key directories and mounts, including "
+"common ones such as `/etc` and `/proc`."
+msgstr ""
+
+#: src/u-root.md:102
+msgid ""
+"Since the init program itself is only 132 lines of code and is easy to "
+"change, the structure is very flexible and allows for many use cases, for "
+"example:"
+msgstr ""
+
+#: src/u-root.md:105
+msgid ""
+"Additional binaries: if the 3 seconds it takes to get to a shell is too long "
+"(some applications such as automotive computing require 800 ms startup "
+"time), and there is room in flash, some programs can be precompiled into "
+"/bin."
+msgstr ""
+
+#: src/u-root.md:108
+msgid ""
+"Build it all on boot: if on-demand compilation is not desired, a background "
+"thread in the init process can build all the programs on boot."
+msgstr ""
+
+#: src/u-root.md:110
+msgid ""
+"Selectively remove binaries after use: if RAM space is at a premium, once "
+"booted, a script can remove everything in `/bin`. Utilities or commands that "
+"are used will be rebuilt on demand."
+msgstr ""
+
+#: src/u-root.md:113
+msgid ""
+"Always build on demand: run in a mode in which programs are never written to "
+"`/bin` and always rebuilt on demand. This is a very practical option given "
+"that program compilation is so fast."
+msgstr ""
+
+#: src/u-root.md:116
+msgid ""
+"Lockdown: if desired, the system can be locked down once booted in one of "
+"several ways: the entire `/src` tree can be removed, for example, or just "
+"the compiler toolchain can be deleted."
+msgstr ""
+
+#: src/u-root.md:120
+msgid "U-root functionality"
+msgstr ""
+
+#: src/u-root.md:122
+msgid ""
+"U-root is packaged as an LZMA-compressed initial RAM file system (initramfs) "
+"in cpio format. It is contained in a Linux compressed kernel image, also "
+"know as bzImage. The bootloader (for example, syslinux) or firmware (for "
+"example, coreboot) loads the bzImage into memory and starts it. The Linux "
+"kernel sets up a RAM-based root file system and unpacks the u-root file "
+"system into it. This initial root file system contains the Go toolchain (4 "
+"binaries), an init binary, the u-root program source, and the entire Go "
+"source tree, which provides packages needed for u-root programs."
+msgstr ""
+
+#: src/u-root.md:131
+msgid ""
+"All Unix systems start an init process on boot and u-root is no exception. "
+"The init for u-root sets up some basic directories, symlinks, and files. It "
+"builds a command installer and invokes the shell. This process is described "
+"in more detail below. The boot file system layout is shown in Table 1."
+msgstr ""
+
+#: src/u-root.md:136
+msgid ""
+"The src directory is where programs and u-root packages reside. The go/bin "
+"directory is for any Go tools built after boot; the go/pkg/tool directory "
+"contains binaries for various architecture/kernel combinations. The "
+"directory in which a compiler toolchain is placed provides information about "
+"the target OS and architecture, for example, the Go build places binaries "
+"for Linux on x86 64 in `/go/pkg/tool/linux` `amd64/`. Note that there is no "
+"`/bin` or many of the other directories expected in a root file system. The "
+"init binary builds them. It creates an empty `/bin` which is filled with "
+"binaries on demand as shown in Table 2.The u-root root file system has very "
+"little state."
+msgstr ""
+
+#: src/u-root.md:146
+msgid ""
+"For most programs to work, the file system must be more complete. Image "
+"space is saved by having init create additional file system structure at "
+"boot time: it fills in the missing parts of the root filesystem. It creates "
+"`/dev` and `/proc` and mounts them. It creates an empty `/bin` which is "
+"filled with binaries on demand."
+msgstr ""
+
+#: src/u-root.md:152
+msgid ""
+"In addition to `/bin`, there is a directory called `/buildbin`. `Buildbin` "
+"and the correct setup of $PATH are the keys to making on-demand compilation "
+"work. The init process sets $PATH to "
+"`/go/bin:/bin:/buildbin:/usr/local/bin`. Init also builds `installcommand` "
+"using the Go bootstrap builder and creates a complete set of symlinks. As a "
+"final step, init execs `sh`."
+msgstr ""
+
+#: src/u-root.md:158
+msgid ""
+"There is no `/bin/sh` at this point; the first `sh` found in $PATH is "
+"`/buildbin/sh`. This is a symlink to `installcommand`. `Installcommand`, "
+"once started, examines argv\\[0\\], which is `sh`, and takes this as "
+"instruction to build `/src/cmds/sh/.go` into `/bin` and then exec `/bin/sh`. "
+"There is no difference between starting the first shell and any other "
+"program. Hence, part of the boot process involves the construction of an "
+"installation tool to build a binary for a shell which is then run."
+msgstr ""
+
+#: src/u-root.md:166
+msgid ""
+"If a user wants to examine the source to the shell, they can `cat` "
+"`/src/cmds/sh/.go`. The `cat` command will be built and then show those "
+"files. U-root is intended for network-based devices and hence good network "
+"initialization code is essential. U-root includes a Go version of the IP and "
+"DHCP programs, along with the docker netlink package and a DHCP package."
+msgstr ""
+
+#: src/u-root.md:172
+msgid "Table 1 below shows the initial layout of a u-root file system."
+msgstr ""
+
+#: src/u-root.md:174
+msgid ""
+"All Go compiler and runtime source is included under `/go/src`. All u-root "
+"source is under `/src` and the compiler toolchain binaries are under "
+"`/go/pkg`."
+msgstr ""
+
+#: src/u-root.md:177 src/u-root.md:229
+msgid "Directory"
+msgstr ""
+
+#: src/u-root.md:177 src/u-root.md:229
+msgid "Subdirectory"
+msgstr ""
+
+#: src/u-root.md:177 src/u-root.md:229
+msgid "Command"
+msgstr ""
+
+#: src/u-root.md:179 src/u-root.md:231
+msgid "/src"
+msgstr ""
+
+#: src/u-root.md:179 src/u-root.md:231
+msgid "cmds/"
+msgstr ""
+
+#: src/u-root.md:180 src/u-root.md:232
+msgid "builtin/builtin.go"
+msgstr ""
+
+#: src/u-root.md:181 src/u-root.md:233
+msgid "/cat.go"
+msgstr ""
+
+#: src/u-root.md:182 src/u-root.md:234
+msgid "/cmp.go"
+msgstr ""
+
+#: src/u-root.md:183 src/u-root.md:235
+msgid "comm/comm.go"
+msgstr ""
+
+#: src/u-root.md:184 src/u-root.md:236
+msgid "cp/cp.go"
+msgstr ""
+
+#: src/u-root.md:185 src/u-root.md:237
+msgid "date/date.go"
+msgstr ""
+
+#: src/u-root.md:186 src/u-root.md:238
+msgid "dmesg/dmesg.go"
+msgstr ""
+
+#: src/u-root.md:187 src/u-root.md:239
+msgid "echo/echo.go"
+msgstr ""
+
+#: src/u-root.md:188 src/u-root.md:240
+msgid "freq/freq.go"
+msgstr ""
+
+#: src/u-root.md:189 src/u-root.md:241
+msgid "grep/grep.go"
+msgstr ""
+
+#: src/u-root.md:190 src/u-root.md:242
+msgid "init/init.go"
+msgstr ""
+
+#: src/u-root.md:191 src/u-root.md:243
+msgid "installcommand/installcommand.go"
+msgstr ""
+
+#: src/u-root.md:192 src/u-root.md:244
+msgid "ip/ip.go"
+msgstr ""
+
+#: src/u-root.md:193 src/u-root.md:245
+msgid "ldd/ldd.go"
+msgstr ""
+
+#: src/u-root.md:194 src/u-root.md:246
+msgid "losetup/losetup.go"
+msgstr ""
+
+#: src/u-root.md:195 src/u-root.md:247
+msgid "ls/ls.go"
+msgstr ""
+
+#: src/u-root.md:196 src/u-root.md:248
+msgid "mkdir/mkdir.go"
+msgstr ""
+
+#: src/u-root.md:197 src/u-root.md:249
+msgid "mount/mount.go"
+msgstr ""
+
+#: src/u-root.md:198 src/u-root.md:250
+msgid "netcat/netcat.go"
+msgstr ""
+
+#: src/u-root.md:199 src/u-root.md:251
+msgid "ping/ping.go"
+msgstr ""
+
+#: src/u-root.md:200 src/u-root.md:252
+msgid "printenv/printenv.go"
+msgstr ""
+
+#: src/u-root.md:201 src/u-root.md:253
+msgid "rm/rm.go"
+msgstr ""
+
+#: src/u-root.md:202 src/u-root.md:254
+msgid "script/script.go"
+msgstr ""
+
+#: src/u-root.md:203 src/u-root.md:255
+msgid "seq/seq.go"
+msgstr ""
+
+#: src/u-root.md:204 src/u-root.md:256
+msgid "sh/{cd.go,parse.go,sh.go,time.go}"
+msgstr ""
+
+#: src/u-root.md:205 src/u-root.md:257
+msgid "srvfiles/srvfiles.go"
+msgstr ""
+
+#: src/u-root.md:206 src/u-root.md:258
+msgid "tcz/tcz.go"
+msgstr ""
+
+#: src/u-root.md:207 src/u-root.md:259
+msgid "tee/tee.go"
+msgstr ""
+
+#: src/u-root.md:208 src/u-root.md:260
+msgid "uniq/uniq.go"
+msgstr ""
+
+#: src/u-root.md:209 src/u-root.md:261
+msgid "wc/wc.go"
+msgstr ""
+
+#: src/u-root.md:210 src/u-root.md:262
+msgid "wget/wget.go"
+msgstr ""
+
+#: src/u-root.md:211 src/u-root.md:263
+msgid "which/which.go"
+msgstr ""
+
+#: src/u-root.md:212 src/u-root.md:217 src/u-root.md:264 src/u-root.md:269
+msgid "pkg/"
+msgstr ""
+
+#: src/u-root.md:213 src/u-root.md:265
+msgid "dhcp/ (dhcp package source)"
+msgstr ""
+
+#: src/u-root.md:214 src/u-root.md:266
+msgid "netlib/ (netlib package source)"
+msgstr ""
+
+#: src/u-root.md:215 src/u-root.md:267
+msgid "golang.org (import package source)"
+msgstr ""
+
+#: src/u-root.md:216 src/u-root.md:268
+msgid "/go"
+msgstr ""
+
+#: src/u-root.md:216 src/u-root.md:268
+msgid "src/"
+msgstr ""
+
+#: src/u-root.md:216 src/u-root.md:268
+msgid "Packages and toolchain"
+msgstr ""
+
+#: src/u-root.md:217 src/u-root.md:269
+msgid "tool/linux amd64/{6a,6c,6g,6l}"
+msgstr ""
+
+#: src/u-root.md:218 src/u-root.md:270
+msgid "misc/"
+msgstr ""
+
+#: src/u-root.md:218 src/u-root.md:219 src/u-root.md:221 src/u-root.md:270
+#: src/u-root.md:271 src/u-root.md:273 src/utilities/UEFI_Tool_Kit.md:489
+msgid "..."
+msgstr ""
+
+#: src/u-root.md:219 src/u-root.md:271
+msgid "tool/"
+msgstr ""
+
+#: src/u-root.md:220 src/u-root.md:272
+msgid "bin/"
+msgstr ""
+
+#: src/u-root.md:220 src/u-root.md:272
+msgid "go"
+msgstr ""
+
+#: src/u-root.md:221 src/u-root.md:273
+msgid "include/"
+msgstr ""
+
+#: src/u-root.md:222 src/u-root.md:274
+msgid "/lib/"
+msgstr ""
+
+#: src/u-root.md:222 src/u-root.md:274
+msgid "libc.so"
+msgstr ""
+
+#: src/u-root.md:222 src/u-root.md:274
+msgid "Needed for tinycore linux packages"
+msgstr ""
+
+#: src/u-root.md:223 src/u-root.md:275
+msgid "libm.so"
+msgstr ""
+
+#: src/u-root.md:225
+msgid "**Table 1**: Initial layout of a u-root filesystem"
+msgstr ""
+
+#: src/u-root.md:227
+msgid "Table 2 below shows the layout after `/init` has run."
+msgstr ""
+
+#: src/u-root.md:277
+msgid "**Table 2**: Layout after `/init` has run."
+msgstr ""
+
+#: src/u-root.md:279
+msgid ""
+"`/buildbin` contains symlinks to enable the on-demand compilation, and other "
+"standard directories and mount points are ready."
+msgstr ""
+
+#: src/u-root.md:282
+msgid "The u-root shell"
+msgstr ""
+
+#: src/u-root.md:284
+msgid ""
+"U-root provides a shell that is stripped down to the fundamentals: it can "
+"read commands in using the Go scanner package; it can expand (that is, glob) "
+"the command elements, using the Go filepath package, and it can run the "
+"resulting commands, either programs or shell builtins. It supports pipelines "
+"and IO redirection. At the same time, the shell defines no language of its "
+"own for scripting and builtins. Instead, the u-root shell uses the Go "
+"compiler. In that sense, the u-root shell reflects a break in important ways "
+"with the last few decades of shell development, which has seen shells and "
+"their language grow ever more complex and, partially as a result, ever more "
+"insecure[^19] and fragile[^11]."
+msgstr ""
+
+#: src/u-root.md:295
+msgid ""
+"The shell has several builtin commands, and you can extend it with builtin "
+"commands of your own. First, you need to understand the basic source "
+"structure of u-root shell builtins. Then, you will learn about user-defined "
+"builtins."
+msgstr ""
+
+#: src/u-root.md:299
+msgid ""
+"All shell builtins, including the ones that come with the shell by default, "
+"are written with a standard Go init pattern which installs one or more "
+"builtins."
+msgstr ""
+
+#: src/u-root.md:302
+msgid ""
+"Builtins in the shell are defined by a name and a function. One or more "
+"builtins can be described in a source file. The name is kept in a map and "
+"the map is searched for a command name before looking in the file system. "
+"The function must accept a string as a name and a (possibly zero-length) "
+"array of string arguments, and return an error. In order to connect the "
+"builtin to the map, a programmer must provide an `init` function which adds "
+"the name and function to the map. The `init` function is special in that it "
+"is run by Go when the program starts up. In this case, the `init` function "
+"just installs a builtin for the time command."
+msgstr ""
+
+#: src/u-root.md:312
+msgid "Figure 1 and Figure 2 below show the shell builtin for time."
+msgstr ""
+
+#: src/u-root.md:315
+msgid ""
+"// Package main is the 'root' of the package hierarchy for a program.\n"
+"// This code is part of the main program, not another package,\n"
+"// and is declared as package main.\n"
+msgstr ""
+
+#: src/u-root.md:320
+msgid ""
+"// A Go source file list all the packages on which it has a direct\n"
+"// dependency.\n"
+msgstr ""
+
+#: src/u-root.md:325
+msgid "\"fmt\""
+msgstr ""
+
+#: src/u-root.md:326
+msgid "\"os\""
+msgstr ""
+
+#: src/u-root.md:327
+msgid "\"time\""
+msgstr ""
+
+#: src/u-root.md:329
+msgid ""
+"// init() is an optional function. If init () is present in a file,\n"
+"// the Go compiler and runtime arrange for it to be called at\n"
+"// program startup. It is therefore like a constructor.\n"
+msgstr ""
+
+#: src/u-root.md:335
+msgid ""
+"// addBuiltIn is provided by the u−root shell for the addition of\n"
+"    // builtin commands. Builtins must have a standard type:\n"
+"    // - The first parameter is a string\n"
+"    // - The second is a string array which may be 0 length\n"
+"    // - The return is the Go error type\n"
+"    // In this case, we are creating a builtincalled time that calls\n"
+"    // the timecmd function.\n"
+msgstr ""
+
+#: src/u-root.md:343
+msgid "\"time \""
+msgstr ""
+
+#: src/u-root.md:347
+msgid "**Figure 1**: The code for the time builtin, Part I: setup"
+msgstr ""
+
+#: src/u-root.md:350
+msgid ""
+"// The timecmd function is passed the name of a command to run,\n"
+"// optional arguments, and returns an error. It:\n"
+"// - gets the starttime using Now from the time package\n"
+"// - runs the command using the u−root shell runit function\n"
+"// - computes a duration using Since from the time package\n"
+"// - if there is an error, prints the error to os.Stderr\n"
+"// - uses fmt. Printf to print the duration to os.Stderr\n"
+"// Note that since runtime always handles the error, by printing\n"
+"// it, it always returns nil. Most builtins return the error.\n"
+"// Here you can see the usage of the imported packages\n"
+"// from the imports statement above.\n"
+msgstr ""
+
+#: src/u-root.md:374
+msgid ""
+"// This function is special in that it handles the error, and hence\n"
+"    // does not return an error.\n"
+"    // Most other builtins return the error.\n"
+msgstr ""
+
+#: src/u-root.md:383
+msgid "**Figure 2**: The code for the shell time builtin, Part II"
+msgstr ""
+
+#: src/u-root.md:385
+msgid "Scripting and builtins"
+msgstr ""
+
+#: src/u-root.md:387
+msgid ""
+"To support scripting and builtins, u-root provides two programs: script and "
+"builtin. The script program allows users to specify a Go fragment on the "
+"command line, and runs that fragment as a program. The builtin program "
+"allows a Go fragment to be built into the shell as a new command. Builtins "
+"are persistent; the builtin command instantiates a new shell with the new "
+"command built in. Scripts run via the script command are not persistent."
+msgstr ""
+
+#: src/u-root.md:394
+msgid "A basic hello builtin can be defined on the command line:"
+msgstr ""
+
+#: src/u-root.md:396
+msgid ""
+"```\n"
+"builtin hello '{ fmt.Printf(\"Hello\\n"
+"\") }'\n"
+"```"
+msgstr ""
+
+#: src/u-root.md:400
+msgid ""
+"The fragment is defined by the {} pair. Given a fragment that starts with a "
+"{, the builtin command generates all the wrapper boiler plate needed. The "
+"builtin command is slightly different from the script command in that the Go "
+"fragment is bundled into one argument. The command accepts multiple pairs of "
+"command name and Go code fragments, allowing multiple new builtin commands "
+"to be installed in the shell."
+msgstr ""
+
+#: src/u-root.md:407
+msgid ""
+"Builtin creates a new shell at `/bin/sh` with the source at `/src/cmds/sh/`. "
+"Invocations of `/bin/sh` by this shell and its children will use the new "
+"shell."
+msgstr ""
+
+#: src/u-root.md:410
+msgid ""
+"Processes spawned by this new shell can access the new shell source and can "
+"run the builtin command again and create a shell that further extends the "
+"new shell. Processes outside the new shell’s process hierarchy can not use "
+"this new shell or the builtin source. When the new shell exits, the builtins "
+"are no longer visible in any part of the file system. We use Linux mount "
+"name spaces to create this effect[^22]. Once the builtin command has "
+"verified that the Go fragment is valid, it builds a new, private namespace "
+"with the shell source, including the new builtin source. From that point on, "
+"the new shell and its children will only use the new shell. The parent "
+"process and other processes outside the private namespace continue to use "
+"the old shell."
+msgstr ""
+
+#: src/u-root.md:421
+msgid "Figure 3 below shows an example usage of the script command."
+msgstr ""
+
+#: src/u-root.md:423
+msgid ""
+"This script implements printenv. Note that it is not a complete Go program "
+"in that it lacks a package statement, imports, a main function declaration, "
+"and a return at the end. All the boilerplate is added by the script command, "
+"which uses the Go imports package to scan the code and create the import "
+"statements required for compilation (in this case, both fmt and os packages "
+"are imported). Because the u-root shell is so simple, there is no need to "
+"escape many of these special characters. The complex parsing tasks have been "
+"offloaded to Go. Builtins are implemented in almost the same way. The "
+"builtin command takes the Go fragment and creates a standard shell builtin "
+"Go source file which conforms to the builtin pattern. This structure is easy "
+"to generate programmatically, building on the techniques used for the script "
+"command."
+msgstr ""
+
+#: src/u-root.md:435
+msgid ""
+"```\n"
+"script{ fmt.Printf(\"%v\\n"
+"\", os.Environ()) }\n"
+"```"
+msgstr ""
+
+#: src/u-root.md:439
+msgid ""
+"**Figure 3**: Go fragment for a printenv script. Code structure is inserted "
+"and packages are determined automatically."
+msgstr ""
+
+#: src/u-root.md:442
+msgid "Environment variables"
+msgstr ""
+
+#: src/u-root.md:444
+msgid ""
+"The u-root shell supports environment variables, but manages them "
+"differently than most Unix environments. The variables are maintained in a "
+"directory called `/env`; the file name corresponds to the environment "
+"variable name, and the files contents are the value. When it is starting a "
+"new process, the shell populates child process environment variables from "
+"the `/env` directory. The syntax is the same; $ followed by a name directs "
+"the shell to substitute the value of the variable in the argument by "
+"prepending `/env` to the path and reading the file."
+msgstr ""
+
+#: src/u-root.md:453
+msgid ""
+"The shell variables described above are relative paths; `/env` is prepended "
+"to them. In the u-root shell, the name can also be an absolute path. For "
+"example, the command script $`/home/$USER/scripts/hello` will substitute the "
+"value of the `hello` script into the command line and then run the script "
+"command. The ability to place arbitrary text from a file into an argument is "
+"proving to be extremely convenient, especially for script and builtin "
+"commands."
+msgstr ""
+
+#: src/u-root.md:460
+msgid "Using external packages and programs"
+msgstr ""
+
+#: src/u-root.md:462
+msgid ""
+"No root file system can provide all the packages all users want, and u-root "
+"is no exception. You need to have the ability to load external packages from "
+"popular Linux distros. The `tcz` command can be used to load external "
+"packages from the TinyCore Linux distribution, also known as _tinycore_. A "
+"tinycore package is a mountable file system image, containing all the "
+"package files, including a file listing any additional package dependencies. "
+"To load these packages, u-root provides the `tcz` command which fetches the "
+"package and needed dependencies. Hence, if a user wants emacs, they need "
+"merely type `tcz emacs`, and emacs will become available in "
+"`/usr/local/bin`. The tinycore packages directory can be a persistent "
+"directory or it can be empty on each boot."
+msgstr ""
+
+#: src/u-root.md:474
+msgid ""
+"The `tcz` command is quite flexible as to what packages it loads and where "
+"they are loaded from. Users can specify the host name which provides the "
+"packages, the TCP port on which to connect, the version of tinycore to use, "
+"and the architecture. The `tcz` command must loopback mount each package as "
+"it is fetched, and hence must cache them locally. It will not refetch "
+"already cached packages. This cache can be volatile or maintained on more "
+"permanent storage. Performance varies depending on the network being used "
+"and the number of packages being loaded, but averages about 1 second per "
+"package on a WIFI-attached laptop. U-root also provides a small web server, "
+"called _srvfiles_, that can be used to serve locally cached tinycore "
+"packages for testing. The entire server is 18 lines of Go."
+msgstr ""
+
+#: src/u-root.md:486
+msgid "On-Demand Compilation"
+msgstr ""
+
+#: src/u-root.md:488
+msgid ""
+"On-Demand compilation is one of the oldest ideas in computer science. "
+"Slimline Open Firmware (SLOF)[^7] is a FORTHbased implementation of Open "
+"Firmware developed by IBM for some of its Power and Cell processors. SLOF is "
+"capable of storing all of Open Firmware as source in the flash memory and "
+"compiling components to indirect threading on demand[^2]."
+msgstr ""
+
+#: src/u-root.md:494
+msgid ""
+"In the last few decades, as our compiler infrastructure has gotten slower "
+"and more complex, true on-demand compilation has split into two different "
+"forms. First is the on-demand compilation of source into executable byte "
+"codes, as in Python. The byte codes are not native but are more efficient "
+"than source. If the python interpreter finds the byte code it will interpret "
+"that instead of source to provide improved performance. Java takes the "
+"process one step further with the Just In Time compilation of byte code to "
+"machine code[^20] to boost performance."
+msgstr ""
+
+#: src/u-root.md:503
+msgid "Embedding kernel and root file systems in flash"
+msgstr ""
+
+#: src/u-root.md:505
+msgid ""
+"The LinuxBIOS project[^14][^1], together with clustermatic[^25], used an "
+"embedded kernel and simple root file system to manage supercomputing "
+"clusters. Due to space constraints of 1 MiB or less of flash, clusters "
+"embedded only a single-processor Linux kernel with a daemon. The daemon was "
+"a network bootloader that downloaded a more complex SMP kernel and root file "
+"system and started them. Clusters built this way were able to boot 1024 "
+"nodes in the time it took the standard PXE network boot firmware to find a "
+"working network interface."
+msgstr ""
+
+#: src/u-root.md:514
+msgid ""
+"Early versions of One Laptop Per Child used LinuxBIOS, with Linux in flash "
+"as a boot loader, to boot the eventual target. This system was very handy, "
+"as they were able to embed a full WIFI stack in flash with Linux, and could "
+"boot test OLPC images over WIFI. The continuing growth of the Linux kernel, "
+"coupled with the small flash size on OLPC, eventually led OLPC to move to "
+"Open Firmware."
+msgstr ""
+
+#: src/u-root.md:520
+msgid ""
+"AlphaPower shipped their Alpha nodes with a so-called Direct Boot Linux, or "
+"DBLX. This work was never published, but the code was partially released on "
+"sourceforge.net just as AlphaPower went out of business.  Compaq also worked "
+"with a Linux-As-Bootloader for the iPaq."
+msgstr ""
+
+#: src/u-root.md:525
+msgid ""
+"Car computers and other embedded ARM systems frequently contain a kernel and "
+"an ext2 formatted file system in NOR flash, that is, flash that can be "
+"treated as memory instead of a block device. Many of these kernels use the "
+"so-called eXecute In Place[^3] (XIP) patch, which allows the kernel to page "
+"binaries directly from the memory-addressable flash rather than copying it "
+"to RAM, providing a significant savings in system startup time. A downside "
+"of this approach is that the executables can not be compressed, which puts "
+"further pressure on the need to optimize binary size. NOR flash is very "
+"slow, and paging from it comes at a significant performance cost. Finally, "
+"an uncompressed binary image stored in NOR flash has a much higher monetary "
+"cost than the same image stored in RAM since the cost per bit is so much "
+"higher."
+msgstr ""
+
+#: src/u-root.md:537
+msgid ""
+"UEFI[^12] contains a non-Linux kernel (the UEFI firmware binary) and a full "
+"set of drivers, file systems, network protocol stacks, and command binaries "
+"in the firmware image. It is a full operating system environment realized as "
+"firmware."
+msgstr ""
+
+#: src/u-root.md:541
+msgid ""
+"The ONIE project[^23] is a more recent realization of the Kernel-in-flash "
+"idea, based on Linux. ONIE packs a Linux kernel and Busybox binaries into a "
+"very small package. Since the Linux build process allows an initial RAM file "
+"system (initramfs) to be built directly into the kernel binary, some "
+"companies are now embedding ONIE images into flash with coreboot. Sage "
+"Engineering has shown a bzImage with a small Busybox packed into a 4M image. "
+"ONIE has brought new life to an old idea: packaging a kernel and small set "
+"of binaries in flash to create a fast, capable boot system."
+msgstr ""
+
+#: src/u-root.md:550
+msgid "References"
+msgstr ""
+
+#: src/u-root.md:552
+msgid ""
+"AGNEW, A., SULMICKI, A., MINNICH, R., AND ARBAUGH, W. A. Flexibility in rom: "
+"A stackable open source bios. In USENIX Annual Technical Conference, FREENIX "
+"Track (2003), pp. 115–124."
+msgstr ""
+
+#: src/u-root.md:555
+msgid "(AUTHOR OF SLOF), S. B. Personal conversation."
+msgstr ""
+
+#: src/u-root.md:556
+msgid ""
+"BENAVIDES, T., TREON, J., HULBERT, J., AND CHANG, W. The enabling of an "
+"execute-in-place architecture to reduce the embedded system memory footprint "
+"and boot time. Journal of computers 3, 1 (2008), 79–89."
+msgstr ""
+
+#: src/u-root.md:559
+msgid ""
+"BOGOWITZ, B., AND SWINFORD, T. Intel⃝R active management technology reduces "
+"it costs with improved pc manageability. Technology@ Intel Magazine (2004)."
+msgstr ""
+
+#: src/u-root.md:562
+msgid ""
+"CELEDA, P., KREJCI, R., VYKOPAL, J., AND DRASAR, M. Embedded malware-an "
+"analysis of the chuck norris botnet. In Computer Network Defense (EC2ND), "
+"2010 European Conference on (2010), IEEE, pp. 3–10."
+msgstr ""
+
+#: src/u-root.md:565
+msgid ""
+"CUI, A., COSTELLO, M., AND STOLFO, S. J. When firmware modifications attack: "
+"A case study of embedded exploitation. In NDSS (2013)."
+msgstr ""
+
+#: src/u-root.md:567
+msgid ""
+"DALY, D., CHOI, J. H., MOREIRA, J. E., AND WATERLAND, A. Base operating "
+"system provisioning and bringup for a commercial supercomputer. In Parallel "
+"and Distributed Processing Symposium, 2007. IPDPS 2007. IEEE International "
+"(2007), IEEE, pp. 1–7."
+msgstr ""
+
+#: src/u-root.md:571
+msgid ""
+"DURUMERIC, Z., KASTEN, J., ADRIAN, D., HALDERMAN, J. A., BAILEY, M., LI, F., "
+"WEAVER, N., AMANN, J., BEEKMAN, J., PAYER, M., ET AL. The matter of "
+"heartbleed. In Proceedings of the 2014 Conference on Internet Measurement "
+"Conference (2014), ACM, pp. 475–488."
+msgstr ""
+
+#: src/u-root.md:575
+msgid ""
+"KALLENBERG, C., AND BULYGIN, Y. All your boot are belong to us intel, mitre. "
+"cansecwest 2014."
+msgstr ""
+
+#: src/u-root.md:577
+msgid ""
+"KALLENBERG, C., KOVAH, X., BUTTERWORTH, J., AND CORNWELL, S. Extreme "
+"privilege escalation on windows 8/uefi systems."
+msgstr ""
+
+#: src/u-root.md:579
+msgid ""
+"KOZIOL, J., LITCHFIELD, D., AITEL, D., ANLEY, C., EREN, S., MEHTA, N., AND "
+"HASSELL, R. The Shellcoder’s Handbook. Wiley Indianapolis, 2004."
+msgstr ""
+
+#: src/u-root.md:581
+msgid "LEWIS, T. Uefi overview, 2007."
+msgstr ""
+
+#: src/u-root.md:582
+msgid "MAY,D.Occam.ACMSigplanNotices18,4(1983),69–79."
+msgstr ""
+
+#: src/u-root.md:583
+msgid "MINNICH, R. G. Linuxbios at four. Linux J. 2004, 118 (Feb. 2004), 8–."
+msgstr ""
+
+#: src/u-root.md:584
+msgid ""
+"MOON, S.-P., KIM, J.-W., BAE, K.-H., LEE, J.-C., AND SEO, D.-W. Embedded "
+"linux implementation on a commercial digital tv system. Consumer "
+"Electronics, IEEE Transactions on 49, 4 (Nov 2003), 1402–1407."
+msgstr ""
+
+#: src/u-root.md:587
+msgid ""
+"PIKE, R. Another go at language design. Stanford University Computer Systems "
+"Laboratory Colloquium."
+msgstr ""
+
+#: src/u-root.md:589
+msgid ""
+"RITCHIE, D. M. The limbo programming language. Inferno Programmer’s Manual 2 "
+"(1997)."
+msgstr ""
+
+#: src/u-root.md:591
+msgid ""
+"SACCO, A. L., AND ORTEGA, A. A. Persistent bios infection. In CanSecWest "
+"Applied Security Conference (2009)."
+msgstr ""
+
+#: src/u-root.md:593
+msgid ""
+"SAMPATHKUMAR, R. Vulnerability Management for Cloud Computing-2014: A Cloud "
+"Computing Security Essential. Rajakumar Sampathkumar, 2014."
+msgstr ""
+
+#: src/u-root.md:595
+msgid ""
+"SUGANUMA, T., OGASAWARA, T., TAKEUCHI, M., YASUE, T., KAWAHITO, M., "
+"ISHIZAKI, K., KOMATSU, H., AND NAKATANI, T. Overview of the ibm java "
+"just-in-time compiler. IBM systems Journal 39, 1 (2000), 175–193."
+msgstr ""
+
+#: src/u-root.md:598
+msgid ""
+"TEAM, G. The go programming language specification. Tech. rep., Technical "
+"Report [http://golang](http://golang/). org/doc/doc/go spec. html, Google "
+"Inc, 2009."
+msgstr ""
+
+#: src/u-root.md:601
+msgid ""
+"VAN HENSBERGEN, E., AND MINNICH, R. Grave robbers from outer space: Using "
+"9p2000 under linux. In USENIX Annual Technical Conference, FREENIX Track "
+"(2005), pp. 83–94."
+msgstr ""
+
+#: src/u-root.md:604
+msgid "VARIOUS. No papers have been published on onie; see onie.org."
+msgstr ""
+
+#: src/u-root.md:605
+msgid "VARIOUS. No papers were published; see perllinux.sourceforge.net."
+msgstr ""
+
+#: src/u-root.md:606
+msgid ""
+"WATSON, G. R., SOTTILE, M. J., MINNICH, R. G., CHOI, S.-E., AND HERTDRIKS, "
+"E. Pink: A 1024-node single-system image linux cluster. In High Performance "
+"Computing and Grid in Asia Pacific Region, 2004. Proceedings. Seventh "
+"International Conference on (2004), IEEE, pp. 454–461."
+msgstr ""
+
+#: src/u-root.md:610
+msgid ""
+"WELLS, N. Busybox: A swiss army knife for linux. Linux J. 2000, 78es (Oct. "
+"2000)."
+msgstr ""
+
+#: src/u-root.md:612
+msgid ""
+"WINTERBOTTOM, P. Alef language reference manual. Plan 9 Programmer’s Man "
+"(1995)."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:3
+msgid ""
+"You can try out LinuxBoot without needing to build anything! You can try out "
+"LinuxBoot needing only 3 commands."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:6
+msgid ""
+"We have made Initial Ram File System (initramfs) images available for four "
+"architectures: arm, aarch64, amd64 (a.k.a. x86_64), and riscv64."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:9
+msgid ""
+"For now, we only have a kernel ready for x86_64, so the instructions below "
+"apply to that."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:12
+msgid ""
+"First, you can get the initramfs image, which mainly contains Go programs "
+"from the u-root project."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:19
+msgid ""
+"Next, you will need to get a kernel. We use a pre-built kernel from Arch "
+"Linux."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:26
+msgid "Now you are ready to test LinuxBoot out."
+msgstr ""
+
+#: src/u-root-qemu-demo.md:29 src/u-root-qemu-demo.md:36
+msgid "\"console=ttyS0\""
+msgstr ""
+
+#: src/u-root-qemu-demo.md:33
+msgid "Or, for example, on Darwin:"
+msgstr ""
+
+#: src/u-root-qemu-demo.md:40
+msgid "You will see the following:"
+msgstr ""
+
+#: src/u-root-qemu-demo.md:54
+msgid "You can type uname:"
+msgstr ""
+
+#: src/u-root-qemu-demo.md:62
+msgid "To exit qemu, just run the poweroff command:"
+msgstr ""
+
+#: src/u-root-qemu-demo.md:69
+msgid "You have just run your first LinuxBoot kernel."
+msgstr ""
+
+#: src/utilities/index.md:1
+msgid "LinuxBoot Utilities"
+msgstr ""
+
+#: src/utilities/index.md:3
+msgid ""
+"In order to bootstrap, build and maintain LinuxBoot projects, we provide a "
+"handful of utilities for extracting, reducing, reworking, and stitching "
+"firmware images."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:3
+msgid "Authors: Ryan O'Leary, Gan Shun Lim and Andrea Barberio"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:5
+msgid ""
+"In previous chapters, you learned how to read a raw ROM image from a flash "
+"part. If you've been following along, you know the next step is to insert a "
+"Linux kernel."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:9
+msgid ""
+"Inspecting and modifying ROM images is tricky and can involve a fair amount "
+"of tinkering. These images typically contain a number of file systems, "
+"drivers, tables, data structures and opaque blobs. They also differ "
+"significantly from the UNIX model of a file systems, thus cannot be "
+"reasonably mounted in Linux."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:14
+msgid ""
+"UEFI Tool Kit (UTK) is intended to be a one-stop-shop for reading, writing "
+"and modifying UEFI images -- the most common type of firmware image for x86 "
+"systems. UTK can parse a number of data structures including UEFI firmware "
+"volumes, Intel firmware descriptors and FIT."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:19
+msgid "In this chapter, we'll go over how to:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:21
+msgid "Install UTK"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:22
+msgid "Inspect ROMs"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:23
+msgid "Modify ROMs"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:24
+msgid "Common pitfalls"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:25
+msgid "Extend UTK with additional commands"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:27
+msgid "Synopsis"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:36
+msgid "Quick start"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:38
+msgid "We assume you have a way to read and write the FLASH into a file."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:40
+msgid ""
+"Let's assume you have read FLASH into an image called ROM.bin and you have a "
+"kernel, called bzImage, which you want to insert into ROM.bin. Be sure the "
+"kernel is buildable as an EFI driver (DXE); see the pitfalls section. The "
+"easiest option is to replace the UEFI shell. This is a quick and easy way to "
+"get started. In the long term, you want to remove as much of UEFI as "
+"possible, but replacing the shell is always our first step on a new board."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:48
+msgid "Get the tool:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:54
+msgid "Replace the shell:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:60
+msgid ""
+"After that, you can flash NEWROM.bin and test. If anything goes wrong, such "
+"as not enough space, you will need to refer to the more detailed "
+"instructions below."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:64
+msgid "Installation"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:66
+msgid ""
+"At the time of writing, you must clone and build UTK from source -- binary "
+"distributions are not officially available. The source code resides in the "
+"[Fiano Github project](https://github.com/linuxboot/fiano/)."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:70
+msgid ""
+"Aside: what is the difference between Fiano and UTK? The Fiano project "
+"contains a few more tools besides UTK, but UTK is a big element."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:73
+msgid "We'll assume you already have Go installed. Check your installation with:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:80
+msgid ""
+"Linux and the latest stable version of Go are recommended. Either download "
+"the official binary distributions of Go or install from source. See "
+"[https://golang.org/](https://golang.org/) for details."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:84
+msgid "With Go, download and install UTK:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:90
+msgid ""
+"Running the above line installs `utk` to your `$GOPATH/bin` directory (or "
+"`$HOME/go/bin` if the `GOPATH` environment variable is not set). Adding this "
+"directory to your `$PATH` is recommended."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:94
+msgid "Make sure it works with:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:124
+msgid ""
+"Don't fret if your list of operations differs. UTK is an evolving project!"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:126
+msgid "Inspecting ROMs"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:128
+msgid ""
+"Throughout this section, we'll demonstrate commands for inspecting a UEFI "
+"image. When confronted with a new image, run these commands to get a \"lay "
+"of the land\"."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:132
+msgid "Start by downloading the UEFI image used in these examples:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:134
+msgid ""
+"```\n"
+"wget "
+"https://github.com/linuxboot/fiano/raw/master/integration/roms/OVMF.rom\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:138
+msgid ""
+"Aside: alternatively, all UTK operations should work with your own UEFI "
+"images. Simply substitute \"OVMF.rom\" with your own UEFI image in all the "
+"examples below. If you encounter any problems, please file an issue at "
+"[https://github.com/linuxboot/fiano/issues](https://github.com/linuxboot/fiano/issues)."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:143
+msgid "First, it is advisable to print a count of each firmware element:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:145
+msgid ""
+"```\n"
+"$ utk OVMF.rom count\n"
+"{\n"
+"        \"FirmwareTypeCount\": {\n"
+"                \"BIOSRegion\": 1,\n"
+"                \"File\": 118,\n"
+"                \"FirmwareVolume\": 5,\n"
+"                \"Section\": 365\n"
+"        },\n"
+"        \"FileTypeCount\": {\n"
+"                \"EFI_FV_FILETYPE_APPLICATION\": 2,\n"
+"                \"EFI_FV_FILETYPE_DRIVER\": 94,\n"
+"                \"EFI_FV_FILETYPE_DXE_CORE\": 1,\n"
+"                \"EFI_FV_FILETYPE_FFS_PAD\": 7,\n"
+"                \"EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE\": 1,\n"
+"                \"EFI_FV_FILETYPE_FREEFORM\": 3,\n"
+"                \"EFI_FV_FILETYPE_PEIM\": 7,\n"
+"                \"EFI_FV_FILETYPE_PEI_CORE\": 1,\n"
+"                \"EFI_FV_FILETYPE_RAW\": 1,\n"
+"                \"EFI_FV_FILETYPE_SECURITY_CORE\": 1\n"
+"        },\n"
+"        \"SectionTypeCount\": {\n"
+"                \"EFI_SECTION_DXE_DEPEX\": 44,\n"
+"                \"EFI_SECTION_FIRMWARE_VOLUME_IMAGE\": 2,\n"
+"                \"EFI_SECTION_GUID_DEFINED\": 1,\n"
+"                \"EFI_SECTION_PE32\": 99,\n"
+"                \"EFI_SECTION_RAW\": 21,\n"
+"                \"EFI_SECTION_USER_INTERFACE\": 99,\n"
+"                \"EFI_SECTION_VERSION\": 99\n"
+"        }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:178
+msgid ""
+"The definition of a \"Firmware Element\" is in order. Firmware images are "
+"hierarchical and can be represented as a tree. Each node in the tree is a "
+"\"Firmware Element\". Each element has a type such as \"BIOSRegion\", "
+"\"FirmwareVolume\", \"File\" and \"Section\" as seen above. Files (and "
+"sections) themselves have an additional type dictated by the UEFI spec. "
+"There are three major file types you should be aware of:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:185
+msgid ""
+"`EFI_FV_FILETYPE_DRIVER`: This is the most numerous file type and is often "
+"called a \"DXE\". They persist in memory even after their main function "
+"exits."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:187
+msgid ""
+"`EFI_FV_FILETYPE_APPLICATION`: Applications do not persist in memory after "
+"exiting. For example, the EFI Shell is an EFI Application."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:189
+msgid ""
+"`EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE`: These file types allow nesting "
+"firmware volumes. You will see this when an entire firmware volume is "
+"compressed."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:193
+msgid "TODO: Diagram showing a tree of these firmware elements."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:195
+msgid ""
+"To view a human-readable tree of all the firmware elements, types and sizes, "
+"run:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:221
+msgid ""
+"This format is compact and easy for humans reading, but not ideal for "
+"machine consumption. Use the `json` command to print everything (including "
+"much more metadata) as JSON:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:229
+msgid ""
+"Combine `utk` with the JSON query command, `jq` (`sudo apt-get install jq`), "
+"and other UNIX commands to quickly write powerful queries. For example, the "
+"following lists all the GUIDs, sorted and without duplicates:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:233
+msgid ""
+"```\n"
+"$ utk OVMF.rom json | jq -r '..|.GUID?|select(type==\"string\")' | sort -u\n"
+"00000000-0000-0000-0000-000000000000\n"
+"0167CCC4-D0F7-4F21-A3EF-9E64B7CDCE8B\n"
+"0170F60C-1D40-4651-956D-F0BD9879D527\n"
+"021722D8-522B-4079-852A-FE44C2C13F49\n"
+"025BBFC7-E6A9-4B8B-82AD-6815A1AEAF4A\n"
+"...\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:243
+msgid "To only print the JSON for specific files, use the find command:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:245
+msgid ""
+"```\n"
+"# The find command uses a regex to match on the name or GUID.\n"
+"# These three examples find and print the JSON for the same file:\n"
+"$ utk OVMF.rom find 'Sh.*'\n"
+"$ utk OVMF.rom find 'Shell'\n"
+"$ utk OVMF.rom find 7C04A583-9E3E-4F1C-AD65-E05268D0B4D1\n"
+"{\n"
+"        \"Header\": {\n"
+"                \"UUID\": {\n"
+"                        \"UUID\": \"7C04A583-9E3E-4F1C-AD65-E05268D0B4D1\"\n"
+"                },\n"
+"                \"Type\": 9,\n"
+"                \"Attributes\": 0\n"
+"        },\n"
+"        \"Type\": \"EFI_FV_FILETYPE_APPLICATION\",\n"
+"        \"Sections\": [\n"
+"                {\n"
+"                        \"Header\": {\n"
+"                                \"Type\": 21\n"
+"                        },\n"
+"                        \"Type\": \"EFI_SECTION_USER_INTERFACE\",\n"
+"                        \"ExtractPath\": \"\",\n"
+"                        \"Name\": \"Shell\"\n"
+"                },\n"
+"                ...\n"
+"        ],\n"
+"        \"ExtractPath\": \"\",\n"
+"        \"DataOffset\": 24\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:276
+msgid ""
+"Note that UEFI uses GUIDs to identify files. Some files also have a name "
+"which is stored within the file's UI section. Like `find`, most of UTKs "
+"commands let you match a file by its name or GUID."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:280
+msgid ""
+"The examples up until now have only dealt with file metadata and not the "
+"file's contents. The `extract <DIR>` command extracts all the files from the "
+"image and saves them to `<DIR>`. `<DIR>/summary.json` lists all the paths to "
+"the extracted files along with their metadata."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:289
+msgid "After modifying the files, they can be reassembled with:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:295
+msgid "Modifying ROMs"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:297
+msgid ""
+"First, let's verify the image works by running it inside QEMU. This step is "
+"not absolutely necessary, but gives us confidence the image works before and "
+"after each change we make."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:305
+msgid "For the provided OVMF.rom image, this should boot to the EDK2 shell."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:307
+msgid "TODO: include screenshot of the EDK2 shell"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:309
+msgid ""
+"Multiple commands can be used together to form a pipeline. The first "
+"argument always loads the image into memory and the last argument typically "
+"writes the output. The commands in between operate on the image in memory "
+"and are reminiscent of a UNIX pipeline. The general syntax is:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:321
+msgid "To see the pipeline in action, we introduce two new commands:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:323
+msgid ""
+"`remove <file GUID or NAME regex>`: Remove a file from a firmware volume. "
+"The search has the same semantics as `find`."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:325
+msgid ""
+"`replace_pe32 <file GUID or NAME regex> <FILE>`: Replace the pe32 section of "
+"a file with the given file. The search has the same semantics as `find`. The "
+"file must be a valid pe32 binary."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:328
+msgid ""
+"`save <FILE>`: Save the firmware image to the given file. Usually, this is "
+"the last command in a pipeline."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:331
+msgid ""
+"The following pipeline removes some unnecessary drivers (anything that "
+"starts with Usb and the Legacy8259 driver which has the GUID "
+"79ca4208-bba1-4a9a-8456-e1e66a81484e) and replaces the Shell with Linux. "
+"Often you need to remove drivers to make room for Linux which makes the "
+"pipeline convenient. This is the essence of LinuxBoot:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:347
+msgid ""
+"That's all there to it! Try experimenting with the other commands such as "
+"insert."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:350
+msgid "Common Pitfalls"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:352
+msgid "Kernel is not built as a DXE or has not enabled UEFI stub mode"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:354
+msgid ""
+"In order to be properly bootable as a DXE, kernels must have the following "
+"enabled:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:362
+msgid "Files are missing from the Firmware Volume"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:364
+msgid ""
+"When UTK does not recognize the compression format used by the particular "
+"image, the files within it are not listed."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:367
+msgid "In the wild, three compression schemes are common:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+msgid "Compression"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+msgid "GUID"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+msgid "UTK Support"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:371
+msgid "Uncompressed"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:371 src/utilities/UEFI_Tool_Kit.md:372
+msgid "Fully supported"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:372
+msgid "LZMA"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:372
+msgid "EE4E5898-3914-4259-9D6E-DC7BD79403CF"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+msgid "LZMA + x86"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+msgid "D42AE6BD-1352-4BFB-909A-CA72A6EAE889"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+msgid "Supported, but not tested"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+msgid "Tianocore"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+msgid "A31280AD-481E-41B6-95E8-127F4C984779"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+msgid ""
+"Not supported, see [\\#226](https://github.com/linuxboot/fiano/issues/226)"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:376
+msgid ""
+"To determine which compression scheme you are using, search for the "
+"respective GUID in the json summary."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:379
+msgid "File size too big"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:385
+msgid ""
+"When saving a UEFI image, files are added successively to each firmware "
+"volume. The first file which overflows the volume's size causes this error."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:388
+msgid ""
+"If you were inserting files, you will need to delete existing files to make "
+"room."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:390
+msgid ""
+"There is a special cases where this error is generated without any "
+"operations:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:396
+msgid "How can this be? No changes should be made to the image!"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:398
+msgid ""
+"Not quite (and the complete list of differences can be found in the \"binary "
+"equality section\") -- compressed volumes are recompressed."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:401
+msgid ""
+"By default, UTK uses the Go compressor, which is generally worse than the "
+"compression found in most UEFI images. Pass `--systemXZ=xz` as the first "
+"argument to UTK to use a better compressor."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:405
+msgid ""
+"(TODO for everything after this point) Arbitrary data before or after the "
+"image"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:407
+msgid ""
+"Find a general solution which works for all images is a topic of research: "
+"[\\#200](https://github.com/linuxboot/fiano/issues/200)."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:410
+msgid "Hard-coded addresses"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:412
+msgid "Binary equality"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:414
+#: src/coreboot.u-root.systemboot/index.md:404
+#: src/coreboot.u-root.systemboot/index.md:408
+#: src/coreboot.u-root.systemboot/index.md:434
+msgid "TODO"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:416
+msgid "Extending UTK"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:418
+msgid "Visitor pattern means decoupling the structure from the operations."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:420
+msgid "pkg/uefi: structure"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:421
+msgid "pkg/visitors: operations"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:423
+msgid "Good resources:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:425
+msgid "https://sourcemaking.com/design_patterns/visitor"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:426
+msgid "https://en.wikipedia.org/wiki/Visitor_pattern"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:428
+msgid ""
+"A good visitor still works when new Firmware are introduced. A good Firmware "
+"still works when a new visitor is introduced."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:431
+msgid "AST"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:433
+msgid ""
+"Abstract Syntax Tree -- this is a concept borrowed from compilers. When "
+"you're extracting the DXE to create a tree of structs containing a "
+"simplified model, you're essentially creating an AST. Then think about how "
+"patterns used in compiler architecture might apply to UTK."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:438
+msgid "Visitor Interface"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:440
+msgid "Each visitor implements the following:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:447
+msgid "// ...\n"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:451
+msgid ""
+"Think of a visitor as an \"action\" or a \"transformation\" being applied on "
+"the AST."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:454
+msgid "Visitor"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:456
+msgid ""
+"A struct implementing Visitor performs a transformation on the AST, for "
+"example:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:463
+msgid "// Recursively apply on files in the FV.\n"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:480
+msgid "You can imagine visitors being implemented for other actions, such as:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:482
+msgid "Remove a DXE with the given GUID from the AST"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:483
+msgid "Replace a GUID with a file"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:484
+msgid "Validate that all the nodes in the tree are valid"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:485
+msgid "Find compressed files in the tree and decompress them"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:486
+msgid "Assemble the AST back into an image."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:487
+msgid ""
+"Recursively write the AST to the filesystem (what you currently do with "
+"extract)"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:488
+msgid "Print an overview of the files to the terminal for debugging"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:491
+msgid ""
+"It is easy to add more visitors without modifying existing code. Each action "
+"can be in a separate file."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:494
+msgid "Applying"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:496
+msgid ""
+"Visitors are applied to the AST. Each node in the AST has an \"Apply\" "
+"method, for example:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:505
+msgid "This is so the visitors can be applied recursively over the AST."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:507
+msgid "To apply the above RenameDXE visitor, you'd run:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:510
+msgid "\"Shell\""
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:510
+msgid "\"NotShell\""
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:514
+msgid "Chaining Visitors Together"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:516
+msgid ""
+"It would be exciting/useful to be able to chain these small actions together "
+"through the command line. For example:"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:528
+msgid ""
+"Again, it is easy to write new actions in Go which modify nodes in the AST. "
+"Create a new file, new struct, and implement the "
+"visitFV/visitFile/visitSection methods to modify the AST."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:532
+msgid "TODO: reference the UEFI spec."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:534
+msgid "TODO: mention alternatives"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:536
+msgid "binwalk"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:537
+msgid "fresh0r/romdump"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:538
+msgid "UEFITool"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:539
+msgid "uefi-firmware-parser"
+msgstr ""
+
+#: src/utilities/cpu.md:1
+msgid "The u-root `cpu` command"
+msgstr ""
+
+#: src/utilities/cpu.md:3
+msgid ""
+"Do you want to have all the tools on your  system that you have on your "
+"desktop, but you can't get them to fit in your tiny flash part? Do you want "
+"all your desktop files visible on your  system, but just remembered there's "
+"no disk on your  system? Are you tired of using `scp` or `wget` to move "
+"files around? Do you want to run `emacs` or `vim` on the  machine, but know "
+"they can't ever fit? What about `zsh`? How about being able to run commands "
+"on your  machine and have the output appear on your home file system? You "
+"say you'd like to make this all work without having to fill out web forms in "
+"triplicate to get your organization to Do Magic to your desktop?"
+msgstr ""
+
+#: src/utilities/cpu.md:13
+msgid ""
+"**Your search is over: `cpu` is here to answer all your usability needs.**"
+msgstr ""
+
+#: src/utilities/cpu.md:15
+msgid "The problem: running your program on some other system"
+msgstr ""
+
+#: src/utilities/cpu.md:17
+msgid ""
+"People often need to run a command on a remote system. That is easy when the "
+"remote system is the same as the system you are on, e.g., both systems are "
+"Ubuntu 16.04; and all the libraries, packages, and files are roughly the "
+"same. But what if the systems are different, say, Ubuntu 16.04 and Ubuntu "
+"18.10? What if one is Centos, the other Debian? What if a required package "
+"is missing on the remote system, even though in all other ways they are the "
+"same?"
+msgstr ""
+
+#: src/utilities/cpu.md:24
+msgid ""
+"While these systems are both Linux, and hence can provide Application Binary "
+"Interface (ABI) stability at the system call boundary, above that boundary "
+"stability vanishes. Even small variations between Ubuntu versions matter: "
+"symbol versions in C libraries differ, files are moved, and so on."
+msgstr ""
+
+#: src/utilities/cpu.md:29
+msgid ""
+"What is a user to do if they want to build a binary on one system, and run "
+"it on another system?"
+msgstr ""
+
+#: src/utilities/cpu.md:32
+msgid ""
+"The simplest approach is to copy the source to that other system and compile "
+"it. That works sometimes. But there are limits: copying the source might not "
+"be allowed; the code might not even compile on the remote system; some "
+"support code might not be available, as for a library; and for embedded "
+"systems, there might not be a compiler on the remote system. Copy and "
+"compile is not always an option. In fact it rarely works nowadays, when even "
+"different Linux distributions are incompatible."
+msgstr ""
+
+#: src/utilities/cpu.md:40
+msgid ""
+"The next option is to use static linking. Static linking is the oldest form "
+"of binary on Linux systems. While it has the downside of creating larger "
+"binaries, in an age of efficient compilers that remove dead code, 100 "
+"gigabit networks, and giant disks and memory, that penalty is not the "
+"problem it once was. The growth in size of static binaries is nothing like "
+"the growth in efficiency and scale of our resources. Nevertheless, static "
+"linking is frowned upon nowadays and many libraries are only made available "
+"for dynamic linking."
+msgstr ""
+
+#: src/utilities/cpu.md:48
+msgid ""
+"Our user might use one of the many tools that package a binary and all its "
+"libraries into a single file, to be executed elsewhere. The u-root project "
+"even offers one such tool, called `pox`, for portable executables. `Pox` "
+"uses the dynamic loader to figure out all the shared libraries a program "
+"uses, and place them into the archive as well. Further, the user can specify "
+"additional files to carry along in case they are needed."
+msgstr ""
+
+#: src/utilities/cpu.md:55
+msgid ""
+"The problem here is that, if our user cares about binary size, this option "
+"is even worse. Dead code removal won’t work; the whole shared library has to "
+"be carried along. Nevertheless, this can work, in some cases."
+msgstr ""
+
+#: src/utilities/cpu.md:59
+msgid ""
+"So our user packages up their executable using `pox` or a similar tool, uses "
+"`scp` to get it to the remote machine, logs in via `ssh`, and all seems to "
+"be well, until at some point there is another message about a missing shared "
+"library! How can this be? The program that packaged it up checked for all "
+"possible shared libraries."
+msgstr ""
+
+#: src/utilities/cpu.md:65
+msgid ""
+"Unfortunately, shared libraries are now in the habit of loading other shared "
+"libraries, as determined by reading text files. It’s no longer possible to "
+"know what shared libraries are used; they can even change from one run of "
+"the program to the next. One can not find them all just by reading the "
+"shared library itself. A good example is the name service switch library, "
+"which uses `/etc/nsswitch.conf` to find other shared libraries. If "
+"`nsswitch.conf` is missing, or a library is missing, some versions of the "
+"name service switch library will core dump."
+msgstr ""
+
+#: src/utilities/cpu.md:74
+msgid ""
+"Not only must our user remember to bring along `/etc/nsswitch.conf`, they "
+"must also remember to bring along all the libraries it might use. This is "
+"also true of other services such as Pluggable Authentication Modules (PAM). "
+"And, further, the program they bring along might run other programs, with "
+"their own dependencies. At some point, as the set of files grows, frustrated "
+"users might decide to gather up all of `/etc/`, `/bin`, and other "
+"directories, in the hope that a wide enough net might bring along all that’s "
+"needed. The remote system will need lots of spare disk or memory! We’re "
+"right back where we started, with too many files for too little space."
+msgstr ""
+
+#: src/utilities/cpu.md:84
+msgid ""
+"In the worst case, to properly run a binary from one system, on another "
+"system, one must copy everything in the local file system to the remote "
+"system. That is obviously difficult, and might be impossible if the remote "
+"system has no disk, only memory."
+msgstr ""
+
+#: src/utilities/cpu.md:89
+msgid ""
+"One might propose having the remote system mount the local system via NFS or "
+"Samba. While this was a common approach years ago, it comes with its own set "
+"of problems: all the remote systems are now hostage to the reliability of "
+"the NFS or Samba server. But there’s a bigger problem: there is still no "
+"guarantee that the remote system is using the same library versions and "
+"files that the user’s desktop is using. The NFS server might provide, e.g. "
+"SUSE, to the remote system; the user’s desktop might be running Ubuntu. If "
+"the user compiles on their desktop, the binary might still not run on the "
+"remote system, as the SUSE libraries might be different. This is a common "
+"problem."
+msgstr ""
+
+#: src/utilities/cpu.md:99
+msgid ""
+"Still worse, with an NFS root, everyone can see everyone’s files. It’s like "
+"living in an apartment building with glass walls. Glass houses only look "
+"good in architecture magazines. People want privacy."
+msgstr ""
+
+#: src/utilities/cpu.md:103
+msgid "What SSH does not provide"
+msgstr ""
+
+#: src/utilities/cpu.md:105
+msgid ""
+"`ssh` solves the problem of safely getting logged in to a remote machine. "
+"While this is no small accomplishment, it is a lot like being parachuted "
+"into a foreign land, where the rules are changed. It’s a lot nicer, when "
+"going to a new place, to be able to bring along some survival gear, if not "
+"your whole house!"
+msgstr ""
+
+#: src/utilities/cpu.md:110
+msgid ""
+"Users need a way to log in to a machine, in a way similar to `ssh`, but they "
+"need to bring their environment with them. They need their login directory; "
+"their standard commands; their configuration files; and they need some "
+"privacy. Other users on the machine should not be able to see any of the "
+"things they bring with them. After all, everyone who goes camping wants to "
+"believe they are the only people at that campground!"
+msgstr ""
+
+#: src/utilities/cpu.md:117
+msgid "How `cpu` provides what we need"
+msgstr ""
+
+#: src/utilities/cpu.md:119
+msgid ""
+"`cpu` is a Go-based implementation of Plan 9's `cpu` command. It uses the go "
+"`ssh` package, so all your communications are as secure as `ssh`. It can be "
+"started from `/sbin/init` or even replace `/sbin/init`, so you have a tiny "
+"flash footprint. You can see the code at "
+"[github.com:u-root/cpu](https://github.com/u-root/cpu). It's also small: "
+"less than 20 files, including tests."
+msgstr ""
+
+#: src/utilities/cpu.md:126
+msgid ""
+"`cpu` runs as both a client (on your desktop) and an `ssh` server (on your "
+"machine). On your desktop, it needs no special privilege. On the system, "
+"there is only one binary needed: the `cpu` daemon (`cpud`). As part of "
+"setting up a session, in addition to normal `ssh` operations, `cpu` sets up "
+"private name space at important places like `/home/$USER`, `/bin, /usr,`and "
+"so on. Nobody gets to see what other people’s files are."
+msgstr ""
+
+#: src/utilities/cpu.md:133
+msgid ""
+"`Ssh` provides remote access. `cpu` goes one step further, providing what is "
+"called _resource sharing_ -- resources, i.e., files from the client machine "
+"can be used directly on the remote machine, without needing to manually copy "
+"them. `cpud` implements resource sharing by setting up a `file system`mount "
+"on the remote machine and relaying file I/O requests back to the desktop "
+"`cpu` process. The desktop command services those requests; you don't need "
+"to run a special external server. One thing that is a bit confusing with "
+"`cpu`: the desktop client is a file server; the remote server’s Linux kernel "
+"is a file client. `cpu` has to do a bit more work to accomplish its task."
+msgstr ""
+
+#: src/utilities/cpu.md:143
+msgid ""
+"`cpu` will change your life. You can forget about moving files via `scp`: "
+"once you '`cpu` in', the `/home` directory on your  node is your home "
+"directory. You can `cd ~`and see all your files. You can pick any shell you "
+"want, since the shell binary comes from your desktop, not flash. You don't "
+"have to worry about fitting `zsh` into flash ever again!"
+msgstr ""
+
+#: src/utilities/cpu.md:149
+msgid ""
+"At Google we can now run `chipsec`, which imports 20M of Python libraries, "
+"because we have `cpu` and we can redirect `chipsec` output to files in our "
+"home directory."
+msgstr ""
+
+#: src/utilities/cpu.md:153
+msgid "Here is an example session:"
+msgstr ""
+
+#: src/utilities/cpu.md:155
+msgid ""
+"In this command, we `cpu` to a PC Engines APU2. We have built a kernel and "
+"u-root initramfs containing just one daemon -- the `cpu` daemon -- into the "
+"flash image. The APU2 does not even need a disk; it starts running as a "
+"“`cpu` appliance.”"
+msgstr ""
+
+#: src/utilities/cpu.md:160
+msgid ""
+"The `bash` is not on the `cpu` node; it will come from our desktop via the "
+"9p mount."
+msgstr ""
+
+#: src/utilities/cpu.md:172
+msgid ""
+"The `bash` and `ls` command, and the shared libraries they need, do not "
+"exist on the apu2; `cpu` makes sure that the client provides them to the "
+"`cpu` server. The home directory is, similarly, made available to the remote "
+"machine from the local machine."
+msgstr ""
+
+#: src/utilities/cpu.md:177
+msgid ""
+"A big benefit of `cpu` is that, as long as the network works, users can "
+"create very minimal flash images, containing just the `cpu` daemon, just "
+"enough to get the network going. Once the network is up, users can `'cpu` "
+"in', and everything they need is there. It actually looks like they are "
+"still logged in to their desktop, except, of course, truly local file "
+"systems such as `/proc` and `/sys` will come from the machine they are on, "
+"not their desktop."
+msgstr ""
+
+#: src/utilities/cpu.md:184
+msgid "An easy overview of how `cpu` works"
+msgstr ""
+
+#: src/utilities/cpu.md:186
+msgid ""
+"`cpu`, as mentioned, consists of a client and a server. The client is on "
+"your desktop (or laptop), and the server is on the remote system. Both "
+"client and server use an `ssh` transport, meaning that the “wire” protocol "
+"is `ssh`. In this way, `cpu` is just like `ssh`."
+msgstr ""
+
+#: src/utilities/cpu.md:191
+msgid ""
+"As mentioned above, the situation for `cpu` is a bit more complicated than "
+"for `ssh`. `cpu` provides resource sharing, but not from the server to the "
+"client, but rather from the client to the server. The `cpu` client is a file "
+"server; the `cpu` server connects the kernel on the server machine to the "
+"file server in the client, as shown below. Things to note:"
+msgstr ""
+
+#: src/utilities/cpu.md:197
+msgid ""
+"`cpud`, on the remote or server machine, sets up a “private name space "
+"mount” of `/tmp` for the program. “Private name space mount” just means that "
+"only that program, and its children, can see what is in its private `/tmp`. "
+"Other, external programs continue to use `/tmp`, but they are _different_ "
+"instantiations of `/tmp`."
+msgstr ""
+
+#: src/utilities/cpu.md:202
+msgid ""
+"The private name space mount of `/tmp` is on a filesystem in RAM. The data "
+"stored in `/tmp` is not visible to other processes, and not persistent."
+msgstr ""
+
+#: src/utilities/cpu.md:204
+msgid ""
+"`cpud` creates a directory, `cpu`, in the private `/tmp`; and mounts the "
+"server on it. This mount point is also invisible outside the process and its "
+"children."
+msgstr ""
+
+#: src/utilities/cpu.md:207
+msgid ""
+"To make sure that names like `/bin/bash`, and `/usr/lib/libc.so` work, "
+"`cpud` sets up _bind mounts_ from, e.g., `/tmp/cpu/bin` to `/bin`. These are "
+"also private mounts, and do not affect any program outside the one `cpud` "
+"starts. Anytime the program and its children access files in `/bin`, `/lib`, "
+"`/usr`, `/home/$USER`, and so on, they are accessing files from the client "
+"machine via the built-in client file server."
+msgstr ""
+
+#: src/utilities/cpu.md:213
+msgid ""
+"The client `cpu` program passes the full environment from the client machine "
+"to `cpud`. When the client program requests that, e.g., `bash` be run, the "
+"`cpud` uses the PATH environment variable to locate `bash`. Because of the "
+"private name space mounts and binds, `bash` will be found in `/bin/bash`, "
+"and its libraries will be found in their usual place. This is an essential "
+"property of `cpu`, that the names used on the user’s machine work the same "
+"way on the remote machine. An overview of the process is shown below."
+msgstr ""
+
+#: src/utilities/cpu.md:223
+msgid "`cpu` startup"
+msgstr ""
+
+#: src/utilities/cpu.md:225
+msgid ""
+"The startup proceeds in several steps. Every session begins with an initial "
+"contact from the `cpu` client to the `cpu` server."
+msgstr ""
+
+#: src/utilities/cpu.md:230
+msgid ""
+"The first step the `cpud` does is set up the mounts back to the client. It "
+"then sets up the bind mounts such as `/bin` to `/tmp/cpu/bin`. In the "
+"following figure, we compress the Linux kernel mount and bind mounts shown "
+"above into a smaller box called “name space.”"
+msgstr ""
+
+#: src/utilities/cpu.md:237
+msgid "Next, `cpu` and the `cpud` set up the terminal management."
+msgstr ""
+
+#: src/utilities/cpu.md:241
+msgid ""
+"Finally, `cpud` sets up the program to run. Because the PATH variable has "
+"been transferred to `cpud`, and the name space includes `/bin` and `/lib`, "
+"the `cpud` can do a standard Linux `exec` system call without having to "
+"locate where everything is. Native kernel mechanisms create requests as "
+"files are referenced, and the `cpu` file server support does the rest."
+msgstr ""
+
+#: src/utilities/cpu.md:249
+msgid ""
+"Why do we only show one program instead of many? From the point of view of "
+"`cpud`, it only starts one program. From the point of view of users, there "
+"can be many. But if there is more than one program to start, _that is not "
+"the responsibility of `cpud`_. If more than one program is run, they will be "
+"started by the program that `cpud` started, i.e., a command interpreter like "
+"the shell. Or it could be as simple as a one-off command like `date`. From "
+"the point of view of `cpud`, it’s all the same. `cpud` will wait until the "
+"process it started, and all its children, have exited. But `cpud`’s "
+"responsibilities to start a program ends with that first program."
+msgstr ""
+
+#: src/utilities/cpu.md:259
+msgid ""
+"But what happens when `cpud` runs that first program? Here is where it gets "
+"interesting, and, depending on your point of view, either magical, "
+"confounding, or counter-intuitive. We’ll go with magical."
+msgstr ""
+
+#: src/utilities/cpu.md:263
+msgid "Starting that first program"
+msgstr ""
+
+#: src/utilities/cpu.md:265
+msgid ""
+"As mentioned above, `cpud` sets up mounts for a name space, and calls the "
+"Linux `exec()` call to start the program."
+msgstr ""
+
+#: src/utilities/cpu.md:268
+msgid ""
+"We can actually watch all the `cpu` file server operations. The file server "
+"protocol is called 9P2000. We are going to present a filtered version of the "
+"file I/O from running a remote `date`; in practice, you can watch all the "
+"opens, reads, writes, and closes the remote process performs."
+msgstr ""
+
+#: src/utilities/cpu.md:273
+msgid ""
+"The trace for running `date` starts right when the remote program has called "
+"`exec`, and the kernel is starting to find the program to run[^1]. The file "
+"opens look like this, on a user’s system:"
+msgstr ""
+
+#: src/utilities/cpu.md:286
+msgid ""
+"The kernel opened `/bin/date`, determined what libraries (files ending in "
+"`.so`) it needed, and opened them as well."
+msgstr ""
+
+#: src/utilities/cpu.md:289
+msgid "We can compare this with a local execution:"
+msgstr ""
+
+#: src/utilities/cpu.md:302
+msgid ""
+"Note that several files do not show up in our trace; they are in `/etc`, and "
+"the `cpud` does not set up a bind mount over `/etc`. But the other files "
+"look very similar. You might wonder why the local version opens "
+"`/etc/localtime`, and the remote version opens "
+"`/usr/share/zoneinfo/America/Los_Angeles`."
+msgstr ""
+
+#: src/utilities/cpu.md:307
+msgid "The reason is that `etc/localtime` is a symlink:"
+msgstr ""
+
+#: src/utilities/cpu.md:313
+msgid ""
+"The access to `/etc/localtime` does not get handled by the server; but the "
+"access to `/usr/share/zoneinfo/America/Los_Angeles`does."
+msgstr ""
+
+#: src/utilities/cpu.md:316
+msgid ""
+"What about different architectures? What if we are using an x86 but want to "
+"`cpu` to an ARM processor?"
+msgstr ""
+
+#: src/utilities/cpu.md:319
+msgid ""
+"We can set the local `cpu` up to talk to a remote `cpu` that needs different "
+"binaries. We might have an entire ARM file system tree in `~/arm`, for "
+"example. We would then invoke `cpu` as follows:"
+msgstr ""
+
+#: src/utilities/cpu.md:327
+msgid ""
+"And the remote `cpud`, running on an ARM, would be provided with ARM "
+"binaries."
+msgstr ""
+
+#: src/utilities/cpu.md:329
+msgid "Learning how to use `cpu`"
+msgstr ""
+
+#: src/utilities/cpu.md:331
+msgid ""
+"`Cpu` can be a hard thing to learn, not because it is difficult, but because "
+"it is different. To paraphrase Yoda, you have to unlearn what you have "
+"learned. Forget about copying files from here to there; when you `cpu` "
+"there, it looks like your files are waiting for you."
+msgstr ""
+
+#: src/utilities/cpu.md:336
+msgid ""
+"You can start experimenting and learning about `cpu` by just running it "
+"locally."
+msgstr ""
+
+#: src/utilities/cpu.md:338
+msgid "A set of binaries for you to try"
+msgstr ""
+
+#: src/utilities/cpu.md:340
+msgid ""
+"In order for you to try it out, start by working with the set of `cpu` "
+"binaries at "
+"[https://github.com/u-root/cpubinaries](https://github.com/u-root/cpubinaries). "
+"With them, you can create a bootable, mountable USB image that you can "
+"download. The image contains a `cpu` client that runs on Linux, a private "
+"key, and, when booted, it starts a `cpu` daemon and waits to serve `cpu` "
+"clients. The `cpu` client is statically linked and hence should run on any "
+"Linux from the last 10 years or so."
+msgstr ""
+
+#: src/utilities/cpu.md:349
+msgid "The binaries include:"
+msgstr ""
+
+#: src/utilities/cpu.md:351
+msgid ""
+"A kernel (`cpukernel`) with a built-in initramfs containing `cpud`, as well "
+"as a public key. Also included, should you want to build your own, is the "
+"config file (`cpu.config`)."
+msgstr ""
+
+#: src/utilities/cpu.md:354
+msgid ""
+"A binary client program, `cpu`, as well as the private key to use. You can "
+"place this key in `~/.ssh` or specify it via the `-key` option to `cpu`."
+msgstr ""
+
+#: src/utilities/cpu.md:356
+msgid ""
+"A script to run the USB stick via `qemu` (`TESTQEMU`); and a script to run a "
+"`cpu` command (`EXAMPLE`)."
+msgstr ""
+
+#: src/utilities/cpu.md:358
+msgid "The `extlinux.conf` used for the USB stick."
+msgstr ""
+
+#: src/utilities/cpu.md:360
+msgid ""
+"`usbstick.xz` is a compressed USB stick image that is bootable. It will "
+"uncompress to about 7GB. You can use the `TESTQEMU` script to try it out, or "
+"use `dd` to write it to a USB stick and boot that stick on an x86 system."
+msgstr ""
+
+#: src/utilities/cpu.md:364
+msgid ""
+"Be careful how you use the keys; they're public. You should really only use "
+"them as part of the demo."
+msgstr ""
+
+#: src/utilities/cpu.md:367
+msgid ""
+"The `cpukernel` was built using the `github.com:/mainboards` repo. If you "
+"clone this repo, the following commands will rebuild the kernel:"
+msgstr ""
+
+#: src/utilities/cpu.md:370
+msgid "`cd mainboards/intel/generic`"
+msgstr ""
+
+#: src/utilities/cpu.md:371
+msgid "`make fetch`"
+msgstr ""
+
+#: src/utilities/cpu.md:372
+msgid "`make cpukernel`"
+msgstr ""
+
+#: src/utilities/cpu.md:374
+msgid "How to use the cpu binaries"
+msgstr ""
+
+#: src/utilities/cpu.md:376
+msgid ""
+"You’ll first need to start the server, and we show the entire sequence "
+"below, including unpacking the image:"
+msgstr ""
+
+#: src/utilities/cpu.md:383
+msgid ""
+"How you run `qemu` depends on whether you want graphics or not: if you are "
+"not in a windowing environment, add `-nographic` to the command below. In "
+"any event, at the `boot:` prompt, you can hit return or wait:"
+msgstr ""
+
+#: src/utilities/cpu.md:403
+msgid ""
+"At this point, the `cpu` daemon is running, and you can try the `cpu` "
+"command:"
+msgstr ""
+
+#: src/utilities/cpu.md:410
+msgid "You can log in and notice that things are the same:"
+msgstr ""
+
+#: src/utilities/cpu.md:422
+msgid ""
+"Note that you end up in the same directory on the remote node that you are "
+"in on the host; all the files are there. We can run any program on the "
+"remote node that we have on the host:"
+msgstr ""
+
+#: src/utilities/cpu.md:450
+msgid ""
+"As you can see, `/tmp/cpu` is mounted via 9p back to the `cpu` client "
+"(recall that the `cpu` client is a 9p server, so your files are visible on "
+"the remote node). Further, you can see mounts on `/usr`, `/bin`, `/etc`, and "
+"so on. For this reason, we can run `date` and it will find its needed "
+"libraries in `/usr`, as the `ldd` command demonstrates."
+msgstr ""
+
+#: src/utilities/cpu.md:456
+msgid "Making cpu easier to use"
+msgstr ""
+
+#: src/utilities/cpu.md:458
+msgid ""
+"If you get tired of typing `-keys`, do the following: put your own `cpu_rsa` "
+"in `~/.ssh`; and copy the `cpu` binary to `bin` (or build a new one)."
+msgstr ""
+
+#: src/utilities/cpu.md:461
+msgid ""
+"Warning! The `cpu` keys we provide in the repo are only to be used for this "
+"demo. You should not use them for any other purpose, as they are in a Github "
+"repo and hence open to the world."
+msgstr ""
+
+#: src/utilities/cpu.md:465
+msgid "Using some of the namespace"
+msgstr ""
+
+#: src/utilities/cpu.md:467
+msgid ""
+"Sometimes, you don’t want all the `/usr` and `/bin` directories to be "
+"replaced with those from your machine. You might, for example, `cpu` into an "
+"ARM system, and hence only need a `/home`, but nothing else."
+msgstr ""
+
+#: src/utilities/cpu.md:471
+msgid ""
+"The `-namespace` switch lets you control the namespace. It is structured "
+"somewhat like a path variable, with `:`\\-separated components. The default "
+"value is `/lib:/lib64:/usr:/bin:/etc:/home`. You can modify it or even force "
+"it to be empty: `-namespace=\"\"`, for example. If it is empty, `cpud` will "
+"only mount the 9p server on `/tmp/cpu`."
+msgstr ""
+
+#: src/utilities/cpu.md:477
+msgid ""
+"This following example will cpu to an ARM64 host, sharing /home, but nothing "
+"else."
+msgstr ""
+
+#: src/utilities/cpu.md:483
+msgid ""
+"For an different architecture system, we might want to specify that the "
+"/bin, /lib, and other directories have a different path on the remote than "
+"they have locally. The -namespace switch allows this via an = sign:"
+msgstr ""
+
+#: src/utilities/cpu.md:491
+msgid ""
+"In this case, `/bin`, `/usr`, and `/lib` on the remote system are supplied "
+"by `/arm/bin`, `/arm/lib`, and `/arm/usr` locally."
+msgstr ""
+
+#: src/utilities/cpu.md:494
+msgid ""
+"If we need to test `cpu` without doing bind mounts, we can specify a `PWD` "
+"that requires no mounts and an empty namespace:"
+msgstr ""
+
+#: src/utilities/cpu.md:511
+msgid ""
+"There is a bit of a subtlety about the interaction of the namespace and 9p "
+"switches, which we are still discussing: the -namespace value can override "
+"the -9p switch."
+msgstr ""
+
+#: src/utilities/cpu.md:514
+msgid ""
+"If you set -9p=false but have a non-empty namespace variable, then 9p will "
+"be set to true. So in this example, the -9p switch has no effect:"
+msgstr ""
+
+#: src/utilities/cpu.md:521
+msgid ""
+"Why is this? Because the default value of -namespace is non-empty. The open "
+"question: should -9p=false force the namespace to be empty; or should a "
+"none-empty namespace for -9p to be true? For now, we have chosen the latter "
+"approach."
+msgstr ""
+
+#: src/utilities/cpu.md:526
+msgid ""
+"Another possible approach is to log conflicting settings of these two "
+"switches and exit:"
+msgstr ""
+
+#: src/utilities/cpu.md:531
+msgid "\"\""
+msgstr ""
+
+#: src/utilities/cpu.md:534
+msgid "We welcome comments on this issue."
+msgstr ""
+
+#: src/utilities/cpu.md:536
+msgid "cpu and Docker"
+msgstr ""
+
+#: src/utilities/cpu.md:538
+msgid ""
+"Maintaining file system images is inconvenient. We can use Docker containers "
+"on remote hosts instead. We can take a standard Docker container and, with "
+"suitable options, use docker to start the container with `cpu` as the first "
+"program it runs."
+msgstr ""
+
+#: src/utilities/cpu.md:543
+msgid ""
+"That means we can use any Docker image, on any architecture, at any time; "
+"and we can even run more than one at a time, since the namespaces are "
+"private."
+msgstr ""
+
+#: src/utilities/cpu.md:546
+msgid "In this example, we are starting a standard Ubuntu image:"
+msgstr ""
+
+#: src/utilities/cpu.md:550
+msgid ""
+"'ubuntu@sha256:073e060cec31fed4a86fcd45ad6f80b1f135109ac2c0b57272f01909c9626486'"
+msgstr ""
+
+#: src/utilities/cpu.md:555
+msgid ""
+"'s platform (linux/arm64/v8) does not match the detected host platform "
+"(linux/amd64) and no specific platform was requested\n"
+"1970/01/01 21:37:32 CPUD:Warning: mounting /tmp/cpu/lib64 on /lib64 failed: "
+"no such file or directory\n"
+"$ ls\n"
+"bbin  buildbin  env  go    init     lib    proc  tcz  ubin  var\n"
+"bin   dev       etc  home  key.pub  lib64  sys   tmp  usr\n"
+msgstr ""
+
+#: src/utilities/cpu.md:562
+msgid ""
+"Note that the image was update and then started. The `/lib64` mount fails, "
+"because there is no `/lib64` directory in the image, but that is harmless."
+msgstr ""
+
+#: src/utilities/cpu.md:565
+msgid ""
+"On the local host, on which we ran docker, this image will show up in docker "
+"`ps`:"
+msgstr ""
+
+#: src/utilities/cpu.md:570
+msgid "\"/home/rminnich/go/b…\""
+msgstr ""
+
+#: src/utilities/cpu.md:573
+msgid "Even though the binaries themselves are running on the remote ARM system."
+msgstr ""
+
+#: src/utilities/cpu.md:575
+msgid "cpu and virtiofs"
+msgstr ""
+
+#: src/utilities/cpu.md:577
+msgid ""
+"While 9p is very general, because it is _transport-independent_, there are "
+"cases where we can get much better performance by using a less general file "
+"system. One such case is with virtofs."
+msgstr ""
+
+#: src/utilities/cpu.md:581
+msgid ""
+"Because virtiofs is purely from guest kernel vfs to host kernel vfs, via "
+"virtio transport, it has been measured to run at up to 100 times faster."
+msgstr ""
+
+#: src/utilities/cpu.md:584
+msgid ""
+"We can use virtiofs by specifying virtiofs mounts. cpud will look for an "
+"environemnt variable, `CPU_FSTAB`, which is in `fstab(5)` format. The client "
+"can specify an fstab in one of two ways. Either via the `-fstab` switch, in "
+"which case the client will populate the `CPU_FSTAB` variable with the "
+"contents of the file or by passing the `CPU_FSTAB` environment variable, "
+"which happens by default."
+msgstr ""
+
+#: src/utilities/cpu.md:591
+msgid ""
+"On the client side, the file specified via the -fstab takes precedence over "
+"any value of the CPU_FSTAB environment variable. On the server side, cpud "
+"does not use the -fstab switch, only using the environment variable."
+msgstr ""
+
+#: src/utilities/cpu.md:595
+msgid "Here is an example of using the CPU_FSTAB variable with one entry:"
+msgstr ""
+
+#: src/utilities/cpu.md:601
+msgid ""
+"In this case, the virtiofs server had the name myfs, and on the remote side, "
+"virtiofs was mounted on /mnt."
+msgstr ""
+
+#: src/utilities/cpu.md:604
+msgid "For the fstab case, the command looks like this:"
+msgstr ""
+
+#: src/utilities/cpu.md:610
+msgid "The fstab in this case would be"
+msgstr ""
+
+#: src/utilities/cpu.md:616
+msgid ""
+"Note that both the environment variable and the fstab can have more than one "
+"entry, but they entries must be separate by newlines. Hence, this will not "
+"work:"
+msgstr ""
+
+#: src/utilities/cpu.md:624
+msgid "as shells insist on converting newlines to spaces."
+msgstr ""
+
+#: src/utilities/cpu.md:626
+msgid ""
+"The fstab can specify any file system. If there is a mount path to, e.g., "
+"Google drive, and it can be specified in fstab format, then cpu clients can "
+"use Google Drive files. Note, again, that these alternative mounts do not "
+"use the 9p server built in to the cpu client; they use the file systems "
+"provided on the cpu server machine."
+msgstr ""
+
+#: src/utilities/cpu.md:632
+msgid "There are thus several choices for setting up the mounts"
+msgstr ""
+
+#: src/utilities/cpu.md:634
+msgid "9p support by the cpu client"
+msgstr ""
+
+#: src/utilities/cpu.md:635
+msgid ""
+"9p supported by the cpu client, with additional mounts via -fstab or "
+"-namespace"
+msgstr ""
+
+#: src/utilities/cpu.md:636
+msgid ""
+"9p _without_ any bind mounts, i.e. -9p=false -namespace \"\", in which case, "
+"on the remote machine, files from the client are visible in /tmp/cpu, but no "
+"bind mounts are done; with additional mounts provided by fstab mounts are "
+"provided"
+msgstr ""
+
+#: src/utilities/cpu.md:640
+msgid ""
+"no 9p mounts at all, when -namespace=\"\" -9p=false; with optional "
+"additional mounts via fstab"
+msgstr ""
+
+#: src/utilities/cpu.md:642
+msgid "if there are no 9p mounts, and no fstab mounts, cpu is equivalent to ssh."
+msgstr ""
+
+#: src/utilities/cpu.md:644
+msgid "For reference, the command we used: `cpu -dbg9p -d apu2 date`"
+msgstr ""
+
+#: src/utilities/dut.md:1
+msgid "DUT, a simple Device Under Test utility."
+msgstr ""
+
+#: src/utilities/dut.md:3
+msgid "Points of contact: [Ron Minnich](https://github.com/rminnich)"
+msgstr ""
+
+#: src/utilities/dut.md:5
+msgid ""
+"DUT is a simple Device Under Test program that gives you control of a node. "
+"It is intended to make very fast startup and control easy."
+msgstr ""
+
+#: src/utilities/dut.md:8
+msgid ""
+"DUT is one program implementing three operations. The first, tester, is run "
+"on a test control system, such as your desktop; the second, called device, "
+"is run on the device; the third, called ssh and also run on the device, "
+"starts an ssh server assuming one is present."
+msgstr ""
+
+#: src/utilities/dut.md:12
+msgid ""
+"DUT is intended to be very limited, with more sophisticated operations, "
+"should they be needed, being done over SSH."
+msgstr ""
+
+#: src/utilities/dut.md:15
+msgid "DUT is found at github.com:linuxboot/dut."
+msgstr ""
+
+#: src/utilities/dut.md:17
+msgid "This chapter describes how we build and use DUT."
+msgstr ""
+
+#: src/utilities/dut.md:19 src/coreboot.u-root.systemboot/index.md:31
+msgid "Components"
+msgstr ""
+
+#: src/utilities/dut.md:21
+msgid "DUT is intended to be built into a u-root image. First one must fetch it:"
+msgstr ""
+
+#: src/utilities/dut.md:27
+msgid ""
+"DUT source tree is structured such that a program called uinit is produced. "
+"This is convenient for u-root usage."
+msgstr ""
+
+#: src/utilities/dut.md:29
+msgid "Building it into a u-root image is easy:"
+msgstr ""
+
+#: src/utilities/dut.md:34
+msgid ""
+"I almost always add an sshd to u-root; it's just too handy. U-root sshd does "
+"not support passwords, so you have to supply the public key:"
+msgstr ""
+
+#: src/utilities/dut.md:40
+msgid "DUT on the device"
+msgstr ""
+
+#: src/utilities/dut.md:41
+msgid ""
+"On boot, the standard init program will find dut, and run it. The standard "
+"mode on a device is device mode, and dut will bring up the ethernet, "
+"currently using 192.168.0.2, and assuming the tester is 192.168.0.1 (this "
+"should be fixed ...). It will then attempt to connect to a uinit running in "
+"'tester' mode on 192.168.0.1. Once connected, it functions as a server and "
+"waits for requests."
+msgstr ""
+
+#: src/utilities/dut.md:47
+msgid "DUT on the controller"
+msgstr ""
+
+#: src/utilities/dut.md:48
+msgid "Running on the controller is easy:"
+msgstr ""
+
+#: src/utilities/dut.md:53
+msgid ""
+"On the controller, the program waits for a connection and then starts "
+"issuing commands to the device. The controller has the option of calling the "
+"following RPC functions:"
+msgstr ""
+
+#: src/utilities/dut.md:63
+msgid ""
+"Each of these RPCs takes arguments and returns a result, with Welcome being "
+"the most fun:"
+msgstr ""
+
+#: src/utilities/dut.md:75
+msgid ""
+"The current tester mode performs an RPC sequence I use for DXE cleaning, "
+"namely, a Welcome, followed by a Reboot, followed by a Welcome. This "
+"sequence verifies that I can get network going from power on, do a reboot, "
+"and reconnect after a reboot. It's been good for finding out if a particular "
+"DXE can be removed."
+msgstr ""
+
+#: src/utilities/dut.md:79
+msgid ""
+"Once the second Welcome has happened, if an sshd is installed, it will have "
+"been started, and you can do additional commands."
+msgstr ""
+
+#: src/utilities/dut.md:81
+msgid "Future work"
+msgstr ""
+
+#: src/utilities/dut.md:83
+msgid ""
+"Obviously, much more can be done. But this is a useful foundation on which "
+"to build DUT environments."
+msgstr ""
+
+#: src/implementation.md:3
+msgid ""
+"The aim of LinuxBoot is to reduce complexity and obscure firmware by moving "
+"that functionality into kernel and user-space."
+msgstr ""
+
+#: src/implementation.md:6
+msgid ""
+"This chapter describes the procedures from a [LinuxBoot "
+"workshop](https://docs.google.com/presentation/d/1s9ka4v7leKeJa3116AQoNb9cv3OqmnW6pgn0ov9WiHo/edit?ts=5e2b227b#slide=id.g7ceec54197_4_163) "
+"where an Atomic Pi board with UEFI firmware was converted to run LinuxBoot. "
+"The build materials associated with this are found at "
+"[digitalloggers/atomicpi](https://github.com/linuxboot/mainboards/tree/master/digitalloggers/atomicpi)."
+msgstr ""
+
+#: src/implementation.md:12
+msgid ""
+"Read the below and consult the Makefile for the details of how it was "
+"implemented."
+msgstr ""
+
+#: src/implementation.md:15
+msgid "A quick refresher on UEFI"
+msgstr ""
+
+#: src/implementation.md:17
+msgid "UEFI has three sections:"
+msgstr ""
+
+#: src/implementation.md:19
+msgid "SEC (\"Boot\")"
+msgstr ""
+
+#: src/implementation.md:20
+msgid "PEI (\"Very early chip setup and DRAM programming\")"
+msgstr ""
+
+#: src/implementation.md:21
+msgid "DXE (\"DRAM code\")"
+msgstr ""
+
+#: src/implementation.md:23
+msgid "DXE process is very complex; some systems have 750 DXEs."
+msgstr ""
+
+#: src/implementation.md:25
+msgid ""
+"LinuxBoot replaces most of the UEFI software with Linux. LinuxBoot has an "
+"initramfs provided by [u-root](../u-root.md)."
+msgstr ""
+
+#: src/implementation.md:28
+msgid ""
+"The above are stored inside a flash filesystem (FFS) inside a region of "
+"flash on your motherboard (the BIOS region). Another important region of "
+"flash is the ME region."
+msgstr ""
+
+#: src/implementation.md:32
+msgid ""
+"The Management Engine (ME) is an x86 CPU embedded in the Intel Platform "
+"Controller Hub (PCH). It runs the Minix operating system which boots first "
+"and enables hardware such as clocks and GPIOs. ME checks the contents of "
+"flash memory and is used to implement \"BootGuard\". If you reflash and the "
+"ME is in \"BootGuard\" mode, your machine will be unusable. You need to run "
+"a tool called `me_cleaner` on the image to disable BootGuard."
+msgstr ""
+
+#: src/implementation.md:39
+msgid "How do you get LinuxBoot on your hardware"
+msgstr ""
+
+#: src/implementation.md:41
+msgid ""
+"Start with a board running standard UEFI and proceed from \"zero changes to "
+"FLASH\" to \"max changes\" in 4 steps:"
+msgstr ""
+
+#: src/implementation.md:44
+msgid "Boot from USB stick via UEFI shell command _or_ netboot (zero changes)"
+msgstr ""
+
+#: src/implementation.md:45
+msgid "Find a way to read flash and write flash"
+msgstr ""
+
+#: src/implementation.md:46
+msgid "Understand the flash layout"
+msgstr ""
+
+#: src/implementation.md:47
+msgid "Prepare linux kernel and initrd/initramfs payload."
+msgstr ""
+
+#: src/implementation.md:48
+msgid ""
+"Replace UEFI Shell code section with Linux kernel and associated initrd "
+"(change part of one thing)"
+msgstr ""
+
+#: src/implementation.md:50
+msgid "Remove as many DXEs as possible (change by removal). This change:"
+msgstr ""
+
+#: src/implementation.md:51
+msgid "Speeds boot"
+msgstr ""
+
+#: src/implementation.md:52
+msgid "Reduces panic possibilities"
+msgstr ""
+
+#: src/implementation.md:53
+msgid "Removes exploits"
+msgstr ""
+
+#: src/implementation.md:54
+msgid "In production, it has solved problems"
+msgstr ""
+
+#: src/implementation.md:55
+msgid "Clear ME region for initrd storage"
+msgstr ""
+
+#: src/implementation.md:56
+msgid "Replace some DXEs with open source components (change by replacement)"
+msgstr ""
+
+#: src/implementation.md:58
+msgid ""
+"One of the challenges in the above is in finding (or reclaiming) enough "
+"space in flash to shoehorn your kernel and initrd into."
+msgstr ""
+
+#: src/implementation.md:61
+msgid "Tools of the trade"
+msgstr ""
+
+#: src/implementation.md:63
+msgid ""
+"There are two tools you use when you modify the UEFI flash image: `utk` and "
+"`me_cleaner`."
+msgstr ""
+
+#: src/implementation.md:66
+msgid "The ME Cleaner tool:"
+msgstr ""
+
+#: src/implementation.md:68
+msgid "`/usr/bin/python2 me_cleaner.py -s` _imagefile.bin_"
+msgstr ""
+
+#: src/implementation.md:70
+msgid ""
+"`me_cleaner` sets the high assurance platform (HAP) bit. HAP provides a way "
+"to disable a feature on Intel chips that does not allow us to modify the "
+"UEFI image and install LinuxBoot. Setting the bit with `me_cleaner` disables "
+"the \"feature\".  Note that this does not always work; check with the "
+"LinuxBoot community."
+msgstr ""
+
+#: src/implementation.md:76
+msgid "When you run `me_cleaner`:"
+msgstr ""
+
+#: src/implementation.md:82
+msgid "you should see output similar to the following:"
+msgstr ""
+
+#: src/implementation.md:86
+msgid "`Full image detected`"
+msgstr ""
+
+#: src/implementation.md:87
+msgid "`Found FPT header at 0x1010`"
+msgstr ""
+
+#: src/implementation.md:88
+msgid "`Found 20 partition(s)`"
+msgstr ""
+
+#: src/implementation.md:89
+msgid "`Found FTPR header: FTPR partition spans from 0x6f000 to 0xe700`"
+msgstr ""
+
+#: src/implementation.md:90
+msgid "`ME/TXE firmware version 2.0.5.3112 (generation 2)`"
+msgstr ""
+
+#: src/implementation.md:91
+msgid "`Public key match: Intel TXE, firmware versions 2.x.x.x`"
+msgstr ""
+
+#: src/implementation.md:92
+msgid "`The AltMeDisable bit is SET`"
+msgstr ""
+
+#: src/implementation.md:93
+msgid "`Setting the AltMeDisable bit in PCHSTRP10 to disable Intel ME…`"
+msgstr ""
+
+#: src/implementation.md:94
+msgid "`Checking the FTPR RSA signature... VALID`"
+msgstr ""
+
+#: src/implementation.md:95
+msgid "`Done! Good luck!`"
+msgstr ""
+
+#: src/implementation.md:97
+msgid ""
+"By applying `me_cleaner`, it has been observed that almost 4M of flash ram "
+"can be reclaimed for use. That 4M is enough to store a reasonably full "
+"featured compressed initrd image."
+msgstr ""
+
+#: src/implementation.md:101
+msgid "The `utk` tool can:"
+msgstr ""
+
+#: src/implementation.md:103
+msgid "Remove DXEs"
+msgstr ""
+
+#: src/implementation.md:104
+msgid "Insert new DXEs"
+msgstr ""
+
+#: src/implementation.md:105
+msgid "Replace the binary code of a DXE with a kernel"
+msgstr ""
+
+#: src/implementation.md:106
+msgid "Reallocate space from the ME region to the BIOS region (\"tighten\")"
+msgstr ""
+
+#: src/implementation.md:108
+msgid "LinuxBoot Implementation steps"
+msgstr ""
+
+#: src/implementation.md:110
+msgid "Step 1: boot Linux via netboot / UEFI shell"
+msgstr ""
+
+#: src/implementation.md:112
+msgid "netboot: standard BIOS-based PXE boot"
+msgstr ""
+
+#: src/implementation.md:113
+msgid "Netboot is probably the most common working boot method on UEFI"
+msgstr ""
+
+#: src/implementation.md:114
+msgid "We have never seen a system that did not have a net boot"
+msgstr ""
+
+#: src/implementation.md:115
+msgid "UEFI Shell (mentioned only for completeness)"
+msgstr ""
+
+#: src/implementation.md:116
+msgid ""
+"Install Linux on FAT-32 media with a name of your choice (e.g. \"kernel\")"
+msgstr ""
+
+#: src/implementation.md:117
+msgid "FAT-32, also known as MS-DOS file system"
+msgstr ""
+
+#: src/implementation.md:118
+msgid "Boot kernel at UEFI Shell prompt"
+msgstr ""
+
+#: src/implementation.md:119
+msgid "We've run into a few systems that don't have a UEFI shell"
+msgstr ""
+
+#: src/implementation.md:121
+msgid "Working with a system that only has a net interface"
+msgstr ""
+
+#: src/implementation.md:123
+msgid ""
+"If the system only has a net interface, you use Dynamic Host Configuration "
+"Protocol (DHCP), using broadcast DISCOVER, and Trivial File Transfer "
+"Protocol (TFTP) to get the boot information you need."
+msgstr ""
+
+#: src/implementation.md:127
+msgid ""
+"Configuration information is provided by REPLY to a DHCP request. The REPLY "
+"returns an IP, server, and a configuration file name that provides:"
+msgstr ""
+
+#: src/implementation.md:130
+msgid "Identity"
+msgstr ""
+
+#: src/implementation.md:131
+msgid "What to boot"
+msgstr ""
+
+#: src/implementation.md:132
+msgid "Where to get it"
+msgstr ""
+
+#: src/implementation.md:134
+msgid ""
+"Data is provided by TFTP. HTTP downloading takes a fraction of a second even "
+"for 16M kernels. With TFTP it's very slow and TFTP won't work with initramfs "
+"much large than 32MiB. Most LinuxBoot shops use or are transitioning to HTTP."
+msgstr ""
+
+#: src/implementation.md:138
+msgid ""
+"Note: Boot images require a kernel(bzImage) + an initramfs + a command line. "
+"They can be loaded as three pieces or compiled and loaded as one piece, as "
+"described in this section."
+msgstr ""
+
+#: src/implementation.md:142
+msgid "Step 2: read & write the flash"
+msgstr ""
+
+#: src/implementation.md:144
+msgid ""
+"There are two main ways to read and write the flash - hardware and software."
+msgstr ""
+
+#: src/implementation.md:146
+msgid ""
+"Hardware: It is worth buying a Pomona 5250 SOIC Clip adapter to read "
+"directly by hardware to have something to roll back to if anything goes "
+"wrong. Avoid cheap SOIC clip adapters that don't allow you to use standard "
+"jumper leads. For a good example of using a Raspberry Pi 3/4 to read/write, "
+"see [Sakaki's EFI Install Guide/Disabling the Intel Management "
+"Engine](https://wiki.gentoo.org/wiki/Sakaki%27s_EFI_Install_Guide/Disabling_the_Intel_Management_Engine#imt_check)"
+msgstr ""
+
+#: src/implementation.md:153
+msgid ""
+"Software: With a working boot image, use flashrom to read an image of your "
+"flash. To write you may need to disable flash protections (look for \"ME "
+"Manufacturing mode\" jumpers on your motherboard). Figure on generally using "
+"software methods for reading & writing flash, but with hardware to drop back "
+"to."
+msgstr ""
+
+#: src/implementation.md:159
+msgid ""
+"Step 3: Familiarise yourself with the flash layout and identify free space"
+msgstr ""
+
+#: src/implementation.md:161
+msgid ""
+"Open your flash image with UEFITool, and locate the filesystem containing "
+"the DXE's (it will have the Shell or `Shell_Full` in it ). Check how much "
+"volume free space is in that filesystem - this will be an initial limit when "
+"you come to place your kernel and initramfs in it in step 5."
+msgstr ""
+
+#: src/implementation.md:166
+msgid "Step 4: Prepare linux/u-root payload"
+msgstr ""
+
+#: src/implementation.md:168
+msgid "Start small and work your way up."
+msgstr ""
+
+#: src/implementation.md:170
+msgid ""
+"Use the tiny.config to configure your first kernel, and embed a small "
+"initramfs in-kernel (the u-root cpu payload is an excellent starting point)."
+msgstr ""
+
+#: src/implementation.md:172
+msgid "One can have a full kernel/initramfs in around 2M of flash."
+msgstr ""
+
+#: src/implementation.md:173
+msgid ""
+"A more full featured kernel might consume 2M and a u-root bb distribution "
+"4M, which may well exceed the volume free space."
+msgstr ""
+
+#: src/implementation.md:175
+msgid ""
+"When there isn't enough space in this filesystem, one can either start "
+"removing unused DXE's (step 6), or use space formerly used by the ME Region "
+"(step 7)."
+msgstr ""
+
+#: src/implementation.md:179
+msgid "Step 5: replace Shell binary section"
+msgstr ""
+
+#: src/implementation.md:181
+msgid "UEFI Shell is a DXE"
+msgstr ""
+
+#: src/implementation.md:182
+msgid "DXEs are Portable Executable 32-bit binaries (PE32)"
+msgstr ""
+
+#: src/implementation.md:183
+msgid "They have multiple sections, one of them being binary code"
+msgstr ""
+
+#: src/implementation.md:184
+msgid ""
+"You need a flash image (in this case called _firmware.bin_). You can get it "
+"via vendor website, flashrom, or other mechanism."
+msgstr ""
+
+#: src/implementation.md:186
+msgid ""
+"The following `utk` command replaces the Shell code section with a Linux "
+"kernel:"
+msgstr ""
+
+#: src/implementation.md:188
+msgid "`utk firmware.bin replace_pe32 Shell bzImage save` _new.bin_"
+msgstr ""
+
+#: src/implementation.md:189
+msgid ""
+"Note: It's always a PE32, even for 64-bit kernels. _new.bin_ is a filename "
+"of your choosing."
+msgstr ""
+
+#: src/implementation.md:191
+msgid "After running `utk`, you can reflash"
+msgstr ""
+
+#: src/implementation.md:193
+msgid "Step 6a: remove as many DXEs as possible"
+msgstr ""
+
+#: src/implementation.md:195
+msgid "You can do an initial mass removal based on your current knowledge"
+msgstr ""
+
+#: src/implementation.md:196
+msgid "`utk` automates removing DXEs: this is the DXE cleaner"
+msgstr ""
+
+#: src/implementation.md:197
+msgid ""
+"`utk` removes a DXE, reflashes, checks if it boots, repeat This part should "
+"be easy: DXE can have a dependency section. In practice, it's hard: because "
+"dependency sections are full of errors and omissions. A lot of UEFI code "
+"does not check for failed DXE loads."
+msgstr ""
+
+#: src/implementation.md:202
+msgid "Step 6b: place your initramfs in me_cleaned region"
+msgstr ""
+
+#: src/implementation.md:204
+msgid ""
+"Run `me_cleaner` and then utk tighten on the source image, then inspect the "
+"image using UEFITool. If successful, there will now be padding at the "
+"beginning of the BIOS region of a substantial size."
+msgstr ""
+
+#: src/implementation.md:207
+msgid ""
+"This padding space can be used, without the filesystem's knowledge, to stash "
+"an initramfs. The kernel is informed of the location this initramfs as an "
+"initrd kernel parameter."
+msgstr ""
+
+#: src/implementation.md:210
+msgid ""
+"Use the base address of this padding region to calculate the offset in the "
+"flash image where the initrd is stashed using dd."
+msgstr ""
+
+#: src/implementation.md:212
+msgid ""
+"Use the address (not base address) as the initramfs location in memory to "
+"pass as a kernel parameter."
+msgstr ""
+
+#: src/implementation.md:215
+msgid "Step 7: replace closed-source with open source"
+msgstr ""
+
+#: src/implementation.md:217
+msgid ""
+"If you can build a DXE from source, you can use `utk` to remove the "
+"proprietary one and replace it with one built from source. You can get DXE "
+"source from the tianocore/EDK2 source repo at github.com. The GitHub repo "
+"has a **_limited_** number of DXEs in source form; i.e., you can't build a "
+"full working image using it."
+msgstr ""
+
+#: src/implementation.md:222
+msgid ""
+"There are scripts that let you compile individual DXEs, including the UEFI "
+"Shell and Boot Device Selection (BDS). These two DXEs have been compiled and "
+"are used in the Atomic Pi. Source-based BDS was needed to ensure the UEFI "
+"Shell was called."
+msgstr ""
+
+#: src/implementation.md:226
+msgid "You only need the UEFI Shell built long enough to replace it with Linux."
+msgstr ""
+
+#: src/implementation.md:228
+msgid "Final step: reflash the image"
+msgstr ""
+
+#: src/implementation.md:230
+msgid ""
+"\"Native\" reflash: Boot the system whatever way is easiest: netboot, usb, "
+"local disk, and run `flashrom -p internal -w _filename.bin_` where "
+"_filename.bin_ is a filename of your choosing."
+msgstr ""
+
+#: src/implementation.md:233
+msgid ""
+"Run `flashrom` with an external device such as an sf100. There may be a "
+"header on the board, or you might have to use a clip. `flashrom -p "
+"dediprog:voltage=1.8 -w _filename.bin_`"
+msgstr ""
+
+#: src/implementation.md:237
+msgid "The voltage option is required for the Atomic Pi."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:3
+msgid ""
+"Points of contact: [Andrea Barberio](https://github.com/insomniacslk), "
+"[David Hendricks](https://github.com/dhendrix)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:7
+msgid ""
+"This chapter describes how to build a LinuxBoot firmware based on coreboot, "
+"u-root and systemboot.  The examples will focus on `x86_64`, and the "
+"coreboot builds will cover virtual and physical OCP hardware."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:11
+msgid "Quick Start with coreboot"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:13
+msgid ""
+"Run these commands in a directory you create or in `/tmp`; do so because it "
+"creates some files and directories:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:22
+msgid ""
+"This produces a coreboot image in coreboot-4.9/build/coreboot.rom You can "
+"now run this ROM image:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:29
+msgid "And see how it looks when you put this in a coreboot ROM image."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:33
+msgid "The final image is built on top of multiple open-source components:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:35
+msgid ""
+"[coreboot](https://coreboot.org), used for the platform initialization. "
+"Silicon and DRAM initialization are done here."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:37
+msgid ""
+"[Linux](https://kernel.org), used to initialize peripherals and various "
+"device drivers like file systems, storage and network devices; network "
+"stack; a multiuser and multitasking environment."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:40
+msgid ""
+"[u-root](https://github.com/u-root/u-root), an user-space environment that "
+"provides basic libraries and utilities to work in a Linux environment."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:42
+msgid ""
+"~~[systemboot](https://systemboot.org), an additional set of libraries and "
+"tools on top of u-root, that provide a bootloader behaviour for various "
+"booting scenarios.~~ systemboot was merged into u-root."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:46
+msgid ""
+"These components are built in reverse order. `u-root` and `systemboot` are "
+"built together in a single step."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:49
+msgid "Building u-root"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:51
+msgid ""
+"The first step is building the initramfs. This is done using the `u-root` "
+"ramfs builder, with additional tools and libraries from `systemboot`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:54
+msgid ""
+"u-root is written in Go. We recommend using a relatively recent version of "
+"the Go toolchain. At the time of writing the latest is 1.11, and we "
+"recommend using at least version 1.10. Previous versions may not be fully "
+"supported."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:58
+msgid ""
+"Adjust your `PATH` to include `${GOPATH}/bin`, in order to find the `u-root` "
+"command that we will use in the next steps."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:61
+msgid "Then, fetch `u-root` and its dependencies:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:67
+msgid ""
+"Then build the ramfs in busybox mode, and add fbnetboot, localboot, and a "
+"custom uinit to wrap everything together:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:74
+msgid ""
+"This command will generate a ramfs named "
+"`/tmp/initramfs_${os}_${arch}.cpio`, e.g. `/tmp/initramfs.linux_amd64.cpio`. "
+"You can specify an alternative output path with `-o`. Run `u-root -h` for "
+"additional command line parameters."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:78
+msgid ""
+"Note: the above command will include only pure-Go commands from `u-root`. If "
+"you need to include other files or non-Go binaries, use the `-file` option "
+"in `u-root`.  For example, you may want to include static builds of `kexec` "
+"or `flashrom`, that we build on https://github.com/systemboot/binaries ."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:83
+msgid ""
+"Then, the initramfs has to be compressed. This step is necessary to embed "
+"the initramfs in the kernel as explained below, in order to maintain the "
+"image size smaller. Linux has a limited XZ compressor, so the compression "
+"requires specific options:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:92
+msgid "which will produce the file `/tmp/initramfs.linux_amd64.cpio.xz`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:94
+msgid ""
+"The kernel compression requirements are documented under "
+"[Documentation/xz.txt](https://www.kernel.org/doc/Documentation/xz.txt) "
+"(last checked 2018-12-03) in the kernel docs."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:98
+msgid "Building a suitable Linux kernel"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:100
+msgid ""
+"A sample config to use with QEMU can be downloaded here: "
+"[linux-4.19.6-linuxboot.config](linux-4.19.6-linuxboot.config)."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:103
+msgid ""
+"You need a relatively recent kernel. Ideally a kernel 4.16, to have support "
+"for VPD variables, but a 4.11 can do the job too, if you don't care about "
+"boot entries and want \"brute-force\" booting only."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:107
+msgid "We will build a kernel with the following properties:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:109
+msgid ""
+"small enough to fit most flash chips, and with some fundamental kernel "
+"features"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:110
+msgid "that can run Go programs (mainly futex and epoll support)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:111
+msgid "with the relevant storage and network stack and drivers"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:112
+msgid "with kexec support, so it can boot a new kernel"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:113
+msgid "with kexec signature verification disabled (optional)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:114
+msgid "with devtmpfs enabled, since we don't use udev"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:115
+msgid "XZ support to decompress the embedded initramfs"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:116
+msgid "VPD (Vital Product Data) (optional)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:117
+msgid "TPM support (optional)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:118
+msgid "embed the u-root initramfs"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:119
+msgid "and last but not least, \"linuxboot\" as default host name :)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:121
+msgid "Download kernel sources"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:123
+msgid ""
+"You can either download a tarball from kernel.org, or get it via git and use "
+"a version tag. We recommend at least a kernel 4.16, in order to have VPD "
+"variables support."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:127
+msgid ""
+"```\n"
+"# download the kernel tarball. Replace 4.19.6` with whatever kernel version "
+"you want\n"
+"wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.6.tar.xz\n"
+"tar xvJf linux-4.19.6.tar.xz\n"
+"cd linux-4.19.6\n"
+"make tinyconfig\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:135
+msgid ""
+"You can also check out the `linux-stable` branch, that will point to the "
+"latest stable commit. You need to download it via `git` as follows:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:138
+msgid ""
+"```\n"
+"git clone --depth 1 -b linux-stable\n"
+"git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git\n"
+"cd linux-stable\n"
+"make tinyconfig\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:145
+msgid ""
+"Some more information about tiny configs can be found at "
+"https://tiny.wiki.kernel.org (last checked 2018-12-01)."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:148
+msgid "A few fundamental features"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:150
+msgid "Assuming we are running on `x86_64`, some basic features to enable are:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:152
+msgid "`64-bit kernel`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:153
+msgid ""
+"`General setup` → `Configure standard kernel features` → `Enable support for "
+"printk`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:155
+msgid ""
+"`General setup` → `Configure standard kernel features` → `Multiple users, "
+"groups and capabilities support` (this is not strictly required on LinuxBoot)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:158
+msgid ""
+"`Processor type and features` → `Built-in kernel command line` (customize "
+"your command line here if needed, e.g. `earlyprintk=serial,ttyS0,57600 "
+"console=ttyS0,57600`)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:161
+msgid ""
+"`Executable file formats / Emulations` → `Kernel support for ELF binaries` "
+"(you may want to enable more formats)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:163
+msgid "`Networking support` → `Networking options` → `TCP/IP networking`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:164
+msgid "`Networking support` → `Networking options` → `The IPv6 protocol`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:165
+msgid "`Device Drivers` → `Character devices` → `Enable TTY`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:166
+msgid ""
+"`Device Drivers` → `Character devices` → `Serial drivers` → `8250/16550 and "
+"compatible serial support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:168
+msgid ""
+"`Device Drivers` → `Character devices` → `Serial drivers` → `Console on "
+"8250/16550 and compatible serial port`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:170
+msgid "`File systems` → `Pseudo filesystems` → `/proc file system support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:171
+msgid "`File systems` → `Pseudo filesystems` → `sysfs file system support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:173
+msgid "Requirements for Go 1.11"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:175
+msgid ""
+"`Go` requires a few kernel features to work properly. At the time of "
+"writing, you need to enable `CONFIG_FUTEX` in your kernel config. Older "
+"versions of Go may require `CONFIG_EPOLL`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:179
+#: src/coreboot.u-root.systemboot/index.md:199
+#: src/coreboot.u-root.systemboot/index.md:232
+#: src/coreboot.u-root.systemboot/index.md:249
+#: src/coreboot.u-root.systemboot/index.md:259
+#: src/coreboot.u-root.systemboot/index.md:274
+#: src/coreboot.u-root.systemboot/index.md:289
+msgid "In menuconfig:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:181
+msgid ""
+"`General setup` → `Configure standard kernel features (expert users)` → "
+"`Enable futex support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:183
+msgid ""
+"`General setup` → `Configure standard kernel features (expert users)` → "
+"`Enable eventpoll support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:186
+msgid ""
+"Additional information about Go's minimum requirements can be found at "
+"https://github.com/golang/go/wiki/MinimumRequirements (last checked "
+"2018-12-01)."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:190
+msgid "Enable devtmpfs"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:192
+msgid ""
+"Our system firmware uses u-root, which does not have (intentionally) an "
+"`udev` equivalent. Therefore, to have `/dev/` automatically populated at "
+"boot time you should enable devtmps."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:196
+msgid ""
+"Simply enable `CONFIG_DEVTMPFS` and `CONFIG_DEVTMPFS_MOUNT` in your kernel "
+"config."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:201
+msgid ""
+"`Device drivers` → `Generic Driver Options` → `Maintain a devtmpfs "
+"filesystem to mount at /dev`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:203
+msgid ""
+"`Device drivers` → `Generic Driver Options` → `Automount devtmpfs at /dev, "
+"after the kernel mounted the rootfs`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:206
+msgid "Additional drivers"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:208
+msgid ""
+"This really depends on your hardware. You may want to add all the relevant "
+"drivers for the platforms you plan to run LinuxBoot on. For example you may "
+"need to include NIC drivers, file system drivers, and any other device that "
+"you need at boot time."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:213
+msgid ""
+"For example, enable SCSI disk, SATA drivers, EXT4, and e1000 NIC driver. In "
+"menuconfig:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:216
+msgid "`Bus options` → `PCI support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:217
+msgid "`Enable the block layer`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:218
+msgid "`Device drivers` → `Block devices` (required for SCSI and SATA)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:219
+msgid "`Device drivers` → `SCSI device support` → `SCSI disk support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:220
+msgid "`Device drivers` → `Serial ATA and Parallel ATA drivers`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:221
+msgid "`File systems` → `The Extended 4 (ext4) filesystem`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:222
+msgid "`Networking support` (required for e1000)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:223
+msgid ""
+"`Device drivers` → `Network device support` → `Ethernet driver support` → "
+"`Intel(R) PRO/1000 Gigabit Ethernet support`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:226
+msgid "Enable XZ kernel and initramfs compression support"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:228
+msgid ""
+"The `u-root`\\-based RAMFS will be compressed with XZ and embedded in the "
+"kernel. Hence you need to enable XZ compression support. Make sure to have "
+"at least `CONFIG_HAVE_KERNEL_XZ`, `CONFIG_KERNEL_XZ`, `CONFIG_DECOMPRESS_XZ`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:234
+msgid "`General setup` → `Kernel compression mode` → `XZ`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:235
+msgid ""
+"`General setup` → `Initial RAM filesystem and RAM disk (initramfs/initrd) "
+"support` → `Support initial ramdisk/ramfs compressed using XZ`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:239
+msgid "Enable VPD"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:241
+msgid ""
+"VPD stands for [Vital Product "
+"Data](https://chromium.googlesource.com/chromiumos/platform/vpd/+/1c1806d8df4bb5976eed71a2e2bf156c36ccdce2/README.md). "
+"We use VPD to store boot configuration for `localboot` and `fbnetboot`, "
+"similarly to UEFI's boot variables. Linux supports VPD out of the box, but "
+"you need at least a kernel 4.16."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:247
+msgid "Make sure to have `CONFIG_GOOGLE_VPD` enabled in your kernel config."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:251
+msgid ""
+"`Firmware drivers` → `Google Firmware Drivers` → `Coreboot Table Access - "
+"ACPI` → `Vital Product Data`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:254
+msgid "TPM support"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:256
+msgid ""
+"This also depends on your needs. If you plan to use TPM, and this is "
+"supported by your platform, make sure to enable `CONFIG_TCG_TPM`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:261
+msgid ""
+"`Device drivers` → `Character devices` → `TPM Hardware Support` → (enable "
+"the relevant drivers)"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:264
+msgid "Include the initramfs"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:266
+msgid ""
+"As mentioned above, the kernel will embed the compressed initramfs image. "
+"Your kernel configuration should point to the appropriate file using the "
+"`CONFIG_INITRAMFS_SOURCE` directive. E.g."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:270
+msgid ""
+"```\n"
+"CONFIG_INITRAMFS_SOURCE=\"/path/to/initramfs_linux.x86_64.cpio.xz\"\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:276
+msgid ""
+"`General setup` → `Initial RAM filesystem and RAM disk (initramfs/initrd) "
+"support` → `Initramfs source file(s)`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:279
+msgid "Default hostname"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:281
+msgid ""
+"We use \"linuxboot\" as the default hostname. You may want to adjust it to a "
+"different value. You need to set `CONFIG_DEFAULT_HOSTNAME` for the purpose. "
+"For example:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:285
+msgid ""
+"```\n"
+"CONFIG_DEFAULT_HOSTNAME=\"linuxboot\"\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:291
+msgid "`General setup` → `Default hostname`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:293
+msgid "Build the kernel"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:295
+msgid "Once your configuration is ready, build the kernel as usual:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:301
+msgid ""
+"The image will be located under `arch/${ARCH}/boot/bzImage` if your "
+"architecture supports bzImage (e.g. x86)."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:304
+msgid ""
+"For more details on how to build a kernel, see "
+"https://kernelnewbies.org/KernelBuild (last checked 2018-12-01)."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:307
+msgid "Building coreboot"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:309
+msgid ""
+"In this step we will build `coreboot` using the Linux kernel image that we "
+"built at the previous step as payload. This build is for a Qemu x86 target, "
+"the process may be somehow different for other platforms."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:313
+msgid "Steps overview:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:315
+msgid "download coreboot from the git repo"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:316
+msgid "build the compiler toolchain"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:317
+msgid "configure coreboot for Qemu, and to use our `bzImage` as payload"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:318
+msgid "build `coreboot.rom`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:320
+msgid "Download coreboot"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:322
+msgid "Our preferred method is to download coreboot from the git repository:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:324
+msgid ""
+"```\n"
+"git clone https://review.coreboot.org/coreboot.git\n"
+"cd coreboot\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:329
+msgid "Build the compiler toolchain"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:331
+msgid ""
+"This step is required to have, among other things, reproducible builds, and "
+"a compiler toolchain that is known to work with coreboot."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:338
+msgid ""
+"The step above may ask you to install a few additional libraries or headers, "
+"do so as requested, with the exception of gcc-gnat, that we won't need."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:341
+msgid "Configure coreboot for Qemu and our payload"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:343
+msgid "Run `make menuconfig` to enter the coreboot configuration menus. Then:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:345
+msgid "Specify the platform we will run on:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:347
+msgid "`Mainboard` → `Mainboard vendor` → `Emulation`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:348
+msgid ""
+"`Mainboard` → `Mainboard Model` → `QEMU x86 q35/ich9 (aka qemu -M q35, since "
+"v1.4)`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:351
+msgid "Specify a large enough flash chip and CBFS size:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:353
+msgid "`Mainboard` → `ROM chip size` → `16 MB`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:354
+msgid "`Mainboard` → `Size of CBFS filesystem in ROM` → `0x1000000`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:356
+msgid "Specify our payload:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:358
+msgid "`Payload` → `Add a payload` → `A Linux payload`"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:359
+msgid "`Payload` → `Linux path and filename` → path to your bzImage"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:361
+msgid "Then save your configuration and exit menuconfig."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:363
+msgid "Build coreboot"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:365
+msgid "This is done with a simple"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:371
+msgid ""
+"The coreboot build system will clone the relevant submodules, if it was not "
+"done already, and will build a coreboot ROM file that will contain the "
+"initialization code, and our bzImage payload. The output file is at "
+"`build/coreboot.rom`."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:375
+msgid ""
+"If everything works correctly you will get an output similar to the "
+"following:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:402
+msgid "Putting everything together"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:406
+msgid "Defining boot entries"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:410
+msgid "Running on a virtual machine"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:412
+msgid ""
+"The image built with the above steps can run on a QEMU virtual machine, "
+"using the machine type `q35`, as specified in the coreboot mainboard "
+"section. Assuming that your coreboot image is located at "
+"`build/coreboot.rom`, you can run the following command:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:428
+msgid ""
+"If everything has been done correctly you should see, in order, the output "
+"from `coreboot`, `linux`, `u-root`, and `systemboot`. You can press `ctrl-c` "
+"when Systemboot instructs you to do so, to enter the `u-root` shell."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:432
+msgid "Running on real OCP hardware"
+msgstr ""
+
+#: src/glossary.md:3
+msgid ""
+"_**BIOS**_: Originally, BIOS was the software built into computers to send "
+"simple instructions to the hardware, allowing input and output before the "
+"operating system was loaded. It was a binary blob with no standardized "
+"structure that was responsible for initializing CPU and memory, and jumping "
+"to a hard-coded position on the master block of the first disk drive. BIOS "
+"has been largely replaced by UEFI. Many UEFI implementations still offer a "
+"\"BIOS compatibility mode\" which makes it behave like an old BIOS, with its "
+"features."
+msgstr ""
+
+#: src/glossary.md:11
+msgid ""
+"_**busybox**_: Busybox is a single user-space binary which includes versions "
+"of a large number of system commands, including a shell. This package can be "
+"very useful for recovering from certain types of system failures, "
+"particularly those involving broken shared libraries. There are multiple "
+"implementations of busybox, such as git.busybox.net/busybox and "
+"github.com/u-root/u-root."
+msgstr ""
+
+#: src/glossary.md:17
+msgid ""
+"[_**coreboot**_](https://doc.coreboot.org/): A project to develop open "
+"source boot firmware for various architectures. Its design philosophy is to "
+"do the bare minimum necessary to ensure that hardware is usable and then "
+"pass control to a different program called the payload. The payload can then "
+"provide user interfaces, file system drivers, various policies etc. to load "
+"the OS."
+msgstr ""
+
+#: src/glossary.md:23
+msgid ""
+"_**DHCP**_: A networking protocol that runs on a DHCP server and that "
+"automatically assigns an IP address from a pre-configured pool to any "
+"machine that queries it on boot up."
+msgstr ""
+
+#: src/glossary.md:26
+msgid ""
+"[_**EDK II**_](https://github.com/tianocore/edk2): An open source reference "
+"implementation of an UEFI-compliant firmware, originally developed by Intel"
+msgstr ""
+
+#: src/glossary.md:28
+msgid ""
+"_**firmware**_: A specific class of computer software that provides "
+"low-level control for a device's specific hardware. It is installed at the "
+"time of manufacturing and is the first program that runs when a computer is "
+"turned on. It checks to see what hardware components the computing device "
+"has, wakes the components up, and hands them over to the operating system "
+"that is to be installed on the machine. The current x86 firmware is based on "
+"Intel’s Universal Extensible Firmware Interface (UEFI)."
+msgstr ""
+
+#: src/glossary.md:35
+msgid ""
+"_**flashkernel**_: A small Linux kernel that is stored in flash and used as "
+"a boot stage (e.g. the kernel used in LinuxBoot). Debian and Ubuntu maintain "
+"a `flash-kernel` script to install the kernel and initramfs in a special "
+"location for embedded devices that can not boot the kernel and initramfs "
+"using the normal `/boot` mechanism"
+msgstr ""
+
+#: src/glossary.md:40
+msgid ""
+"[_**Heads**_](https://github.com/linuxboot/heads): An open source firmware "
+"for laptops and servers, aimed at strong platform security. Developed by "
+"Trammell Hudson, based on stripped UEFI plus Linux, and BusyBox instead of "
+"u-root."
+msgstr ""
+
+#: src/glossary.md:44
+msgid ""
+"_**iSCSI**_: A protocol that provides a way to make network-attached storage "
+"appear to be a local device to the hosts using it, allowing it to be (among "
+"other things) mounted as a regular local file system."
+msgstr ""
+
+#: src/glossary.md:47
+msgid ""
+"_**kexec**_: A system call that enables you to load and boot into another "
+"kernel from the currently running kernel. kexec performs the function of the "
+"boot loader from within the kernel."
+msgstr ""
+
+#: src/glossary.md:50
+msgid ""
+"_**LinuxBIOS**_: A project originated in 1999 from Ron Minnich, Stefan "
+"Reinauer and others. It was an experiment in the idea of running Linux as "
+"firmware. At that time Linux was not mature enough for a hardware "
+"initialization project, and while LinuxBIOS was successful in several "
+"performance-and-reliability critical environments, it didn't see mass "
+"adoption. It later became coreboot."
+msgstr ""
+
+#: src/glossary.md:56
+msgid ""
+"_**LinuxBoot**_: LinuxBoot is not a product, but rather a concept. It's the "
+"idea of booting Linux (OS) with Linux (system firmware). In a way, the same "
+"concept pioneered by LinuxBIOS. It is like a Linux distribution, but for "
+"firmware. It is a collection of various open source components, combined to "
+"work as a consistent firmware OS."
+msgstr ""
+
+#: src/glossary.md:61
+msgid ""
+"_**NERF**_: The original name for the LinuxBoot project composed of stripped "
+"UEFI plus Linux plus u-root. The name stands for Non-Extensible Reduced "
+"Firmware, as opposed to UEFI's Unified Extensible Firmware Interface. NERF "
+"is an UEFI replacement that is more compact and less extensible. While "
+"extensibility is nice and often desirable, too much extensibility can make a "
+"complex project very hard to maintain and keep secure."
+msgstr ""
+
+#: src/glossary.md:67
+msgid ""
+"_**Open Source Firmware**_: OSF can be used to refer to Open Source Firmware "
+"or Open System Firmware depending on the context."
+msgstr ""
+
+#: src/glossary.md:69
+msgid ""
+"_**Open System Firmware (OSF)**_: An official subproject of the Open Compute "
+"Project (OCP). OSF has been developed in the open, by various members of OCP "
+"that were interested in having open source system firmware. OSF defines a "
+"set of guidelines with contributions from Microsoft, Google, Facebook, "
+"Intel, 9elements, TwoSigma, and several other companies."
+msgstr ""
+
+#: src/glossary.md:74
+msgid ""
+"_**OVMF**_: Open Virtual Machine Firmware. Open Virtual Machine Firmware is "
+"a build of EDK II for virtual machines. It includes full support for UEFI, "
+"including Secure Boot, allowing use of UEFI in place of a traditional BIOS "
+"in your EFI Initialization (PEI)|UEFI stage which runs before RAM is "
+"initialized, from cache and ROM. PEI is mostly C-code running in 32-bit "
+"protected flat mode.  The main goal of the PEI stage is to detect RAM. As "
+"soon as RAM is detected and configured, PEI stage give control to the DXE "
+"through DXE Initial Program Load (IPL) driver"
+msgstr ""
+
+#: src/glossary.md:82
+msgid ""
+"_**production kernel**_: LinuxBoot is not intended to be a runtime "
+"production kernel; rather, it is meant to replace specific UEFI "
+"functionality using Linux kernel capabilities and then boot the actual "
+"production kernel (prodkernel) on the machine. Kernel configuration files "
+"specific to LinuxBoot provide the needed Linux kernel capabilities without "
+"bloating the size of the BIOS with unnecessary drivers."
+msgstr ""
+
+#: src/glossary.md:88
+msgid ""
+"_**PureBoot**_: A combination of disabling IME, coreboot, a TPM, Heads and "
+"the Librem Key (see [Trusted Boot (Anti-Evil-Maid, Heads, and "
+"PureBoot)](https://tech.michaelaltfield.net/2023/02/16/evil-maid-heads-pureboot/#pureboot))"
+msgstr ""
+
+#: src/glossary.md:91
+msgid ""
+"_**QEMU**_: An emulator that performs hardware virtualization. QEMU is a "
+"hosted virtual machine monitor."
+msgstr ""
+
+#: src/glossary.md:93
+msgid ""
+"_**Secure Boot Preverifier (SEC)**_: In UEFI, the SEC stage initializes the "
+"CPU cache-as-RAM (CAR) and gives control to the PEI dispatcher. It is 99.9% "
+"assembly code (32-bit protected mode)."
+msgstr ""
+
+#: src/glossary.md:96
+msgid ""
+"_**u-boot**_: A very popular open source firmware and bootloader. Not to be "
+"confused with u-root."
+msgstr ""
+
+#: src/glossary.md:98
+msgid ""
+"_**u-root**_: A modern, embedded user-space environment for Linux, with "
+"bootloader tools. See the section on u-root."
+msgstr ""
+
+#: src/glossary.md:100
+msgid ""
+"_**UEFI**_: Unified Extensible Firmware Interface. It is Intel’s "
+"specification of a standard for system firmware. UEFI defines everything "
+"from the layout on the flash chip, to how to interface to peripherals, "
+"enables boot from disk or from a network, defines how UEFI applications "
+"work, etc). It is not an implementation, it's a standard. EDK II and OpenEDK "
+"II are UEFI implementations. UEFI is not closed source per-se, but in "
+"practice most implementations are."
+msgstr ""
+
+#: src/history.md:5
+msgid ""
+"[BIOS](https://en.wikipedia.org/wiki/BIOS) is the good old, inscrutable way "
+"of initializing a hardware platform in the pre-UEFI days. It's a binary blob "
+"with no standardized structure, that is responsible for initializing CPU and "
+"memory, and jumping to a hard-coded position on the MBR of the first disk "
+"drive."
+msgstr ""
+
+#: src/history.md:10
+msgid ""
+"Starting around 2000, BIOS has been largely replaced by the standardized "
+"[UEFI](https://en.wikipedia.org/wiki/UEFI). Many UEFI implementations still "
+"offer a BIOS compatibility mode called CSM (Compatibility Support Module), "
+"which makes it behave like an old BIOS."
+msgstr ""
+
+#: src/history.md:15
+msgid ""
+"Note that the term \"BIOS\" is sometimes misused to refer to the general "
+"concept of _system firmware_, such as UEFI or even LinuxBoot. However, as "
+"\"BIOS\" refers to firmware with specific functionality, UEFI is definitely "
+"_not_ a BIOS, nor is LinuxBoot a BIOS in the original sense."
+msgstr ""
+
+#: src/history.md:20
+msgid "LinuxBIOS"
+msgstr ""
+
+#: src/history.md:22
+msgid ""
+"The "
+"[LinuxBIOS](https://web.archive.org/web/20070430170020/http://www.linuxbios.org/Welcome_to_LinuxBIOS) "
+"project was created in 1999 by Ron Minnich, Stefan Reinauer and others. It "
+"is not much younger than UEFI, but they were already experimenting the idea "
+"of running Linux as firmware. Like many great ideas, it was way ahead of its "
+"time. At that time Linux was not mature enough to be used in a hardware "
+"initialization project, and while LinuxBIOS was successful in several "
+"performance-and-reliability critical environments, it didn't see mass "
+"adoption."
+msgstr ""
+
+#: src/history.md:31
+msgid "In 2008 LinuxBIOS became [coreboot](https://www.coreboot.org/)."
+msgstr ""
+
+#: src/history.md:33
+msgid "LinuxBoot"
+msgstr ""
+
+#: src/history.md:35
+msgid "NERF"
+msgstr ""
+
+#: src/history.md:37
+msgid ""
+"This is the original name for the stripped UEFI, plus Linux, plus u-root. "
+"The name stands for Non-Extensible Reduced Firmware, as opposed to UEFI's "
+"Unified Extensible Firmware Interface. Basically, saying that NERF is an "
+"UEFI replacement that prefers to be more compact, less extensible, and a bit "
+"more opinionated. While extensibility is nice and often desirable, too much "
+"extensibility and too many \"yes\" can make a complex project very hard to "
+"maintain and keep secure."
+msgstr ""
+
+#: src/history.md:45
+msgid ""
+"NERF was created by Ron Minnich while at Google in 2017. The project grew "
+"and was maintained by Google's \"NERF team\"."
+msgstr ""
+
+#: src/history.md:48
+msgid ""
+"NERF eventually became the "
+"[linuxboot](https://github.com/linuxboot/linuxboot/) build system."
+msgstr ""
+
+#: src/history.md:53
+msgid ""
+"[Heads](https://github.com/linuxboot/heads) is an open source firmware for "
+"laptops and servers created by  Trammell Hudson (a.k.a. osreasrch), aimed at "
+"strong platform security. It is currently maintained by Thierry Laurion."
+msgstr ""
+
+#: src/history.md:57
+msgid "See also"
+msgstr ""
+
+#: src/history.md:59
+msgid "[osresearch.net](https://osresearch.net/)"
+msgstr ""
+
+#: src/history.md:60
+msgid "[trmm.net/NERF](https://trmm.net/NERF/)"
+msgstr ""
+
+#: src/history.md:61
+msgid ""
+"[NERF-Projekt statt "
+"UEFI](https://www.golem.de/news/freie-linux-firmware-google-will-server-ohne-intel-me-und-uefi-1710-130840-2.html)"
+msgstr ""
+
+#: src/history.md:62
+msgid ""
+"[Bringing Linux back to the Server BIOS with "
+"LinuxBoot](https://www.twosigma.com/articles/bringing-linux-back-to-the-server-bios-with-linuxboot/)"
+msgstr ""
+
+#: src/history.md:63
+msgid ""
+"[LinuxBoot: A Fast, Reliable Open Source Firmware for Linux "
+"Servers](https://www.twosigma.com/articles/linuxboot-a-fast-reliable-open-source-firmware-for-linux-servers/)"
+msgstr ""
+
+#: src/history.md:64
+msgid ""
+"[safeboot: Improving the Safety of Booting Linux on Normal "
+"Laptops](https://www.twosigma.com/articles/safeboot-improving-the-safety-of-booting-linux-on-normal-laptops/)"
+msgstr ""
+
+#: src/history.md:66
+msgid "Open Platform Firmware"
+msgstr ""
+
+#: src/history.md:68
+msgid ""
+"[Open Platform "
+"Firmware](https://www.opencompute.org/projects/open-system-firmware) (OPF), "
+"formerly Open System Firmware (OSF), is an official subproject of the [Open "
+"Compute Project](https://www.opencompute.org) (OCP). OPF has been developed "
+"in the open, by various members of OCP that were interested in having open "
+"source system firmware. OPF defines a set of guidelines with contributions "
+"from Microsoft, Google, Facebook, Intel, 9elements, Two Sigma, and several "
+"other companies."
+msgstr ""
+
+#: src/history.md:77
+msgid ""
+"The important thing to keep in mind is that **Open Platform Firmware is a "
+"project name**, not an implementation, nor an idea. An implementation (like "
+"LinuxBoot or OpenEDK2) can be OPF-compliant if it follows the aforementioned "
+"guidelines."
+msgstr ""
+
+#: src/history.md:81
+msgid "Currently, Open Platform Firmware has two work streams:"
+msgstr ""
+
+#: src/history.md:83
+msgid ""
+"LinuxBoot, led by Google, Facebook, 9elements, ITRenew, TwoSigma, and others"
+msgstr ""
+
+#: src/history.md:84
+msgid "OpenEDK II, led by Microsoft and Intel"
+msgstr ""
+
+#: src/case_studies/index.md:3
+msgid "This chapter contains case studies for various solutions."
+msgstr ""
+
+#: src/case_studies/index.md:5
+msgid "Table of Contents"
+msgstr ""
+
+#: src/case_studies/index.md:7
+msgid "[Ampere study](Ampere_study.md)"
+msgstr ""
+
+#: src/case_studies/index.md:8
+msgid "[Google study](Google_study.md)"
+msgstr ""
+
+#: src/case_studies/index.md:9
+msgid "[OCP TiogaPass](TiogaPass.md)"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:1
+msgid "LinuxBoot on Ampere Mt. Jade Platform"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:3
+msgid ""
+"The Ampere Altra Family processor based Mt. Jade platform is a "
+"high-performance ARM server platform, offering up to 256 processor cores in "
+"a dual socket configuration. The Tianocore EDK2 firmware for the Mt. Jade "
+"platform has been fully upstreamed to the tianocore/edk2-platforms "
+"repository, enabling the community to build and experiment with the "
+"platform's firmware using entirely open-source code. It also supports "
+"LinuxBoot, an open-source firmware framework that reduces boot time, "
+"enhances security, and increases flexibility compared to standard UEFI "
+"firmware."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:12
+msgid ""
+"Mt. Jade has also achieved a significant milestone by becoming [the first "
+"server certified under the Arm SystemReady LS certification "
+"program](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-systemready-ls). "
+"SystemReady LS ensures compliance with standardized boot and runtime "
+"environments for Linux-based systems, enabling seamless deployment across "
+"diverse hardware.  This certification further emphasizes Mt. Jade's "
+"readiness for enterprise and cloud-scale adoption by providing assurance of "
+"compatibility, performance, and reliability."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:21
+msgid ""
+"This case study explores the LinuxBoot implementation on the Ampere Mt. Jade "
+"platform, inspired by the approach used in [Google's LinuxBoot "
+"deployment](Google_study.md)."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:25
+msgid "Ampere EDK2-LinuxBoot Components"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:27
+msgid ""
+"The Mt. Jade platform embraces a hybrid firmware architecture, combining "
+"UEFI/EDK2 for hardware initialization and LinuxBoot for advanced boot "
+"functionalities. The platform aligns closely with step 6 in the LinuxBoot "
+"adoption model."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:34
+msgid ""
+"The entire boot firmware stack for the Mt. Jade is open source and available "
+"in the Github."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:37
+msgid ""
+"**EDK2**: The PEI and minimal (stripped-down) DXE drivers, including both "
+"common and platform code, are fully open source and resides in Tianocore "
+"edk2-platforms and edk2 repositories."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:40
+msgid ""
+"**LinuxBoot**: The LinuxBoot binary ([flashkernel](../glossary.md)) for Mt. "
+"Jade is supported in the "
+"[linuxboot/linuxboot](https://github.com/linuxboot/linuxboot/tree/main/mainboards/ampere/jade) "
+"repository."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:45
+msgid "Ampere Solution for LinuxBoot as a Boot Device Selection"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:47
+msgid ""
+"Ampere has implemented and successfully upstreamed a solution for "
+"integrating LinuxBoot as a Boot Device Selection (BDS) option into the "
+"TianoCore EDK2 framework, as seen in commit [ArmPkg: Implement "
+"PlatformBootManagerLib for "
+"LinuxBoot](https://github.com/tianocore/edk2/commit/62540372230ecb5318a9c8a40580a14beeb9ded0). "
+"This innovation simplifies the boot process for the Mt. Jade platform and "
+"aligns with LinuxBoot's goals of efficiency and flexibility."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:55
+msgid ""
+"Unlike the earlier practice that replaced the UEFI Shell with a LinuxBoot "
+"flashkernel, Ampere's solution introduces a custom BDS implementation that "
+"directly boots into the LinuxBoot environment as the active boot option. "
+"This approach bypasses the need to load the UEFI Shell or UiApp (UEFI Setup "
+"Menu), which depend on numerous unnecessary DXE drivers."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:61
+msgid ""
+"To further enhance flexibility, Ampere introduced a new GUID specifically "
+"for the LinuxBoot binary, ensuring clear separation from the UEFI Shell "
+"GUID. This distinction allows precise identification of LinuxBoot components "
+"in the firmware."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:66
+msgid "Build Process"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:68
+msgid ""
+"Building a flashable EDK2 firmware image with an integrated LinuxBoot "
+"flashkernel for the Ampere Mt. Jade platform involves two main steps: "
+"building the LinuxBoot flashkernel and integrating it into the EDK2 firmware "
+"build."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:72
+msgid "Step 1: Build the LinuxBoot Flashkernel"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:74
+msgid "The LinuxBoot flash kernel is built as follows:"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:81
+msgid ""
+"After the build process completes, the flash kernel will be located at: "
+"linuxboot/mainboards/ampere/jade/flashkernel"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:84
+msgid "Step 2: Build the EDK2 Firmware Image with the Flash Kernel"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:86
+msgid ""
+"The EDK2 firmware image is built with the LinuxBoot flashkernel integrated "
+"into the flash image using the following steps:"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:96
+msgid ""
+"The `buildfw.sh` script automatically integrates the LinuxBoot flash kernel "
+"(provided via the -l option) as part of the final EDK2 firmware image."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:99
+msgid ""
+"This process generates a flashable EDK2 firmware image with embedded "
+"LinuxBoot, ready for deployment on the Ampere Mt. Jade platform."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:102
+msgid "Booting with LinuxBoot"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:104
+msgid ""
+"When powered on, the system will boot into the u-root and automatically "
+"kexec to the target OS."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:107
+msgid ""
+"```text\n"
+"Run /init as init process\n"
+"1970/01/01 00:00:10 Welcome to u-root!\n"
+"                              _\n"
+"   _   _      _ __ ___   ___ | |_\n"
+"  | | | |____| '__/ _ \\ / _ \\| __|\n"
+"  | |_| |____| | | (_) | (_) | |_\n"
+"   \\__,_|    |_|  \\___/ \\___/ \\__|\n"
+"\n"
+"cgroup: Unknown subsys name 'perf_event'\n"
+"init: 1970/01/01 00:00:10 Deprecation warning: use UROOT_NOHWRNG=1 on kernel "
+"cmdline instead of uroot.nohwrng\n"
+"1970/01/01 00:00:10 Booting from the following block devices: "
+"[BlockDevice(name=nvme0n1, fs_uuid=) BlockDevice(name=nvme0n1p1, "
+"fs_uuid=d6c6-6306) BlockDevice(name=nvme0n1p2, "
+"fs_uuid=63402158-6266-48fb-b602-5f83f26bd0b9) BlockDevice(name=nvme0n1p3, "
+"fs_uuid=) BlockDevice(name=nvme1n1, fs_uuid=) BlockDevice(name=nvme1n1p1, "
+"fs_uuid=525c-92fb)]\n"
+"1970/01/01 00:00:10 [grub] Got config file "
+"file:///tmp/u-root-mounts3457412855/nvme0n1p1/EFI/ubuntu/grub.cfg:\n"
+"search.fs_uuid 63402158-6266-48fb-b602-5f83f26bd0b9 root\n"
+"set prefix=($root)'/grub'\n"
+"configfile $prefix/grub.cfg\n"
+"\n"
+"1970/01/01 00:00:10 Warning: Grub parser could not parse [\"search\" "
+"\"--fs-uuid\" \"63402158-6266-48fb-b602-5f83f26bd0b9\" \"root\"]\n"
+"1970/01/01 00:00:10 [grub] Got config file "
+"file:///tmp/u-root-mounts3457412855/nvme0n1p2/grub/grub.cfg\n"
+"1970/01/01 00:00:10 Error: Expected 1 device with UUID "
+"\"1334d6c5-c16f-46ba-9120-5127ae43bf63\", found 0\n"
+"1970/01/01 00:00:10 Error: Expected 1 device with UUID "
+"\"1334d6c5-c16f-46ba-9120-5127ae43bf63\", found 0\n"
+"\n"
+"\n"
+"Welcome to LinuxBoot's Menu\n"
+"\n"
+"Enter a number to boot a kernel:\n"
+"\n"
+"1.  Ubuntu\n"
+"\n"
+"2.  Ubuntu, with Linux 6.8.0-49-generic\n"
+"\n"
+"3.  Ubuntu, with Linux 6.8.0-49-generic (recovery mode)\n"
+"\n"
+"4.  Ubuntu, with Linux 6.8.0-48-generic\n"
+"\n"
+"5.  Ubuntu, with Linux 6.8.0-48-generic (recovery mode)\n"
+"\n"
+"6.  Reboot\n"
+"\n"
+"7.  Enter a LinuxBoot shell\n"
+"\n"
+"\n"
+"Enter an option ('01' is the default, 'e' to edit kernel cmdline):\n"
+" > 07\n"
+"\n"
+"> dmidecode -t 4\n"
+"# dmidecode-go\n"
+"Reading SMBIOS/DMI data from sysfs.\n"
+"SMBIOS 3.3.0 present.\n"
+"\n"
+"Handle 0x0003, DMI type 4, 51 bytes\n"
+"Processor Information\n"
+"        Socket Designation: CPU01\n"
+"        Type: Central Processor\n"
+"        Family: ARMv8\n"
+"        Manufacturer: Ampere(R)\n"
+"        ID: 01 00 16 0A A1 00 00 00\n"
+"        Signature: Implementor 0x0a, Variant 0x1, Architecture 6, Part "
+"0x000, Revision 1\n"
+"        Version: Ampere(R) Altra(R) Processor\n"
+"        Voltage: 1.0 V\n"
+"        External Clock: 25 MHz\n"
+"        Max Speed: 3000 MHz\n"
+"        Current Speed: 3000 MHz\n"
+"        Status: Populated, Enabled\n"
+"        Upgrade: Unknown\n"
+"        L1 Cache Handle: 0x0001\n"
+"        L2 Cache Handle: 0x0002\n"
+"        L3 Cache Handle: Not Provided\n"
+"        Serial Number: 000000000000000002550904033865B4\n"
+"        Asset Tag: Not Set\n"
+"        Part Number: Q80-30\n"
+"        Core Count: 80\n"
+"        Core Enabled: 80\n"
+"        Thread Count: 80\n"
+"        Characteristics:\n"
+"                64-bit capable\n"
+"                Multi-Core\n"
+"                Execute Protection\n"
+"                Enhanced Virtualization\n"
+"                Power/Performance Control\n"
+"\n"
+"Handle 0x0007, DMI type 4, 51 bytes\n"
+"Processor Information\n"
+"        Socket Designation: CPU02\n"
+"        Type: Central Processor\n"
+"        Family: ARMv8\n"
+"        Manufacturer: Ampere(R)\n"
+"        ID: 01 00 16 0A A1 00 00 00\n"
+"        Signature: Implementor 0x0a, Variant 0x1, Architecture 6, Part "
+"0x000, Revision 1\n"
+"        Version: Ampere(R) Altra(R) Processor\n"
+"        Voltage: 1.0 V\n"
+"        External Clock: 25 MHz\n"
+"        Max Speed: 3000 MHz\n"
+"        Current Speed: 3000 MHz\n"
+"        Status: Populated, Enabled\n"
+"        Upgrade: Unknown\n"
+"        L1 Cache Handle: 0x0005\n"
+"        L2 Cache Handle: 0x0006\n"
+"        L3 Cache Handle: Not Provided\n"
+"        Serial Number: 000000000000000002560909033865B4\n"
+"        Asset Tag: Not Set\n"
+"        Part Number: Q80-30\n"
+"        Core Count: 80\n"
+"        Core Enabled: 80\n"
+"        Thread Count: 80\n"
+"        Characteristics:\n"
+"                64-bit capable\n"
+"                Multi-Core\n"
+"                Execute Protection\n"
+"                Enhanced Virtualization\n"
+"                Power/Performance Control\n"
+"\n"
+">\n"
+"M-? toggle key help • C-d erase/stop • C-c clear/cancel • C-r search hist …\n"
+"```"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:223
+msgid "Future Work"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:225
+msgid ""
+"While the LinuxBoot implementation on the Ampere Mt. Jade platform "
+"represents a significant milestone, several advanced features and "
+"improvements remain to be explored. These enhancements would extend the "
+"platform's capabilities, improve its usability, and reinforce its position "
+"as a leading open source firmware solution. Key areas for future development "
+"include:"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:231
+msgid "Secure Boot with LinuxBoot"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:233
+msgid ""
+"One of the critical areas for future development is enabling secure boot "
+"verification for the target operating system. In the LinuxBoot environment, "
+"the target OS is typically booted using kexec. However, it is unclear how "
+"Secure Boot operates in this context, as kexec bypasses traditional "
+"firmware-controlled secure boot mechanisms. Future work should investigate "
+"how to extend Secure Boot principles to kexec, ensuring that the OS kernel "
+"and its components are verified and authenticated before execution. This may "
+"involve implementing signature checks and utilizing trusted certificate "
+"chains directly within the LinuxBoot environment to mimic the functionality "
+"of UEFI Secure Boot during the kexec process."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:244
+msgid "TPM Support"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:246
+msgid ""
+"The platform supports TPM, but its integration with LinuxBoot is yet to be "
+"defined. Future work could explore utilizing the TPM for secure boot "
+"measurements, and system integrity attestation."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:250
+msgid "Expanding Support for Additional Ampere Platforms"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:252
+msgid ""
+"Building on the success of LinuxBoot on Mt. Jade, future efforts should "
+"expand support to other Ampere platforms.  This would ensure broader "
+"adoption and usability across different hardware configurations."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:256
+msgid "Optimizing the Transition Between UEFI and LinuxBoot"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:258
+msgid ""
+"Improving the efficiency of the handoff between UEFI and LinuxBoot could "
+"further reduce boot times.  This optimization would involve refining the "
+"initialization process and minimizing redundant operations during the "
+"handoff."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:262
+msgid "Advanced Diagnostics and Monitoring Tools"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:264
+msgid ""
+"Adding more diagnostic and monitoring tools to the LinuxBoot u-root "
+"environment would enhance debugging and system management.  These tools "
+"could provide deeper insights into system performance and potential issues, "
+"improving reliability and maintainability."
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:269
+msgid "See Also"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:271
+msgid ""
+"[LinuxBoot on Ampere Platforms: A new (old) approach to "
+"firmware](https://amperecomputing.com/blogs/linuxboot-on-ampere-platforms--a-new-old-approach-to-firmware)"
+msgstr ""
+
+#: src/case_studies/Google_study.md:1
+msgid "The LinuxBoot project at Google"
+msgstr ""
+
+#: src/case_studies/Google_study.md:3
+msgid ""
+"Google runs workloads across a number of clusters each with up to tens of "
+"thousands of machines. Firmware runs on these machines when they first start "
+"up. Google is pushing the state-of-the-art in many places including "
+"firmware. The discussion here about Google's implementation of LinuxBoot is "
+"limited to replacing specific UEFI [firmware](../glossary.md) functionality "
+"with a Linux kernel and runtime. Over the years this project has grown to "
+"include various initiatives with the overarching goal of moving from "
+"obscure, complex firmware to simpler, open source firmware."
+msgstr ""
+
+#: src/case_studies/Google_study.md:12
+msgid "Team"
+msgstr ""
+
+#: src/case_studies/Google_study.md:14
+msgid ""
+"There have been a number of contributors to the Google LinuxBoot project "
+"including:"
+msgstr ""
+
+#: src/case_studies/Google_study.md:17
+msgid "Ron Minnich (technical lead)"
+msgstr ""
+
+#: src/case_studies/Google_study.md:18
+msgid "Gan-shun Lim"
+msgstr ""
+
+#: src/case_studies/Google_study.md:19
+msgid "Ryan O'Leary"
+msgstr ""
+
+#: src/case_studies/Google_study.md:20
+msgid "Prachi Laud"
+msgstr ""
+
+#: src/case_studies/Google_study.md:21
+msgid "Chris Koch"
+msgstr ""
+
+#: src/case_studies/Google_study.md:22
+msgid "Xuan Chen"
+msgstr ""
+
+#: src/case_studies/Google_study.md:23
+msgid "Andrew Sun"
+msgstr ""
+
+#: src/case_studies/Google_study.md:25
+msgid ""
+"Ryan O'Leary is one of the Open Compute Platform Foundation [Open System "
+"Firmware project](https://www.opencompute.org/projects/open-system-firmware) "
+"volunteer leads and Ron Minnich is the Open Compute Platform Foundation "
+"Incubation Committee Representative."
+msgstr ""
+
+#: src/case_studies/Google_study.md:30
+msgid "Goal"
+msgstr ""
+
+#: src/case_studies/Google_study.md:32
+msgid ""
+"The primary goal of Google's LinuxBoot is to modernize the firmware by "
+"simplifying it to technologies engineers understand and trust. In UEFI "
+"systems, LinuxBoot consists of a \"full stack\" solution of stripped-down "
+"UEFI firmware, a Linux kernel, and an initramfs with tools written in Go. "
+"Although these components all make up one bundle stored in ROM, there are "
+"three parts: the closed-source EFI firmware, a Linux kernel, and "
+"[u-root](../u-root.md). The Linux kernel is an unmodified kernel.  The "
+"user-space initramfs image with Go tools for system booting is available as "
+"u-root. Due to this modularity, LinuxBoot can be used with a variety of "
+"systems. In many cases, for example, the same kernel and initramfs have been "
+"used, without recompilation, on both AMD and Intel x86 boards. The UEFI on "
+"these boards is always specific to the board, however."
+msgstr ""
+
+#: src/case_studies/Google_study.md:46
+msgid "Converting a UEFI firmware image to use LinuxBoot"
+msgstr ""
+
+#: src/case_studies/Google_study.md:48
+msgid ""
+"The conversion to LinuxBoot starts with generic UEFI. A UEFI computer boots "
+"in four main phases. The security phase (SEC) and the Pre-EFI Initialization "
+"Stage (PEI) are responsible for low-level operations to prepare the hardware "
+"and are usually specific to the hardware they are implemented for. After "
+"these two stages, the Driver Execution Environment (DXE) loads various "
+"drivers, and then the Boot Device Select (BDS) phase begins."
+msgstr ""
+
+#: src/case_studies/Google_study.md:56
+msgid ""
+"It is not possible to modify the SEC and PEI stages, as their components are "
+"tightly coupled to the chips on the board; even small changes to the chips "
+"require new SEC and PEI stages. LinuxBoot starts during the DXE stage, "
+"resulting in most of the drivers (and their associated attack surface) not "
+"being loaded. Instead, a Linux kernel is loaded as if it were a driver. By "
+"loading during the DXE, LinuxBoot runs after the first two stages of the "
+"UEFI, but takes over after that point, replacing the UEFI drivers. It "
+"therefore completely replaces a large portion of the boot process."
+msgstr ""
+
+#: src/case_studies/Google_study.md:67
+msgid "Phases of the project"
+msgstr ""
+
+#: src/case_studies/Google_study.md:69
+msgid ""
+"Google's LinuxBoot project is focused on moving UEFI boot functionality into "
+"the kernel and user-space. That is, converting UEFI firmware to run "
+"LinuxBoot. The project has taken the standard UEFI boot process and "
+"converted it to LinuxBoot for production environments. The steps to reach "
+"this goal are described below."
+msgstr ""
+
+#: src/case_studies/Google_study.md:75
+msgid "Step 1. Reduce or replace UEFI components"
+msgstr ""
+
+#: src/case_studies/Google_study.md:77
+msgid ""
+"UEFI contains proprietary, closed-source, vendor-supplied firmware drivers "
+"and firmware. LinuxBoot replaces many Driver Execution Environment (DXE) "
+"modules used by UEFI and other firmware, particularly the network stack and "
+"file system modules, with Linux applications."
+msgstr ""
+
+#: src/case_studies/Google_study.md:83
+msgid ""
+"The following diagram shows the phases of the UEFI boot process. The items "
+"in <span style=\"color:red\">red</span> are components that are either "
+"reduced or eliminated with LinuxBoot. The <span style=\"color:blue\">dark "
+"blue</span> items on the left cannot be changed."
+msgstr ""
+
+#: src/case_studies/Google_study.md:91
+msgid ""
+"In the real FLASH part, the SEC and PEI are actually only 10% of total, so "
+"we reduce the size of those boxes in this and following diagrams."
+msgstr ""
+
+#: src/case_studies/Google_study.md:96
+msgid ""
+"Another part of the conversion process was to modify the UEFI boot process "
+"to boot a LinuxBoot image as shown below."
+msgstr ""
+
+#: src/case_studies/Google_study.md:101
+msgid ""
+"Step 2. Delete or replace as many proprietary DXEs as required to make step "
+"3 work. In most cases, none need to be removed."
+msgstr ""
+
+#: src/case_studies/Google_study.md:106
+msgid "Step 3. Replace the UEFI shell with a Linux kernel + u-root"
+msgstr ""
+
+#: src/case_studies/Google_study.md:110
+msgid ""
+"When Linux boots it needs a root file system with utilities. LinuxBoot "
+"provides a file system based on u-root standard utilities written in Go."
+msgstr ""
+
+#: src/case_studies/Google_study.md:114
+msgid ""
+"Step 4. Through trial and error, continue to remove DXEs until you can't "
+"remove anymore."
+msgstr ""
+
+#: src/case_studies/Google_study.md:117
+msgid ""
+"The DXEs are delivered as binary blobs. There are three ways to handle them:"
+msgstr ""
+
+#: src/case_studies/Google_study.md:120
+msgid ""
+"The most desirable is to remove them and let Linux drivers take over what "
+"they did. This works well for USB, network, disk, and other drivers, as well "
+"as network protocols and file systems. In fact we have resolved many system "
+"reliability and performance issues just by removing DXEs!"
+msgstr ""
+
+#: src/case_studies/Google_study.md:125
+msgid ""
+"The second way is to replace the DXE with an open source driver. This is "
+"less desirable, as the DXE environment is not as hardened as the Linux "
+"kernel environment."
+msgstr ""
+
+#: src/case_studies/Google_study.md:128
+msgid ""
+"The final, least desired option, is to continue to use the DXE. This is "
+"required if the DXE contains proprietary code that \"tweaks\" chipset "
+"settings, for example, memory timing or other controls, and there is no "
+"chance of ever bringing them to open source."
+msgstr ""
+
+#: src/case_studies/Google_study.md:136
+msgid "Step 5. Replace closed source DXEs with open source"
+msgstr ""
+
+#: src/case_studies/Google_study.md:138
+msgid "If we can build a DXE from source, we can use `utk` to:"
+msgstr ""
+
+#: src/case_studies/Google_study.md:140
+msgid "Remove the proprietary one"
+msgstr ""
+
+#: src/case_studies/Google_study.md:141
+msgid "Replace it with one built from source"
+msgstr ""
+
+#: src/case_studies/Google_study.md:145
+msgid "Step 6. Next steps: complete LinuxBoot"
+msgstr ""
+
+#: src/case_studies/Google_study.md:147
+msgid ""
+"LinuxBoot is currently in production, but the LinuxBoot project development "
+"continues to provide an open-source solution that does the following:"
+msgstr ""
+
+#: src/case_studies/Google_study.md:151
+msgid ""
+"Brings up the Linux kernel as a DXE in flash ROM instead of the UEFI shell."
+msgstr ""
+
+#: src/case_studies/Google_study.md:152
+msgid ""
+"Provides a Go based user-space that can then bring up the kernel that you "
+"want to run on the machine."
+msgstr ""
+
+#: src/case_studies/Google_study.md:154
+msgid ""
+"Enables writing traditional firmware applications such as bootloader, "
+"debugging, diagnosis, and error detection applications as cross-architecture "
+"and cross-platform portable Linux applications."
+msgstr ""
+
+#: src/case_studies/Google_study.md:158
+msgid "The complete LinuxBoot solution is shown in the following diagram."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:1
+msgid "OCP TiogaPass Case Study"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:3
+msgid ""
+"Points of contact: [Jonathan Zhang](https://github.com/jonzhang-fb), [Andrea "
+"Barberio](https://github.com/insomniacslk), [David "
+"Hendricks](https://github.com/dhendrix), "
+"[Adi](https://github.com/agangidi53), [Morgan "
+"Jang](https://github.com/morganjangwiwynn), [Johnny "
+"Lin](https://github.com/johnnylinwiwynn)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:11
+msgid ""
+"This case study describes information for firmware development community to "
+"use [OCP](https://www.opencompute.org/) platform TiogaPass, made by [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:15
+msgid "It contains following sections:"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:17
+msgid "[Quick Start](#Quick-Start)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:18
+msgid "[Details](#Details)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:19
+msgid "[How to build](#How-to-build)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:20
+msgid "[How to operate](#How-to-operate)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:21
+msgid "[Platform info](#Platform-info)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:22
+msgid "[Support](#Support)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:23
+msgid "[Hardware support](#Hardware-support)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:24
+msgid "[Community support](#Community-support)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:25
+msgid "[Professional support](#Professional-support)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:27
+msgid "Quick Start"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:29
+msgid ""
+"[Order the hardware](http://www.wiwynn.com/english) if you have not done so."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:30
+msgid ""
+"Download or build the firmware binary. The current solution is to boot "
+"embedded Linux kernel and initramfs as UEFI payload. Please contact Wiwynn "
+"to get a UEFI binary after ordering."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:33
+msgid "Flash the firmware."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:34
+msgid "Copy the downloaded firmware to OpenBMC."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:35 src/case_studies/TiogaPass.md:40
+msgid "From OpenBMC"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:39
+msgid "Boot and enjoy."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:46
+msgid "Details"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:48
+msgid "How to build"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:50
+msgid ""
+"Follow [Build Details](#Build-Details) for details on how to get the source "
+"code, and how to build."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:53
+msgid ""
+"Boot flow of the current firmware solution is: Power on → minimized UEFI → "
+"LinuxBoot → target OS."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:56
+msgid ""
+"In near feature, the boot flow will be: power on → Coreboot → LinuxBoot → "
+"target OS."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:59
+msgid "Build Details"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:61
+msgid ""
+"Download the code from [linuxboot "
+"github](https://github.com/linuxboot/linuxboot)"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:62
+msgid ""
+"```\n"
+"  git clone https://github.com/linuxboot/linuxboot.git\n"
+"```"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:65
+msgid "You need to apply Wiwiynn's linuxboot patch for now"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:66
+msgid ""
+"```\n"
+"cd linuxboot\n"
+"wget -O TiogaPass.patch "
+"https://github.com/johnnylinwiwynn/linuxboot/commit/28ae8450b3b05c6e6b8c74e29d0974ccf711d5e6.patch\n"
+"git am TiogaPass.patch\n"
+"```"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:71
+msgid ""
+"Build the kernel bzImage (has embedded initramfs) for linuxboot, please "
+"reference [Building "
+"u-root](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemboot#building-u-root) "
+"and [Building a suitable Linux "
+"kernel](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemboot#building-a-suitable-linux-kernel) "
+"for how to build the bzImage. You can always customize your Linux kernel "
+"configuration to suit your needs, please reference Wiwynn's kernel "
+"configuration file as a sample [linux_config](linux_config)."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:77
+msgid ""
+"Place the tioga.rom into linuxboot/boards/tioga which is provided from "
+"Wiwynn after ordering, and also put your bzImage to the root folder of "
+"linuxboot, and then make"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:86
+msgid "You should see the built image at build/tioga/linuxboot.rom."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:88
+msgid "How to operate"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:90
+msgid "Follow **TBD section** for details on:"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:92
+msgid ""
+"How to flash. The image can be flashed either out-of-band, or from LinuxBoot "
+"u-root shell, or from targetOS shell."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:94
+msgid "How to run LinuxBoot u-root shell commands."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:96
+msgid "Platform info"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:98
+msgid ""
+"The SKU contains TiogaPass board, a debug card, a VGA card, a power adapter. "
+"The details can be obtained from the [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:101
+msgid ""
+"Platform design details (including the design spec and schematics) can be "
+"found on the [Open Compute Project UfiSpace product "
+"page](https://www.opencompute.org/products/108/wiwynn-tioga-pass-standard-sv7220g3-s-2u-ocp-server-up-to-768gb-8gb16gb32gb-ddr4-up-to-2666mts-12-dimm-slots)."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:105
+msgid "Support"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:107
+msgid "Hardware support"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:109
+msgid ""
+"Hardware support can be obtained from [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:111
+msgid "Community support"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:113
+msgid ""
+"[OCP Open System "
+"Firmware](https://www.opencompute.org/projects/open-system-firmware) is "
+"where industry collaborates on how to move forward with OSF. The OCP OSF "
+"project has regular recorded meetings and a mailing list."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:117
+msgid ""
+"[LinuxBoot open source community](https://www.linuxboot.org/) is the "
+"community you can ask any technical questions. LinuxBoot community has a "
+"slack channel, a IRC channel, a mailing list and regular meetings."
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:121
+msgid "Professional support"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:123
+msgid "Following companies provides professional support services:"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:125
+msgid "\\** TBD **"
+msgstr ""
+
+#: src/faq.md:1
+msgid "Frequently asked questions"
+msgstr ""
+
+#: src/faq.md:3
+msgid "Troubleshooting"
+msgstr ""
+
+#: src/faq.md:5
+msgid "**Why does the u-root DHCP client take ages?**"
+msgstr ""
+
+#: src/faq.md:7
+msgid ""
+"The problem is a lack of early entropy. If your platform has a hardware "
+"random number generator then enable it with `CONFIG_ARCH_RANDOM` and trust "
+"it with `CONFIG_RANDOM_TRUST_CPU`. Otherwise, add `uroot.nohwrng` to your "
+"kernel command line so u-root use a non-blocking random number generator "
+"implementation."
+msgstr ""
+

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -13,44 +13,37 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: src/SUMMARY.md:1 src/intro.md:1
-#, fuzzy
 msgid "LinuxBoot Introduction"
 msgstr "LinuxBoot介紹"
 
 #: src/SUMMARY.md:2 src/use-cases.md:1
-#, fuzzy
 msgid "Use cases"
-msgstr "用例"
+msgstr "使用情境"
 
 #: src/SUMMARY.md:3
-#, fuzzy
 msgid "Talks and news coverage"
-msgstr "演講和新聞報道"
+msgstr "演講和新聞報導"
 
 #: src/SUMMARY.md:4 src/components.md:1
-#, fuzzy
 msgid "LinuxBoot Components"
-msgstr "LinuxBoot 元件"
+msgstr "LinuxBoot 的組成"
 
 #: src/SUMMARY.md:5 src/tools-evaluation.md:1
-#, fuzzy
 msgid "Evaluation of tools"
 msgstr "工具評估"
 
 #: src/SUMMARY.md:6 src/u-root.md:1
-#, fuzzy
 msgid "All about u-root"
 msgstr "關於 u-root"
 
 #: src/SUMMARY.md:7 src/u-root-qemu-demo.md:1
-#, fuzzy
 msgid "u-root demo with QEMU"
-msgstr "使用 QEMU 的 u-root 演示"
+msgstr "使用 QEMU 的 u-root 示範"
 
 #: src/SUMMARY.md:8
 #, fuzzy
 msgid "LinuxBoot utilities"
-msgstr "Linux啟動實用程式"
+msgstr "Linux 啟動實用程式"
 
 #: src/SUMMARY.md:9 src/utilities/UEFI_Tool_Kit.md:1
 #, fuzzy
@@ -58,98 +51,79 @@ msgid "UEFI Tool Kit"
 msgstr "UEFI工具包"
 
 #: src/SUMMARY.md:10
-#, fuzzy
 msgid "The magical cpu command"
 msgstr "神奇的 CPU 指令"
 
 #: src/SUMMARY.md:11
-#, fuzzy
 msgid "Device Under Test"
-msgstr "被測設備"
+msgstr "被測試的設備"
 
 #: src/SUMMARY.md:12 src/implementation.md:1
-#, fuzzy
 msgid "Implementing LinuxBoot"
 msgstr "實作 LinuxBoot"
 
 #: src/SUMMARY.md:13 src/coreboot.u-root.systemboot/index.md:1
-#, fuzzy
 msgid "LinuxBoot using coreboot, u-root and systemboot"
 msgstr "使用 coreboot、u-root 和 systemboot 的 LinuxBoot"
 
 #: src/SUMMARY.md:14 src/glossary.md:1
-#, fuzzy
 msgid "Glossary"
 msgstr "詞彙表"
 
 #: src/SUMMARY.md:15 src/history.md:1
-#, fuzzy
 msgid "History"
 msgstr "歷史"
 
 #: src/SUMMARY.md:16 src/case_studies/index.md:1
-#, fuzzy
 msgid "Case Studies"
 msgstr "案例研究"
 
 #: src/SUMMARY.md:17
-#, fuzzy
 msgid "Ampere study"
-msgstr "安培研究"
+msgstr "Ampere 的案例研究"
 
 #: src/SUMMARY.md:18
-#, fuzzy
 msgid "Google study"
-msgstr "谷歌研究"
+msgstr "Google 的案例研究"
 
 #: src/SUMMARY.md:19
-#, fuzzy
 msgid "OCP TiogaPass"
-msgstr "OCP 泰奧加山口"
+msgstr "OCP TiogaPass 的案例研究"
 
 #: src/SUMMARY.md:20
-#, fuzzy
 msgid "Frequently Asked Questions"
 msgstr "常見問題"
 
 #: src/intro.md:3
-#, fuzzy
 msgid ""
 "This is the official “LinuxBoot Book” for the LinuxBoot project. The book:"
 msgstr "這是 LinuxBoot 專案的官方「LinuxBoot 書籍」。這本書："
 
 #: src/intro.md:5
-#, fuzzy
 msgid "Describes the LinuxBoot project"
 msgstr "描述 LinuxBoot 項目"
 
 #: src/intro.md:6
-#, fuzzy
 msgid "Explains why you would want to use LinuxBoot"
 msgstr "解釋為什麼要使用 LinuxBoot"
 
 #: src/intro.md:7
-#, fuzzy
 msgid "Describes the components that comprise LinuxBoot"
 msgstr "描述組成 LinuxBoot 的元件"
 
 #: src/intro.md:8
-#, fuzzy
 msgid "Highlights the differences between other boot processes and LinuxBoot"
-msgstr "重點介紹其他啟動過程與 LinuxBoot 之間的差異"
+msgstr "說明其他啟動系統（如 UEFI）與 LinuxBoot 的差異"
 
 #: src/intro.md:9
-#, fuzzy
 msgid "Guides you through the steps needed to implement LinuxBoot"
 msgstr "指導您完成實作 LinuxBoot 所需的步驟"
 
 #: src/intro.md:11
-#, fuzzy
 msgid "What is LinuxBoot?"
 msgstr "什麼是 LinuxBoot？"
 
 #: src/intro.md:13
-#, fuzzy
 msgid ""
 "LinuxBoot is the idea of replacing proprietary or corporate-driven "
 "late-stage boot [firmware](./glossary.md) with the Linux kernel and a "
@@ -157,8 +131,9 @@ msgid ""
 "years includes various initiatives with the overarching goal of moving from "
 "obscure and complex firmware to simpler and open source firmware."
 msgstr ""
-"LinuxBoot 的想法是用 Linux "
-"核心和基於社群的用戶空間取代專有或企業驅動的後期啟動[韌體](./glossary.md)。這個想法逐漸發展成為一個項目，多年來包括各種舉措，其總體目標是從晦澀複雜的韌體轉變為更簡單和開源的韌體。"
+"LinuxBoot 的想法是用 Linux 核心和基於社群的用戶空間（user-space） 取代專有或企業主導的後期"
+"啟動[韌體](./glossary.md)。這個想法逐漸發展成為一個項目，多年來包括各種舉措，其總體目標是"
+"從晦澀複雜的韌體轉變為更簡單和開源的韌體。"
 
 #: src/intro.md:19
 msgid ""
@@ -168,59 +143,58 @@ msgid ""
 "[initramfs](https://de.wikipedia.org/wiki/Initramfs) that contains a minimal "
 "Golang user-space built using [u-root](https://github.com/u-root/u-root)."
 msgstr ""
+"LinuxBoot 專案提供兩個參考實作；`linuxboot` 和 Heads。"
+"[`linuxboot`](https://github.com/linuxboot/linuxboot) "
+"建置系統輸出一個啟動載荷 (boot payload) ，包含一個 Linux 核心和一個 "
+"[initramfs](https://de.wikipedia.org/wiki/Initramfs)，其中包含使用 "
+"[u-root](https://github.com/u-root/u-root) 建置的最小 Golang 使用者空間（user-space）。"
 
 #: src/intro.md:25
-#, fuzzy
 msgid ""
 "The Heads build system is more focused on local attestation, TPM DUK "
 "seal/unseal operations, GPG-based security measurement, reproducible builds "
 "and uses BusyBox to provide a much larger suite of Linux tools allowing it "
 "to also be used as a recovery environment."
 msgstr ""
-"Heads 構建系統更側重於本地證明、TPM DUK 密封/解封操作、基於 GPG 的安全測量、可重現構建，並使用 BusyBox 提供更大的 "
-"Linux 工具套件，使其也可以用作恢復環境。"
+"Heads 構建系統更側重於本地證明（local attestation）、TPM DUK 密封/解封（seal/unseal）"
+"操作、基於 GPG 的安全措施、可重現構建（reproducible builds），並使用 BusyBox 提供更大的 "
+"Linux 工具套件，使其也可以用作修復環境（recovery environment）。"
 
 #: src/intro.md:30
-#, fuzzy
 msgid "Many other implementations exist independently of the project:"
 msgstr "許多其他實作獨立於專案而存在："
 
 #: src/intro.md:32
-#, fuzzy
 msgid ""
 "[petitboot](https://github.com/open-power/petitboot) under the OpenPOWER "
 "project originally targeting the PS3"
 msgstr ""
-"[petitboot](https://github.com/open-power/petitboot) 屬於 OpenPOWER 項目，最初針對的是 "
-"PS3"
+"[petitboot](https://github.com/open-power/petitboot) 屬於 OpenPOWER 項目，最初針"
+"對的是 PS3"
 
 #: src/intro.md:34
-#, fuzzy
 msgid ""
 "[k-boot](https://github.com/BayLibre/k-boot) developed by BayLibre in 2023 "
 "using BusyBox"
 msgstr ""
-"[k-boot](https://github.com/BayLibre/k-boot) 由 BayLibre 於 2023 年使用 BusyBox 開發"
+"[k-boot](https://github.com/BayLibre/k-boot) 由 BayLibre 於 2023 年使用 BusyBox "
+"開發"
 
 #: src/intro.md:36
-#, fuzzy
 msgid "[nmbl](https://github.com/rhboot/nmbl-poc) developed by RedHat in 2024"
 msgstr "[nmbl](https://github.com/rhboot/nmbl-poc) 由 RedHat 於 2024 年開發"
 
 #: src/intro.md:37
-#, fuzzy
 msgid "[ZFSBootMenu](https://docs.zfsbootmenu.org/en/latest)"
 msgstr "[ZFSBootMenu](https://docs.zfsbootmenu.org/en/latest)"
 
 #: src/intro.md:39
-#, fuzzy
 msgid ""
 "And there is a long history of similar implementations including projects "
 "that are no longer maintained:"
-msgstr "類似的實作由來已久，包括不再維護的專案："
+msgstr "此外，過去也曾有許多類似的實作，其中包含一些已不再維護的專案："
 
 #: src/intro.md:42
-#, fuzzy
 msgid ""
 "MILO on Alpha started before 2000 (see [What is "
 "MILO?](https://tldp.org/HOWTO/MILO-HOWTO/what-section.html))"
@@ -229,12 +203,10 @@ msgstr ""
 "MILO？](https://tldp.org/HOWTO/MILO-HOWTO/what-section.html)）"
 
 #: src/intro.md:44
-#, fuzzy
 msgid "kboot developed by Werner Almesberger in 2005"
 msgstr "kboot 由 Werner Almesberger 於 2005 年開發"
 
 #: src/intro.md:46
-#, fuzzy
 msgid ""
 "These projects all attempt to reduce the role of firmware to a small, "
 "fixed-function core whose only purpose is to get a flash-based Linux kernel "
@@ -242,16 +214,16 @@ msgid ""
 "Linux kernel and a user-space environment will run on the machine. Go is the "
 "recommended user-space environment, but is not required."
 msgstr ""
-"這些專案都試圖將韌體的作用簡化為一個小型的、固定功能的核心，其唯一目的是啟動基於快閃記憶體的 Linux 核心。這個「基本要素」韌體準備硬體並啟動 "
-"Linux 內核，並且用戶空間環境將在機器上運行。 Go 是建議的使用者空間環境，但不是必需的。"
+"這些專案都試圖將韌體的角色簡化為一個小型、固定功能的核心，其唯一目的是啟動一個儲存在快閃記憶體"
+"（flash）中的 Linux 核心（Linux kernel）。這個「最低必要」（bare essentials）的韌體會負"
+"責初始化硬體，接著啟動 Linux 核心，並讓使用者空間環境（user-space environment）在機器上"
+"運行。Go 是建議使用的使用者空間環境，但並非必須。"
 
 #: src/intro.md:52
-#, fuzzy
 msgid "Why LinuxBoot is needed"
 msgstr "為什麼需要 LinuxBoot"
 
 #: src/intro.md:54
-#, fuzzy
 msgid ""
 "Sometimes firmware contains drivers and utilities. They can have bugs, or be "
 "unmaintained, which can be a source of problems and security issues. "
@@ -264,29 +236,31 @@ msgid ""
 "drivers are currently being run around the clock at scale, they will have "
 "fewer bugs."
 msgstr ""
-"有時韌體包含驅動程式和實用程式。它們可能存在錯誤，或無人維護，這可能會成為問題和安全問題的根源。 LinuxBoot 以 Linux "
-"驅動程式取代了專有的、閉源的、供應商提供的韌體驅動程式。這使得編寫 Linux "
-"驅動程式的工程師和編寫韌體驅動程式的工程師能夠專注於一組驅動程式。因此，這些驅動程式將擁有更多的貢獻者和審查者，並且由於這些驅動程式是 Linux "
-"的一部分，因此可以使用標準產業編碼基礎架構來改進它們。最後，由於這些 Linux 驅動程式目前正在大規模全天候運行，因此它們的錯誤會更少。"
+"有時候，韌體會包含驅動程式和工具程式（utilities）。這些元件可能存在漏洞，或是已無人維護，進而"
+"成為問題或資安風險的來源。LinuxBoot 以 Linux 驅動程式取代了供應商提供的專有閉源韌體驅動"
+"（proprietary, closed-source firmware drivers），讓開發 Linux 驅動與韌體驅動的工程師"
+"能專注於同一套驅動程式。如此一來，這些驅動程式將擁有更多的貢獻者 (contributors) 與審閱者"
+"（reviewers），又因為它們是 Linux 的一部分，能夠運用業界標準的開發流程與工具"
+"（standard industry coding infrastructure）來持續改善。最終，由於這些 Linux 驅動目前"
+"已在大量系統上長時間穩定運作（run around the clock at scale），其錯誤率也會相對較低。"
 
 #: src/intro.md:64
-#, fuzzy
 msgid "What LinuxBoot does"
-msgstr "LinuxBoot 的作用"
+msgstr "LinuxBoot 的功能"
 
 #: src/intro.md:66
-#, fuzzy
 msgid ""
 "LinuxBoot replaces many Driver Execution Environment (DXE) modules used by "
 "Unified Extensible Firmware Interface (UEFI) and other firmware, "
 "particularly the network stack and file system modules, with Linux "
 "applications."
 msgstr ""
-"LinuxBoot 以 Linux 應用程式取代了統一可擴充韌體介面 (UEFI) 和其他韌體所使用的許多驅動程式執行環境 (DXE) "
-"模組，特別是網路堆疊和檔案系統模組。"
+"LinuxBoot 以 Linux 應用程式取代了統一可擴充韌體介面"
+"（Unified Extensible Firmware Interface，UEFI）與其他韌體中大量的驅動程式執行環境"
+"（Driver Execution Environment，DXE）模組，特別是網路協定堆疊（network stack）和檔案"
+"系統（file system）模組。"
 
 #: src/intro.md:70
-#, fuzzy
 msgid ""
 "LinuxBoot brings up the Linux kernel as a DXE in flash ROM instead of the "
 "UEFI shell. The Linux kernel, with a provided Go based user-space, can then "
@@ -295,37 +269,37 @@ msgid ""
 "detection applications as cross-architecture and cross-platform portable "
 "Linux applications."
 msgstr ""
-"LinuxBoot 將 Linux 核心作為快閃 ROM 中的 DXE 而不是 UEFI shell 啟動。然後，Linux 核心可以透過提供的基於 "
-"Go 的使用者空間來載入運行時核心。 LinuxBoot "
-"範例支援將傳統韌體應用程式（如開機載入程式、偵錯、診斷和錯誤檢測應用程式）編寫為跨架構和跨平台的可移植 Linux 應用程式。"
+"LinuxBoot 將 Linux 核心（Linux kernel）作為快閃記憶體（flash ROM）中的驅動程式執行環境"
+"（Driver Execution Environment, DXE）啟動，而非傳統的 UEFI shell。接著，Linux 核心"
+"可透過隨附的基於 Go 的使用者空間（user-space）來載入運行時核心（runtime kernel）。"
+"LinuxBoot 的架構（paradigm）使得傳統的韌體應用程式（例如開機載入器、偵錯工具、診斷與錯誤偵"
+"測應用程式）能夠以跨架構、跨平台的可攜式 Linux 應用程式形式實作。"
 
 #: src/intro.md:77
-#, fuzzy
 msgid ""
 "When Linux boots it needs a root file system with utilities. One such root "
 "filesystem used for LinuxBoot is based on u-root standard utilities written "
 "in Go. The following diagram shows the current state of the UEFI boot "
 "process and what is planned for the transition to LinuxBoot."
 msgstr ""
-"當 Linux 啟動時，它需要一個具有實用程式的根檔案系統。 LinuxBoot 使用的一個這樣的根檔案系統是基於用 Go 編寫的 u-root "
-"標準實用程式。下圖顯示了 UEFI 啟動過程的目前狀態以及向 LinuxBoot 過渡的計畫。"
+"當 Linux 啟動時，它需要一個包含工具程式（utilities）的根檔案系統（root file system）。"
+"LinuxBoot 使用的其中一種根檔案系統是基於使用 Go 語言編寫的 u-root 標準工具程式"
+"（standard utilities）。下圖顯示了目前 UEFI 啟動過程的狀況，以及計畫中的 LinuxBoot 過渡"
+"流程。"
 
 #: src/intro.md:82
-#, fuzzy
 msgid ""
 "[![comparison of UEFI boot and "
 "LinuxBoot](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
 msgstr ""
-"[![UEFI 啟動與 LinuxBoot "
-"的比較](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
+"[![UEFI 啟動與 LinuxBoot 的比較]"
+"(../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
 
 #: src/intro.md:84
-#, fuzzy
 msgid "Benefits of using the Go user-space environment and compiler"
-msgstr "使用 Go 使用者空間環境和編譯器的好處"
+msgstr "使用 Go 使用者空間(user-space)環境和編譯器的好處"
 
 #: src/intro.md:86
-#, fuzzy
 msgid ""
 "Go is a systems programming language created by Google. Go has strong "
 "typing, language level support for concurrency, inter-process communication "
@@ -334,12 +308,15 @@ msgid ""
 "notation similar to Java that makes it clear to determine what packages a "
 "given program needs."
 msgstr ""
-"Go 是由 Google 創建的系統程式語言。 Go "
-"具有強類型、語言級別的並發支援、透過通道進行進程間通訊、運行時類型安全性和其他保護措施、動態分配和垃圾收集以及閉包。 Go 具有與 Java "
-"類似的套件名稱符號，可以清楚地確定給定程式需要哪些套件。"
+"Go 是由 Google 創建的系統程式語言。"
+"Go 具有強類型（strong typing）、語言級別的並發支援（concurrency support）、"
+"透過通道（channels）進行進程間通訊（inter-process communication）、運行時類型安全性"
+"（runtime type safety）和其他保護措施、動態分配（dynamic allocation）和垃圾收集"
+"（garbage collection）以及閉包（closures）。"
+"Go 具有與 Java 類似的套件名稱符號（package name notation），"
+"使得可以清楚地確定給定程式需要哪些套件（packages）。"
 
 #: src/intro.md:92
-#, fuzzy
 msgid ""
 "The modern language constructs make Go a much safer language than C. This "
 "safety is critical for network-attached embedded systems, which usually have "
@@ -348,11 +325,12 @@ msgid ""
 "itself written in C. All are proving to be vulnerable to the attack-rich "
 "environment that the Internet has become."
 msgstr ""
-"現代語言結構使 Go 成為一種比 C 更安全的語言。這種安全性對於網路連接嵌入式系統至關重要，這些系統通常具有用 C 編寫的網路實用程序，包括 Web "
-"伺服器、包括「sshd」的網路伺服器以及提供對命令解釋器的存取的程式（本身以 C 編寫）。事實證明，所有這些都容易受到互聯網已成為攻擊頻繁的環境的影響。"
+"現代語言結構使 Go 成為比 C 更安全的語言。這種安全性對於網路連接的嵌入式系統至關重要，"
+"這些系統通常擁有用 C 編寫的網路工具程式，包括網頁伺服器、"
+"包含 sshd 的網路伺服器（network servers），以及提供命令解釋器存取的程式（本身以 C 編寫）。"
+"所有這些都證明容易受到互聯網成為攻擊頻繁環境的威脅。"
 
 #: src/intro.md:99
-#, fuzzy
 msgid ""
 "Even the most skilled programmers can make mistakes that in C can be "
 "unrecoverable, especially on network connected systems. Currently, even the "
@@ -360,20 +338,20 @@ msgid ""
 "network-connected. These programming mistakes are either impossible to make "
 "in Go or, if made, are detected at runtime and result in the program exiting."
 msgstr ""
-"即使是最熟練的程式設計師也會犯下 C "
-"語言中無法恢復的錯誤，尤其是在網路連線系統上。目前，即使我們個人電腦、印表機和恆溫器中最低等級的韌體也是連網的。這些程式錯誤要么在 Go "
-"中不可能犯，要么如果犯了，則會在運行時檢測到並導致程式退出。"
+"即使是最熟練的程式設計師也會犯下 C 語言中無法恢復的錯誤，"
+"尤其是在網路連線系統上。目前，即使我們個人電腦、印表機和恆溫器中最低等級的韌體也是連網的。"
+"這些程式錯誤要麼在 Go 中不可能犯，要麼如果犯了，則會在運行時檢測到並導致程式退出。"
 
 #: src/intro.md:105
-#, fuzzy
 msgid ""
 "The case for using a high-level, safe language like Go in low level embedded "
 "firmware might be stronger than for user programs, because exploits at the "
 "firmware level are nearly impossible to detect and mitigate."
-msgstr "在低階嵌入式韌體中使用像 Go 這樣的高級安全語言的情況可能比用戶程式更強烈，因為韌體層級的漏洞幾乎不可能被檢測和緩解。"
+msgstr ""
+"在低階嵌入式韌體中使用像 Go 這樣的高級安全語言的理由，"
+"可能比用戶程式更為充分，因為在韌體層級的漏洞幾乎不可能被檢測和緩解。"
 
 #: src/intro.md:109
-#, fuzzy
 msgid ""
 "The challenge to using Go in a storage-constrained environment such as "
 "firmware is that advanced language features lead to big binaries. Even a "
@@ -389,143 +367,127 @@ msgid ""
 "programs can be fetched over the network, but compiling dynamically with Go "
 "or creating a BusyBox program are the recommended solutions."
 msgstr ""
-"在韌體等儲存受限的環境中使用 Go 的挑戰在於高階語言特性會導致二進位檔案很大。即使是約會程序也大約有 2 MiB。一個實現一個功能的 Go "
-"二進位檔案的大小是實現多個功能的 BusyBox 二進位檔案的兩倍。目前，典型的 BIOS FLASH 部分為 16MiB。將許多 Go "
-"二進位檔案裝入單一 BIOS 快閃記憶體部分是不切實際的。 Go "
-"編譯器速度很快，其速度顯示只有在使用程式時才對其進行編譯的解決方案。透過這種方法，您可以建立一個除了 Go "
-"編譯器本身之外幾乎沒有二進位檔案的根檔案系統。編譯後的程式和套件可以儲存到基於 RAM 的檔案系統中。另一個解決方案是將所有內容編譯成一個 "
-"BusyBox 風格的程式。或者，可以透過網路取得程序，但使用 Go 動態編譯或建立 BusyBox 程式是建議的解決方案。"
+"在韌體等儲存受限的環境中使用 Go 的挑戰在於，高階語言特性會導致二進位檔案過大。即使是簡單的日"
+"期程式也約有 2 MiB。一個實現單一功能的 Go 二進位檔案大小是實現多個功能的 BusyBox 二進位檔"
+"案的兩倍。當前，典型的 BIOS 快閃記憶體（FLASH）大小為 16 MiB。"
+"將多個 Go 二進位檔案裝入單一 BIOS 快閃記憶體區塊是不切實際的。Go 編譯器速度非常快，且其速度"
+"顯示了只有在使用程式時進行編譯的解決方案。"
+"透過這種方式，您可以建立一個幾乎不含二進位檔案（除了 Go 編譯器本身）的根檔案系統。編譯後的程"
+"式和套件可儲存到基於 RAM 的檔案系統中。"
+"另一個解決方案是將所有程式編譯成一個 BusyBox 風格的程式。或者，程式可以透過網路獲取，但動態"
+"編譯 Go 或創建 BusyBox 程式是建議的解決方案。"
 
 #: src/intro.md:123
-#, fuzzy
 msgid "Benefits of LinuxBoot with UEFI servers"
-msgstr "LinuxBoot 與 UEFI 伺服器的優勢"
+msgstr "在 UEFI 伺服器上使用 LinuxBoot 的好處"
 
 #: src/intro.md:125
-#, fuzzy
 msgid ""
 "Most server firmware is based on Intel’s Universal Extensible Firmware "
 "Interface (UEFI). LinuxBoot provides the following benefits over UEFI:"
-msgstr "大多數伺服器韌體基於英特爾的通用可擴展韌體介面 (UEFI)。與 UEFI 相比，LinuxBoot 具有以下優點："
+msgstr "大多數伺服器韌體基於 Intel 的通用可擴展韌體介面 (UEFI)。與 UEFI 相比，LinuxBoot"
+" 具有以下優點："
 
 #: src/intro.md:128
-#, fuzzy
 msgid "Reliability"
 msgstr "可靠性"
 
 #: src/intro.md:130
-#, fuzzy
 msgid ""
 "Improves boot reliability by replacing lightly-tested firmware drivers with "
 "hardened Linux drivers"
 msgstr "透過使用強化的 Linux 驅動程式取代未經充分測試的韌體驅動程式來提高啟動可靠性"
 
 #: src/intro.md:132
-#, fuzzy
 msgid ""
 "Proven approach for almost 20 years in military, consumer electronics, and "
 "supercomputers – wherever reliability and performance are paramount"
-msgstr "近 20 年來，在軍事、消費性電子和超級電腦領域，可靠性和性能至關重要的領域，該方法已得到驗證"
+msgstr ""
+"近 20 年來，在軍事、消費性電子和超級電腦領域，可靠性和性能至關重要的領域，該實踐方法已得到驗證"
 
 #: src/intro.md:134
-#, fuzzy
 msgid ""
 "Fault Tolerance - Linux isolates processes\\*\\* \\*\\*(for example, when "
 "`pxeboot` fails catastrophically, `diskboot` still works afterwards)"
-msgstr "容錯 - Linux 隔離程序\\*\\* \\*\\*（例如，當「pxeboot」發生災難性故障時，「diskboot」仍然可以運作）"
+msgstr ""
+"容錯 - Linux 隔離程序\\*\\* \\*\\*（例如，當「pxeboot」發生災難性故障時，"
+"「diskboot」仍然可以運作）"
 
 #: src/intro.md:137
-#, fuzzy
 msgid "Security"
-msgstr "安全"
+msgstr "安全性"
 
 #: src/intro.md:139
-#, fuzzy
 msgid "Move “Ring 0” boot loaders to “Ring 3”"
-msgstr "將“Ring 0”引導程式移至“Ring 3”"
+msgstr "將“Ring 0”引導程式（bootloaders）移至“Ring 3”"
 
 #: src/intro.md:140
-#, fuzzy
 msgid "`pxeboot` and `diskboot` do parsing and other logic in user-space"
-msgstr "`pxeboot` 和 `diskboot` 在使用者空間進行解析和其他邏輯"
+msgstr "`pxeboot` 和 `diskboot` 在使用者空間（user-space）進行解析和其他邏輯處理"
 
 #: src/intro.md:141
-#, fuzzy
 msgid "Go provides memory safety and type safety"
-msgstr "Go 提供記憶體安全和類型安全"
+msgstr "Go 提供記憶體安全和類型安全（type safety）"
 
 #: src/intro.md:142
-#, fuzzy
 msgid "A buggy parser is much less likely to affect other programs"
-msgstr "有缺陷的解析器不太可能影響其他程式"
+msgstr "有缺陷的解析器（parser）不太可能影響其他程式"
 
 #: src/intro.md:143
-#, fuzzy
 msgid "Kernel security patches can apply to firmware"
-msgstr "核心安全性補丁可應用於韌體"
+msgstr "核心安全性補丁（patches）可應用於韌體"
 
 #: src/intro.md:145
-#, fuzzy
 msgid "Flexibility"
 msgstr "靈活性"
 
 #: src/intro.md:147
-#, fuzzy
 msgid ""
 "Can be used with coreboot, u-boot, OpenPOWER Abstraction Layer (OPAL), "
 "SlimBootLoader, ARM Trusted Firmware (ATF)"
 msgstr ""
-"可與 coreboot、u-boot、OpenPOWER 抽象層 (OPAL)、SlimBootLoader、ARM 可信任韌體 (ATF) 搭配"
+"可與 coreboot、u-boot、OpenPOWER 抽象層 (OpenPOWER Abstraction Layer, OPAL)、"
+"SlimBootLoader、ARM 可信任韌體 (Arm Trusted Firmware, ATF) 搭配"
 
 #: src/intro.md:149
-#, fuzzy
 msgid ""
 "Can boot multiple operating systems (Linux, Berkeley UNIX (BSD), XEN, "
 "Windows)"
 msgstr "可啟動多個作業系統（Linux、Berkeley UNIX（BSD）、XEN、Windows）"
 
 #: src/intro.md:151
-#, fuzzy
 msgid "Supports the following server mainboards:"
 msgstr "支援以下伺服器主機板："
 
 #: src/intro.md:152
-#, fuzzy
 msgid "QEMU emulated Q35 systems"
-msgstr "QEMU 模擬 Q35 系統"
+msgstr "QEMU 模擬的 Q35 系統"
 
 #: src/intro.md:153
-#, fuzzy
 msgid "[Intel S2600WF](https://trmm.net/S2600wf)"
-msgstr "[Intel S2600WF]（https://trmm.net/S2600wf）"
+msgstr "[Intel S2600WF](https://trmm.net/S2600wf)"
 
 #: src/intro.md:154
-#, fuzzy
 msgid "[Dell R630](https://trmm.net/NERF)"
-msgstr "戴爾 R630"
+msgstr "[Dell R630](https://trmm.net/NERF)"
 
 #: src/intro.md:155
-#, fuzzy
 msgid "Winterfell Open Compute node"
-msgstr "Winterfell 開放式運算節點"
+msgstr "Winterfell Open Compute node"
 
 #: src/intro.md:156
-#, fuzzy
 msgid "Leopard Open Compute node"
-msgstr "Leopard 開放式運算節點"
+msgstr "Leopard Open Compute node"
 
 #: src/intro.md:157
-#, fuzzy
 msgid "Tioga Pass Open Compute node"
-msgstr "Tioga Pass 開放運算節點"
+msgstr "Tioga Pass Open Compute node"
 
 #: src/intro.md:158
-#, fuzzy
 msgid "Monolake Open Compute node (not tested)"
-msgstr "Monolake Open Compute 節點（未經測試）"
+msgstr "Monolake Open Compute node（未經測試）"
 
 #: src/intro.md:160
-#, fuzzy
 msgid "Boot speed"
 msgstr "啟動速度"
 
@@ -533,105 +495,86 @@ msgstr "啟動速度"
 msgid ""
 "Improves boot time by removing unnecessary code; typically makes boot 20 "
 "times faster"
-msgstr ""
+msgstr "透過移除不必要的程式碼來提升啟動時間；通常能使啟動速度提高 20 倍"
 
 #: src/intro.md:165
-#, fuzzy
 msgid "Customization"
 msgstr "客製化"
 
 #: src/intro.md:167
-#, fuzzy
 msgid ""
 "Allows customization of the initramfs runtime to support site-specific needs "
 "(both device drivers as well as custom executables)"
-msgstr "允許自訂 initramfs 運行時以支援特定網站的需求（裝置驅動程式和自訂執行檔）"
+msgstr "允許自訂 initramfs 運行時，支援特定環境的需求（包括裝置驅動程式和自訂執行檔）"
 
 #: src/intro.md:170
-#, fuzzy
 msgid "Engineering Productivity"
 msgstr "工程生產力"
 
 #: src/intro.md:172
-#, fuzzy
 msgid "Write a driver once, not twice"
 msgstr "編寫一次驅動程序，無需編寫兩次"
 
 #: src/intro.md:173
-#, fuzzy
 msgid ""
 "Linux is **open, measurable, reproducible, and straightforward to update**"
-msgstr "Linux 是**開放的、可測量的、可複製的、並且易於更新**"
+msgstr "Linux 是 **開放、可衡量、可重現且易於更新的**"
 
 #: src/intro.md:174
-#, fuzzy
 msgid "Linux already has drivers for almost everything"
 msgstr "Linux 已經為幾乎所有東西提供了驅動程式"
 
 #: src/intro.md:175
-#, fuzzy
 msgid "Kernel Engineers = Firmware Engineers"
-msgstr "核心工程師=韌體工程師"
+msgstr "核心（kernel）工程師=韌體工程師"
 
 #: src/intro.md:176
-#, fuzzy
 msgid "Many more Engineers know Linux than know UEFI"
 msgstr "了解 Linux 的工程師比了解 UEFI 的工程師多得多"
 
 #: src/intro.md:177
-#, fuzzy
 msgid "Reduced build time"
 msgstr "減少建置時間"
 
 #: src/intro.md:178
-#, fuzzy
 msgid "**30s** for initramfs"
-msgstr "initramfs 需要 30 秒"
+msgstr "initramfs 需要 **30 秒**"
 
 #: src/intro.md:179
-#, fuzzy
 msgid "**15s** for kernel (incremental)"
-msgstr "核心需要 **15 秒**（增量）"
+msgstr "核心需要 **15 秒**（增量式）"
 
 #: src/intro.md:180
-#, fuzzy
 msgid "**~15s** to repack the bios image (using fiano/utk)"
-msgstr "大約 15 秒重新包裝 bios 映像（使用 fiano/utk）"
+msgstr "大約 **15 秒** 重新包裝 bios 映像檔（使用 fiano/utk）"
 
 #: src/intro.md:181
-#, fuzzy
 msgid "**Total: ~1m** for a new full bios image, ready to be tested"
-msgstr "**總計：約 1m** 用於新的完整 BIOS 映像，可供測試"
+msgstr "**總計：約 1 分鐘** 用於新的完整 BIOS 映像，可供測試"
 
 #: src/intro.md:182
-#, fuzzy
 msgid "Testing and debugging"
-msgstr "測試和調試"
+msgstr "測試和除錯"
 
 #: src/intro.md:183
-#, fuzzy
 msgid "`diskboot` and `pxeboot` already have unit tests"
-msgstr "`diskboot` 和 `pxeboot` 已經有單元測試"
+msgstr "`diskboot` 和 `pxeboot` 已經有單元測試 （unit tests）"
 
 #: src/intro.md:184
-#, fuzzy
 msgid "Easier to write tests using resources (like network) with Linux"
-msgstr "使用 Linux 資源（如網路）編寫測試更容易"
+msgstr "使用 Linux 資源（如網路）使編寫測試更容易"
 
 #: src/intro.md:185
-#, fuzzy
 msgid ""
 "Open-source projects such as u-root follow excellent software practices such "
 "as running automated test on each submitted change"
 msgstr "u-root 等開源專案遵循優秀的軟體實踐，例如對每個提交的變更執行自動化測試"
 
 #: src/intro.md:187
-#, fuzzy
 msgid "Much easier to debug Go user-space applications"
-msgstr "更容易調試 Go 用戶空間應用程式"
+msgstr "更容易除錯的 Go 用戶空間（user-space）應用程式"
 
 #: src/intro.md:188
-#, fuzzy
 msgid "Test with a kernel in QEMU"
 msgstr "使用 QEMU 中的核心進行測試"
 

--- a/po/zh-TW.po
+++ b/po/zh-TW.po
@@ -1,0 +1,8173 @@
+
+msgid ""
+msgstr ""
+"Project-Id-Version: LinuxBoot\n"
+"POT-Creation-Date: 2025-04-28T16:48:12+08:00\n"
+"PO-Revision-Date: 2025-04-28 16:48+0800\n"
+"Last-Translator: CHIAOSUNG YANG <chiao.cs.yang@gmail.com>\n"
+"Language-Team: Language zh-TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh-TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1 src/intro.md:1
+#, fuzzy
+msgid "LinuxBoot Introduction"
+msgstr "LinuxBoot介紹"
+
+#: src/SUMMARY.md:2 src/use-cases.md:1
+#, fuzzy
+msgid "Use cases"
+msgstr "用例"
+
+#: src/SUMMARY.md:3
+#, fuzzy
+msgid "Talks and news coverage"
+msgstr "演講和新聞報道"
+
+#: src/SUMMARY.md:4 src/components.md:1
+#, fuzzy
+msgid "LinuxBoot Components"
+msgstr "LinuxBoot 元件"
+
+#: src/SUMMARY.md:5 src/tools-evaluation.md:1
+#, fuzzy
+msgid "Evaluation of tools"
+msgstr "工具評估"
+
+#: src/SUMMARY.md:6 src/u-root.md:1
+#, fuzzy
+msgid "All about u-root"
+msgstr "關於 u-root"
+
+#: src/SUMMARY.md:7 src/u-root-qemu-demo.md:1
+#, fuzzy
+msgid "u-root demo with QEMU"
+msgstr "使用 QEMU 的 u-root 演示"
+
+#: src/SUMMARY.md:8
+#, fuzzy
+msgid "LinuxBoot utilities"
+msgstr "Linux啟動實用程式"
+
+#: src/SUMMARY.md:9 src/utilities/UEFI_Tool_Kit.md:1
+#, fuzzy
+msgid "UEFI Tool Kit"
+msgstr "UEFI工具包"
+
+#: src/SUMMARY.md:10
+#, fuzzy
+msgid "The magical cpu command"
+msgstr "神奇的 CPU 指令"
+
+#: src/SUMMARY.md:11
+#, fuzzy
+msgid "Device Under Test"
+msgstr "被測設備"
+
+#: src/SUMMARY.md:12 src/implementation.md:1
+#, fuzzy
+msgid "Implementing LinuxBoot"
+msgstr "實作 LinuxBoot"
+
+#: src/SUMMARY.md:13 src/coreboot.u-root.systemboot/index.md:1
+#, fuzzy
+msgid "LinuxBoot using coreboot, u-root and systemboot"
+msgstr "使用 coreboot、u-root 和 systemboot 的 LinuxBoot"
+
+#: src/SUMMARY.md:14 src/glossary.md:1
+#, fuzzy
+msgid "Glossary"
+msgstr "詞彙表"
+
+#: src/SUMMARY.md:15 src/history.md:1
+#, fuzzy
+msgid "History"
+msgstr "歷史"
+
+#: src/SUMMARY.md:16 src/case_studies/index.md:1
+#, fuzzy
+msgid "Case Studies"
+msgstr "案例研究"
+
+#: src/SUMMARY.md:17
+#, fuzzy
+msgid "Ampere study"
+msgstr "安培研究"
+
+#: src/SUMMARY.md:18
+#, fuzzy
+msgid "Google study"
+msgstr "谷歌研究"
+
+#: src/SUMMARY.md:19
+#, fuzzy
+msgid "OCP TiogaPass"
+msgstr "OCP 泰奧加山口"
+
+#: src/SUMMARY.md:20
+#, fuzzy
+msgid "Frequently Asked Questions"
+msgstr "常見問題"
+
+#: src/intro.md:3
+#, fuzzy
+msgid ""
+"This is the official “LinuxBoot Book” for the LinuxBoot project. The book:"
+msgstr "這是 LinuxBoot 專案的官方「LinuxBoot 書籍」。這本書："
+
+#: src/intro.md:5
+#, fuzzy
+msgid "Describes the LinuxBoot project"
+msgstr "描述 LinuxBoot 項目"
+
+#: src/intro.md:6
+#, fuzzy
+msgid "Explains why you would want to use LinuxBoot"
+msgstr "解釋為什麼要使用 LinuxBoot"
+
+#: src/intro.md:7
+#, fuzzy
+msgid "Describes the components that comprise LinuxBoot"
+msgstr "描述組成 LinuxBoot 的元件"
+
+#: src/intro.md:8
+#, fuzzy
+msgid "Highlights the differences between other boot processes and LinuxBoot"
+msgstr "重點介紹其他啟動過程與 LinuxBoot 之間的差異"
+
+#: src/intro.md:9
+#, fuzzy
+msgid "Guides you through the steps needed to implement LinuxBoot"
+msgstr "指導您完成實作 LinuxBoot 所需的步驟"
+
+#: src/intro.md:11
+#, fuzzy
+msgid "What is LinuxBoot?"
+msgstr "什麼是 LinuxBoot？"
+
+#: src/intro.md:13
+#, fuzzy
+msgid ""
+"LinuxBoot is the idea of replacing proprietary or corporate-driven "
+"late-stage boot [firmware](./glossary.md) with the Linux kernel and a "
+"community-based user-space. That idea grew into a project that over the "
+"years includes various initiatives with the overarching goal of moving from "
+"obscure and complex firmware to simpler and open source firmware."
+msgstr ""
+"LinuxBoot 的想法是用 Linux "
+"核心和基於社群的用戶空間取代專有或企業驅動的後期啟動[韌體](./glossary.md)。這個想法逐漸發展成為一個項目，多年來包括各種舉措，其總體目標是從晦澀複雜的韌體轉變為更簡單和開源的韌體。"
+
+#: src/intro.md:19
+msgid ""
+"The LinuxBoot project provides two reference implementations; `linuxboot` "
+"and Heads. The [`linuxboot`](https://github.com/linuxboot/linuxboot) build "
+"system outputs a boot payload consisting of a Linux kernel and an "
+"[initramfs](https://de.wikipedia.org/wiki/Initramfs) that contains a minimal "
+"Golang user-space built using [u-root](https://github.com/u-root/u-root)."
+msgstr ""
+
+#: src/intro.md:25
+#, fuzzy
+msgid ""
+"The Heads build system is more focused on local attestation, TPM DUK "
+"seal/unseal operations, GPG-based security measurement, reproducible builds "
+"and uses BusyBox to provide a much larger suite of Linux tools allowing it "
+"to also be used as a recovery environment."
+msgstr ""
+"Heads 構建系統更側重於本地證明、TPM DUK 密封/解封操作、基於 GPG 的安全測量、可重現構建，並使用 BusyBox 提供更大的 "
+"Linux 工具套件，使其也可以用作恢復環境。"
+
+#: src/intro.md:30
+#, fuzzy
+msgid "Many other implementations exist independently of the project:"
+msgstr "許多其他實作獨立於專案而存在："
+
+#: src/intro.md:32
+#, fuzzy
+msgid ""
+"[petitboot](https://github.com/open-power/petitboot) under the OpenPOWER "
+"project originally targeting the PS3"
+msgstr ""
+"[petitboot](https://github.com/open-power/petitboot) 屬於 OpenPOWER 項目，最初針對的是 "
+"PS3"
+
+#: src/intro.md:34
+#, fuzzy
+msgid ""
+"[k-boot](https://github.com/BayLibre/k-boot) developed by BayLibre in 2023 "
+"using BusyBox"
+msgstr ""
+"[k-boot](https://github.com/BayLibre/k-boot) 由 BayLibre 於 2023 年使用 BusyBox 開發"
+
+#: src/intro.md:36
+#, fuzzy
+msgid "[nmbl](https://github.com/rhboot/nmbl-poc) developed by RedHat in 2024"
+msgstr "[nmbl](https://github.com/rhboot/nmbl-poc) 由 RedHat 於 2024 年開發"
+
+#: src/intro.md:37
+#, fuzzy
+msgid "[ZFSBootMenu](https://docs.zfsbootmenu.org/en/latest)"
+msgstr "[ZFSBootMenu](https://docs.zfsbootmenu.org/en/latest)"
+
+#: src/intro.md:39
+#, fuzzy
+msgid ""
+"And there is a long history of similar implementations including projects "
+"that are no longer maintained:"
+msgstr "類似的實作由來已久，包括不再維護的專案："
+
+#: src/intro.md:42
+#, fuzzy
+msgid ""
+"MILO on Alpha started before 2000 (see [What is "
+"MILO?](https://tldp.org/HOWTO/MILO-HOWTO/what-section.html))"
+msgstr ""
+"Alpha 版 MILO 於 2000 年之前就已啟動（請參閱[什麼是 "
+"MILO？](https://tldp.org/HOWTO/MILO-HOWTO/what-section.html)）"
+
+#: src/intro.md:44
+#, fuzzy
+msgid "kboot developed by Werner Almesberger in 2005"
+msgstr "kboot 由 Werner Almesberger 於 2005 年開發"
+
+#: src/intro.md:46
+#, fuzzy
+msgid ""
+"These projects all attempt to reduce the role of firmware to a small, "
+"fixed-function core whose only purpose is to get a flash-based Linux kernel "
+"started. This “bare essentials” firmware prepares the hardware and starts a "
+"Linux kernel and a user-space environment will run on the machine. Go is the "
+"recommended user-space environment, but is not required."
+msgstr ""
+"這些專案都試圖將韌體的作用簡化為一個小型的、固定功能的核心，其唯一目的是啟動基於快閃記憶體的 Linux 核心。這個「基本要素」韌體準備硬體並啟動 "
+"Linux 內核，並且用戶空間環境將在機器上運行。 Go 是建議的使用者空間環境，但不是必需的。"
+
+#: src/intro.md:52
+#, fuzzy
+msgid "Why LinuxBoot is needed"
+msgstr "為什麼需要 LinuxBoot"
+
+#: src/intro.md:54
+#, fuzzy
+msgid ""
+"Sometimes firmware contains drivers and utilities. They can have bugs, or be "
+"unmaintained, which can be a source of problems and security issues. "
+"LinuxBoot replaces proprietary, closed-source, vendor-supplied firmware "
+"drivers with Linux drivers. This enables engineers writing Linux drivers and "
+"engineers writing firmware drivers to focus on one set of drivers. Those "
+"drivers will, as a result, have a larger set of contributors and reviewers, "
+"and because the drivers are part of Linux, standard industry coding "
+"infrastructure can be used to improve them. Finally, because these Linux "
+"drivers are currently being run around the clock at scale, they will have "
+"fewer bugs."
+msgstr ""
+"有時韌體包含驅動程式和實用程式。它們可能存在錯誤，或無人維護，這可能會成為問題和安全問題的根源。 LinuxBoot 以 Linux "
+"驅動程式取代了專有的、閉源的、供應商提供的韌體驅動程式。這使得編寫 Linux "
+"驅動程式的工程師和編寫韌體驅動程式的工程師能夠專注於一組驅動程式。因此，這些驅動程式將擁有更多的貢獻者和審查者，並且由於這些驅動程式是 Linux "
+"的一部分，因此可以使用標準產業編碼基礎架構來改進它們。最後，由於這些 Linux 驅動程式目前正在大規模全天候運行，因此它們的錯誤會更少。"
+
+#: src/intro.md:64
+#, fuzzy
+msgid "What LinuxBoot does"
+msgstr "LinuxBoot 的作用"
+
+#: src/intro.md:66
+#, fuzzy
+msgid ""
+"LinuxBoot replaces many Driver Execution Environment (DXE) modules used by "
+"Unified Extensible Firmware Interface (UEFI) and other firmware, "
+"particularly the network stack and file system modules, with Linux "
+"applications."
+msgstr ""
+"LinuxBoot 以 Linux 應用程式取代了統一可擴充韌體介面 (UEFI) 和其他韌體所使用的許多驅動程式執行環境 (DXE) "
+"模組，特別是網路堆疊和檔案系統模組。"
+
+#: src/intro.md:70
+#, fuzzy
+msgid ""
+"LinuxBoot brings up the Linux kernel as a DXE in flash ROM instead of the "
+"UEFI shell. The Linux kernel, with a provided Go based user-space, can then "
+"load the runtime kernel. The LinuxBoot paradigm enables writing traditional "
+"firmware applications such as boot loader, debugging, diagnosis, and error "
+"detection applications as cross-architecture and cross-platform portable "
+"Linux applications."
+msgstr ""
+"LinuxBoot 將 Linux 核心作為快閃 ROM 中的 DXE 而不是 UEFI shell 啟動。然後，Linux 核心可以透過提供的基於 "
+"Go 的使用者空間來載入運行時核心。 LinuxBoot "
+"範例支援將傳統韌體應用程式（如開機載入程式、偵錯、診斷和錯誤檢測應用程式）編寫為跨架構和跨平台的可移植 Linux 應用程式。"
+
+#: src/intro.md:77
+#, fuzzy
+msgid ""
+"When Linux boots it needs a root file system with utilities. One such root "
+"filesystem used for LinuxBoot is based on u-root standard utilities written "
+"in Go. The following diagram shows the current state of the UEFI boot "
+"process and what is planned for the transition to LinuxBoot."
+msgstr ""
+"當 Linux 啟動時，它需要一個具有實用程式的根檔案系統。 LinuxBoot 使用的一個這樣的根檔案系統是基於用 Go 編寫的 u-root "
+"標準實用程式。下圖顯示了 UEFI 啟動過程的目前狀態以及向 LinuxBoot 過渡的計畫。"
+
+#: src/intro.md:82
+#, fuzzy
+msgid ""
+"[![comparison of UEFI boot and "
+"LinuxBoot](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
+msgstr ""
+"[![UEFI 啟動與 LinuxBoot "
+"的比較](../images/UEFI-versus-LinuxBoot.svg)](../images/UEFI-versus-LinuxBoot.svg)"
+
+#: src/intro.md:84
+#, fuzzy
+msgid "Benefits of using the Go user-space environment and compiler"
+msgstr "使用 Go 使用者空間環境和編譯器的好處"
+
+#: src/intro.md:86
+#, fuzzy
+msgid ""
+"Go is a systems programming language created by Google. Go has strong "
+"typing, language level support for concurrency, inter-process communication "
+"via channels, runtime type safety and other protective measures, dynamic "
+"allocation and garbage collection, and closures. Go has a package name "
+"notation similar to Java that makes it clear to determine what packages a "
+"given program needs."
+msgstr ""
+"Go 是由 Google 創建的系統程式語言。 Go "
+"具有強類型、語言級別的並發支援、透過通道進行進程間通訊、運行時類型安全性和其他保護措施、動態分配和垃圾收集以及閉包。 Go 具有與 Java "
+"類似的套件名稱符號，可以清楚地確定給定程式需要哪些套件。"
+
+#: src/intro.md:92
+#, fuzzy
+msgid ""
+"The modern language constructs make Go a much safer language than C. This "
+"safety is critical for network-attached embedded systems, which usually have "
+"network utilities written in C, including web servers, network servers "
+"including `sshd`, and programs that provide access to a command interpreter, "
+"itself written in C. All are proving to be vulnerable to the attack-rich "
+"environment that the Internet has become."
+msgstr ""
+"現代語言結構使 Go 成為一種比 C 更安全的語言。這種安全性對於網路連接嵌入式系統至關重要，這些系統通常具有用 C 編寫的網路實用程序，包括 Web "
+"伺服器、包括「sshd」的網路伺服器以及提供對命令解釋器的存取的程式（本身以 C 編寫）。事實證明，所有這些都容易受到互聯網已成為攻擊頻繁的環境的影響。"
+
+#: src/intro.md:99
+#, fuzzy
+msgid ""
+"Even the most skilled programmers can make mistakes that in C can be "
+"unrecoverable, especially on network connected systems. Currently, even the "
+"lowest-level firmware in our PCs, printers, and thermostats is "
+"network-connected. These programming mistakes are either impossible to make "
+"in Go or, if made, are detected at runtime and result in the program exiting."
+msgstr ""
+"即使是最熟練的程式設計師也會犯下 C "
+"語言中無法恢復的錯誤，尤其是在網路連線系統上。目前，即使我們個人電腦、印表機和恆溫器中最低等級的韌體也是連網的。這些程式錯誤要么在 Go "
+"中不可能犯，要么如果犯了，則會在運行時檢測到並導致程式退出。"
+
+#: src/intro.md:105
+#, fuzzy
+msgid ""
+"The case for using a high-level, safe language like Go in low level embedded "
+"firmware might be stronger than for user programs, because exploits at the "
+"firmware level are nearly impossible to detect and mitigate."
+msgstr "在低階嵌入式韌體中使用像 Go 這樣的高級安全語言的情況可能比用戶程式更強烈，因為韌體層級的漏洞幾乎不可能被檢測和緩解。"
+
+#: src/intro.md:109
+#, fuzzy
+msgid ""
+"The challenge to using Go in a storage-constrained environment such as "
+"firmware is that advanced language features lead to big binaries. Even a "
+"date program is about 2 MiB. One Go binary, implementing one function, is "
+"twice as large as a BusyBox binary implementing many functions. Currently, a "
+"typical BIOS FLASH part is 16 MiB. Fitting many Go binaries into a single "
+"BIOS flash part is not practical. The Go compiler is fast and its sheer "
+"speed suggests a solution of having programs compiled only when they are "
+"used. With this approach, you can build a root file system that has almost "
+"no binaries except the Go compiler itself. The compiled programs and "
+"packages can be saved to a RAM-based file system. Another solution is to "
+"compile everything together into one BusyBox-style program. Alternatively, "
+"programs can be fetched over the network, but compiling dynamically with Go "
+"or creating a BusyBox program are the recommended solutions."
+msgstr ""
+"在韌體等儲存受限的環境中使用 Go 的挑戰在於高階語言特性會導致二進位檔案很大。即使是約會程序也大約有 2 MiB。一個實現一個功能的 Go "
+"二進位檔案的大小是實現多個功能的 BusyBox 二進位檔案的兩倍。目前，典型的 BIOS FLASH 部分為 16MiB。將許多 Go "
+"二進位檔案裝入單一 BIOS 快閃記憶體部分是不切實際的。 Go "
+"編譯器速度很快，其速度顯示只有在使用程式時才對其進行編譯的解決方案。透過這種方法，您可以建立一個除了 Go "
+"編譯器本身之外幾乎沒有二進位檔案的根檔案系統。編譯後的程式和套件可以儲存到基於 RAM 的檔案系統中。另一個解決方案是將所有內容編譯成一個 "
+"BusyBox 風格的程式。或者，可以透過網路取得程序，但使用 Go 動態編譯或建立 BusyBox 程式是建議的解決方案。"
+
+#: src/intro.md:123
+#, fuzzy
+msgid "Benefits of LinuxBoot with UEFI servers"
+msgstr "LinuxBoot 與 UEFI 伺服器的優勢"
+
+#: src/intro.md:125
+#, fuzzy
+msgid ""
+"Most server firmware is based on Intel’s Universal Extensible Firmware "
+"Interface (UEFI). LinuxBoot provides the following benefits over UEFI:"
+msgstr "大多數伺服器韌體基於英特爾的通用可擴展韌體介面 (UEFI)。與 UEFI 相比，LinuxBoot 具有以下優點："
+
+#: src/intro.md:128
+#, fuzzy
+msgid "Reliability"
+msgstr "可靠性"
+
+#: src/intro.md:130
+#, fuzzy
+msgid ""
+"Improves boot reliability by replacing lightly-tested firmware drivers with "
+"hardened Linux drivers"
+msgstr "透過使用強化的 Linux 驅動程式取代未經充分測試的韌體驅動程式來提高啟動可靠性"
+
+#: src/intro.md:132
+#, fuzzy
+msgid ""
+"Proven approach for almost 20 years in military, consumer electronics, and "
+"supercomputers – wherever reliability and performance are paramount"
+msgstr "近 20 年來，在軍事、消費性電子和超級電腦領域，可靠性和性能至關重要的領域，該方法已得到驗證"
+
+#: src/intro.md:134
+#, fuzzy
+msgid ""
+"Fault Tolerance - Linux isolates processes\\*\\* \\*\\*(for example, when "
+"`pxeboot` fails catastrophically, `diskboot` still works afterwards)"
+msgstr "容錯 - Linux 隔離程序\\*\\* \\*\\*（例如，當「pxeboot」發生災難性故障時，「diskboot」仍然可以運作）"
+
+#: src/intro.md:137
+#, fuzzy
+msgid "Security"
+msgstr "安全"
+
+#: src/intro.md:139
+#, fuzzy
+msgid "Move “Ring 0” boot loaders to “Ring 3”"
+msgstr "將“Ring 0”引導程式移至“Ring 3”"
+
+#: src/intro.md:140
+#, fuzzy
+msgid "`pxeboot` and `diskboot` do parsing and other logic in user-space"
+msgstr "`pxeboot` 和 `diskboot` 在使用者空間進行解析和其他邏輯"
+
+#: src/intro.md:141
+#, fuzzy
+msgid "Go provides memory safety and type safety"
+msgstr "Go 提供記憶體安全和類型安全"
+
+#: src/intro.md:142
+#, fuzzy
+msgid "A buggy parser is much less likely to affect other programs"
+msgstr "有缺陷的解析器不太可能影響其他程式"
+
+#: src/intro.md:143
+#, fuzzy
+msgid "Kernel security patches can apply to firmware"
+msgstr "核心安全性補丁可應用於韌體"
+
+#: src/intro.md:145
+#, fuzzy
+msgid "Flexibility"
+msgstr "靈活性"
+
+#: src/intro.md:147
+#, fuzzy
+msgid ""
+"Can be used with coreboot, u-boot, OpenPOWER Abstraction Layer (OPAL), "
+"SlimBootLoader, ARM Trusted Firmware (ATF)"
+msgstr ""
+"可與 coreboot、u-boot、OpenPOWER 抽象層 (OPAL)、SlimBootLoader、ARM 可信任韌體 (ATF) 搭配"
+
+#: src/intro.md:149
+#, fuzzy
+msgid ""
+"Can boot multiple operating systems (Linux, Berkeley UNIX (BSD), XEN, "
+"Windows)"
+msgstr "可啟動多個作業系統（Linux、Berkeley UNIX（BSD）、XEN、Windows）"
+
+#: src/intro.md:151
+#, fuzzy
+msgid "Supports the following server mainboards:"
+msgstr "支援以下伺服器主機板："
+
+#: src/intro.md:152
+#, fuzzy
+msgid "QEMU emulated Q35 systems"
+msgstr "QEMU 模擬 Q35 系統"
+
+#: src/intro.md:153
+#, fuzzy
+msgid "[Intel S2600WF](https://trmm.net/S2600wf)"
+msgstr "[Intel S2600WF]（https://trmm.net/S2600wf）"
+
+#: src/intro.md:154
+#, fuzzy
+msgid "[Dell R630](https://trmm.net/NERF)"
+msgstr "戴爾 R630"
+
+#: src/intro.md:155
+#, fuzzy
+msgid "Winterfell Open Compute node"
+msgstr "Winterfell 開放式運算節點"
+
+#: src/intro.md:156
+#, fuzzy
+msgid "Leopard Open Compute node"
+msgstr "Leopard 開放式運算節點"
+
+#: src/intro.md:157
+#, fuzzy
+msgid "Tioga Pass Open Compute node"
+msgstr "Tioga Pass 開放運算節點"
+
+#: src/intro.md:158
+#, fuzzy
+msgid "Monolake Open Compute node (not tested)"
+msgstr "Monolake Open Compute 節點（未經測試）"
+
+#: src/intro.md:160
+#, fuzzy
+msgid "Boot speed"
+msgstr "啟動速度"
+
+#: src/intro.md:162
+msgid ""
+"Improves boot time by removing unnecessary code; typically makes boot 20 "
+"times faster"
+msgstr ""
+
+#: src/intro.md:165
+#, fuzzy
+msgid "Customization"
+msgstr "客製化"
+
+#: src/intro.md:167
+#, fuzzy
+msgid ""
+"Allows customization of the initramfs runtime to support site-specific needs "
+"(both device drivers as well as custom executables)"
+msgstr "允許自訂 initramfs 運行時以支援特定網站的需求（裝置驅動程式和自訂執行檔）"
+
+#: src/intro.md:170
+#, fuzzy
+msgid "Engineering Productivity"
+msgstr "工程生產力"
+
+#: src/intro.md:172
+#, fuzzy
+msgid "Write a driver once, not twice"
+msgstr "編寫一次驅動程序，無需編寫兩次"
+
+#: src/intro.md:173
+#, fuzzy
+msgid ""
+"Linux is **open, measurable, reproducible, and straightforward to update**"
+msgstr "Linux 是**開放的、可測量的、可複製的、並且易於更新**"
+
+#: src/intro.md:174
+#, fuzzy
+msgid "Linux already has drivers for almost everything"
+msgstr "Linux 已經為幾乎所有東西提供了驅動程式"
+
+#: src/intro.md:175
+#, fuzzy
+msgid "Kernel Engineers = Firmware Engineers"
+msgstr "核心工程師=韌體工程師"
+
+#: src/intro.md:176
+#, fuzzy
+msgid "Many more Engineers know Linux than know UEFI"
+msgstr "了解 Linux 的工程師比了解 UEFI 的工程師多得多"
+
+#: src/intro.md:177
+#, fuzzy
+msgid "Reduced build time"
+msgstr "減少建置時間"
+
+#: src/intro.md:178
+#, fuzzy
+msgid "**30s** for initramfs"
+msgstr "initramfs 需要 30 秒"
+
+#: src/intro.md:179
+#, fuzzy
+msgid "**15s** for kernel (incremental)"
+msgstr "核心需要 **15 秒**（增量）"
+
+#: src/intro.md:180
+#, fuzzy
+msgid "**~15s** to repack the bios image (using fiano/utk)"
+msgstr "大約 15 秒重新包裝 bios 映像（使用 fiano/utk）"
+
+#: src/intro.md:181
+#, fuzzy
+msgid "**Total: ~1m** for a new full bios image, ready to be tested"
+msgstr "**總計：約 1m** 用於新的完整 BIOS 映像，可供測試"
+
+#: src/intro.md:182
+#, fuzzy
+msgid "Testing and debugging"
+msgstr "測試和調試"
+
+#: src/intro.md:183
+#, fuzzy
+msgid "`diskboot` and `pxeboot` already have unit tests"
+msgstr "`diskboot` 和 `pxeboot` 已經有單元測試"
+
+#: src/intro.md:184
+#, fuzzy
+msgid "Easier to write tests using resources (like network) with Linux"
+msgstr "使用 Linux 資源（如網路）編寫測試更容易"
+
+#: src/intro.md:185
+#, fuzzy
+msgid ""
+"Open-source projects such as u-root follow excellent software practices such "
+"as running automated test on each submitted change"
+msgstr "u-root 等開源專案遵循優秀的軟體實踐，例如對每個提交的變更執行自動化測試"
+
+#: src/intro.md:187
+#, fuzzy
+msgid "Much easier to debug Go user-space applications"
+msgstr "更容易調試 Go 用戶空間應用程式"
+
+#: src/intro.md:188
+#, fuzzy
+msgid "Test with a kernel in QEMU"
+msgstr "使用 QEMU 中的核心進行測試"
+
+#: src/use-cases.md:3
+#, fuzzy
+msgid ""
+"The general concept of using a Linux kernel to boot into an operating system "
+"sounds simple at first glance. The challenges in the details, in part not "
+"only limited to using Linux, are being discussed in this chapter, with ideas "
+"on solving specific problems in the domain of bootloaders."
+msgstr ""
+"使用 Linux 核心啟動作業系統的一般概念乍看之下很簡單。本章討論了細節中的挑戰，部分挑戰不僅限於使用 "
+"Linux，還提出了解決引導程式領域中特定問題的想法。"
+
+#: src/use-cases.md:8
+#, fuzzy
+msgid "Constrained environments"
+msgstr "受限環境"
+
+#: src/use-cases.md:10
+#, fuzzy
+msgid ""
+"Booting a system means dealing with constraints. Those can have either of "
+"two effects: spark creativity or keep you from pursuing a goal. On foot, you "
+"can only reach as far in a day, whereas a vehicle gets you much further. "
+"With LinuxBoot, we want to take the chance to reevaluate contemporary "
+"designs and go beyond."
+msgstr ""
+"啟動系統意味著要處理約束。這些可能會產生兩種影響：激發創造力或阻止你追求目標。步行一天只能到達這麼遠，而乘車可以到達更遠的地方。借助 "
+"LinuxBoot，我們希望藉此機會重新評估當代設計並超越。"
+
+#: src/use-cases.md:16
+#, fuzzy
+msgid ""
+"When it comes to hardware, the vendor would choose the parts for their "
+"product and consider them in their price calculation."
+msgstr "當涉及硬體時，供應商會選擇其產品的零件並在價格計算中考慮它們。"
+
+#: src/use-cases.md:19
+#, fuzzy
+msgid ""
+"One main constraint is the initial boot source. A System-on-Chip (SoC) "
+"typically starts off with a mask ROM and continues with a simple storage "
+"part, which may range from a SPI flash of a few megabytes up to eMMC or SD "
+"cards of hundreds of megabytes or even gigabytes."
+msgstr ""
+"一個主要的限制是初始啟動來源。系統單晶片 (SoC) 通常從掩模 ROM 開始，然後是簡單的儲存部分，其範圍可能從幾兆位元組的 SPI "
+"快閃記憶體到數百兆位元組甚至千兆位元組的 eMMC 或 SD 卡。"
+
+#: src/use-cases.md:24
+#, fuzzy
+msgid ""
+"We neglect other storages here that are attached via NVMe, SATA or other "
+"high-speed buses, because those are commonly not supported by mask ROMs. "
+"They are, on the other hand, what a bootloader offers to boot from, as well "
+"as network sources."
+msgstr ""
+"我們忽略了透過 NVMe、SATA 或其他高速匯流排連接的其他存儲，因為這些儲存通常不受遮罩 ROM "
+"支援。另一方面，它們是引導程式提供的引導來源以及網路來源。"
+
+#: src/use-cases.md:29
+#, fuzzy
+msgid "Embedded devices"
+msgstr "嵌入式裝置"
+
+#: src/use-cases.md:31
+#, fuzzy
+msgid ""
+"Many devices, nowadays known as IoT (Internet of Things), appliances, or "
+"similar, have a narrow use case. They are meant to perform a specific set of "
+"tasks, and thus can be tailored for it. In hardware terms, that often means "
+"an SoC, a bit of storage, and peripherals. Debug interfaces are reduced or "
+"removed for the final product."
+msgstr ""
+"如今，許多設備（稱為 IoT（物聯網）、家用電器或類似設備）的用途都很狹窄。它們旨在執行一組特定的任務，因此可以進行客製化。從硬體角度來說，這通常意味著 "
+"SoC、一些儲存空間和周邊設備。最終產品的調試介面被減少或刪除。"
+
+#: src/use-cases.md:37
+#, fuzzy
+msgid "Desktop, laptop, workstation and server systems"
+msgstr "桌上型電腦、筆記型電腦、工作站和伺服器系統"
+
+#: src/use-cases.md:39
+#, fuzzy
+msgid ""
+"At this point, many systems are still based on x86 processors, coming with a "
+"SPI flash on the board. While laptops and desktops mostly have a mere 16 or "
+"32 megabytes to offer, high-end servers and workstations already have 64, "
+"and even a second whole system called the Board Management Controller (BMC), "
+"which has its own firmware and corresponding storage. Designs around those "
+"constraints vary among OEMs."
+msgstr ""
+"目前，許多系統仍基於 x86 處理器，主機板上配有 SPI 快閃記憶體。雖然筆記型電腦和桌上型電腦大多只有 16 或 32 MB "
+"的儲存空間，但高階伺服器和工作站已經擁有 64 MB 的儲存空間，甚至還有第二個完整的系統，稱為主機板管理控制器 "
+"(BMC)，它有自己的韌體和相應的儲存空間。針對這些限制的設計因 OEM 而異。"
+
+#: src/use-cases.md:46
+#, fuzzy
+msgid ""
+"Note that it need not be that way. Arm based, RISC-V based and other systems "
+"already show that you can expect more, such as booting off eMMC. Laptops and "
+"desktop boards in that range are available as of now, even some servers and "
+"workstations."
+msgstr ""
+"請注意，事實並非必須如此。基於 Arm、基於 RISC-V 和其他系統已經表明您可以期待更多，例如從 eMMC "
+"啟動。目前，該範圍內的筆記型電腦和桌上型電腦主機板已經上市，甚至一些伺服器和工作站也已上市。"
+
+#: src/use-cases.md:51
+#, fuzzy
+msgid "Single Board Computers (SBCs)"
+msgstr "單板計算機 (SBC)"
+
+#: src/use-cases.md:53
+#, fuzzy
+msgid ""
+"The SBC market has grown to such a degree that credit card size boards "
+"nowadays comes with both small storage parts that can act as boot sources as "
+"well as PCIe connectors that can hold NVMes of gigabytes and terabytes of "
+"storage. This gives us the opportunity to work out a boot flow that provides "
+"the end user with a very rich environment already early on before the main "
+"operating system is loaded."
+msgstr ""
+"SBC 市場已經發展到如此程度，以至於如今信用卡大小的主機板既配備了可以作為啟動來源的小型儲存零件，也配備了可以容納 GB 和 TB 級儲存的 NVMe "
+"的 PCIe 連接器。這使我們有機會制定一個啟動流程，在主作業系統載入之前儘早為最終用戶提供非常豐富的環境。"
+
+#: src/talks-news.md:1
+#, fuzzy
+msgid "Coverage"
+msgstr "覆蓋範圍"
+
+#: src/talks-news.md:3
+#, fuzzy
+msgid "Talks"
+msgstr "會談"
+
+#: src/talks-news.md:5 src/talks-news.md:39
+#, fuzzy
+msgid "Date"
+msgstr "日期"
+
+#: src/talks-news.md:5
+#, fuzzy
+msgid "Presenter"
+msgstr "主持人"
+
+#: src/talks-news.md:5 src/talks-news.md:39
+#, fuzzy
+msgid "Title"
+msgstr "標題"
+
+#: src/talks-news.md:7
+#, fuzzy
+msgid "12/27/2016"
+msgstr "2016年12月27日"
+
+#: src/talks-news.md:7 src/talks-news.md:9
+#, fuzzy
+msgid "Trammell Hudson"
+msgstr "特拉梅爾·哈德森"
+
+#: src/talks-news.md:7
+#, fuzzy
+msgid "[Bootstraping a slightly more secure laptop](https://trmm.net/Heads_33c3)"
+msgstr "[引導一台更安全的筆記型電腦](https://trmm.net/Heads_33c3)"
+
+#: src/talks-news.md:8
+#, fuzzy
+msgid "10/27/2017"
+msgstr "2017年10月27日"
+
+#: src/talks-news.md:8
+#, fuzzy
+msgid "Ron Minnich"
+msgstr "羅恩·明尼奇"
+
+#: src/talks-news.md:8
+#, fuzzy
+msgid ""
+"Replace your exploit-ridden firmware with a Linux kernel "
+"([YouTube](https://www.youtube.com/watch?v=iffTJ1vPCSo), "
+"[slides](https://schd.ws/hosted_files/osseu17/84/Replace%20UEFI%20with%20Linux.pdf))"
+msgstr ""
+"以 Linux 核心取代漏洞利用的韌體 "
+"([YouTube](https://www.youtube.com/watch?v=iffTJ1vPCSo)、[投影片](https://schd.ws/hosted_files/osseu17/84/Replace%20UEFI%20with%20Linux.pdf))"
+
+#: src/talks-news.md:9
+#, fuzzy
+msgid "12/29/2017"
+msgstr "2017年12月29日"
+
+#: src/talks-news.md:9
+#, fuzzy
+msgid ""
+"[Bringing Linux back to the server BIOS with "
+"LinuxBoot](https://trmm.net/LinuxBoot_34c3)"
+msgstr "[使用 LinuxBoot 將 Linux 重新引入伺服器 BIOS](https://trmm.net/LinuxBoot_34c3)"
+
+#: src/talks-news.md:10
+#, fuzzy
+msgid "09/13/2018"
+msgstr "2018年9月13日"
+
+#: src/talks-news.md:10 src/talks-news.md:11
+#, fuzzy
+msgid "Andrea Barberio, David Hendricks"
+msgstr "安德里亞·巴貝裡奧，大衛·亨德里克斯"
+
+#: src/talks-news.md:10
+#, fuzzy
+msgid ""
+"[Open Source Firmware @ "
+"Facebook](https://www.osfc.io/2018/talks/open-source-firmware-facebook/)"
+msgstr ""
+"[開源韌體@Facebook]（https://www.osfc.io/2018/talks/open-source-firmware-facebook/）"
+
+#: src/talks-news.md:11
+#, fuzzy
+msgid "10/02/2018"
+msgstr "2018年10月2日"
+
+#: src/talks-news.md:11
+#, fuzzy
+msgid ""
+"[Turning Linux Engineers into Firmware "
+"Engineers](https://2018ocpregionalsummit.sched.com/event/F8ax/turning-linux-engineers-into-firmware-engineers) "
+"([slides](https://insomniac.slackware.it/static/2018_ocp_regional_summit_linuxboot_at_facebook.pdf), "
+"[YouTube](https://www.youtube.com/watch?v=i84df1z6mdI))"
+msgstr "將 Linux 工程師轉變為韌體工程師"
+
+#: src/talks-news.md:12
+#, fuzzy
+msgid "06/15/2024"
+msgstr "2024年6月15日"
+
+#: src/talks-news.md:12
+#, fuzzy
+msgid "Marta Lewandowska"
+msgstr "瑪塔·萊萬多夫斯卡"
+
+#: src/talks-news.md:12
+#, fuzzy
+msgid ""
+"[No more boot loader: Please use the kernel "
+"instead](https://pretalx.com/devconf-cz-2024/talk/W3AVCT/)"
+msgstr "[不再使用引導程式：請使用內核取代]（https://pretalx.com/devconf-cz-2024/talk/W3AVCT/）"
+
+#: src/talks-news.md:14
+#, fuzzy
+msgid ""
+"[Make Your System Firmware Faster, More Flexible and Reliable with "
+"LinuxBoot](https://www.usenix.org/conference/lisa18/presentation/barberio) "
+"by [David Hendricks](https://github.com/dhendrix) and [Andrea "
+"Barberio](https://github.com/insomniacslk) at [LISA "
+"2018](https://www.usenix.org/conference/lisa18) "
+"([slides](https://insomniac.slackware.it/static/2018_lisa_linuxboot_at_facebook.pdf)) "
+"(2018-10-31)"
+msgstr ""
+"[使用 LinuxBoot "
+"讓您的系統韌體更快、更靈活、更可靠](https://www.usenix.org/conference/lisa18/presentation/barberio)，作者：[David "
+"Hendricks](https://github.com/dhendrix) 和 [Andrea "
+"Barberio](https://github.com/insniaub.com "
+"2018](https://www.usenix.org/conference/lisa18) "
+"([投影片](https://insomniac.slackware.it/static/2018_lisa_linuxboot_at_facebook.pdf)) "
+"(2018-10-31)"
+
+#: src/talks-news.md:20
+#, fuzzy
+msgid ""
+"[Open Source Firmware - A love "
+"story](https://www.youtube.com/watch?v=xfqKm190dbU) by [Philipp "
+"Deppenwiese](https://cybersecurity.9elements.com) at "
+"[35c3](https://events.ccc.de/congress/2018) "
+"([slides](https://cdn.media.ccc.de/congress/2018/slides-h264-hd/35c3-9778-deu-eng-Open_Source_Firmware_hd-slides.mp4)) "
+"(2018-12-27)"
+msgstr ""
+"[開源韌體 - 一個愛情故事](https://www.youtube.com/watch?v=xfqKm190dbU)，作者：[Philipp "
+"Deppenwiese](https://cybersecurity.9elements.com)，發佈於 "
+"[35c3](https://events.ccc.de/congress/2018) "
+"([幻燈片](https://cdn.media.ccc.de/congress/2018/slides-h264-hd/35c3-9778-deu-eng-Open_Source_Firmware_hd-slides.mp4)) "
+"(2018-12-27)"
+
+#: src/talks-news.md:25
+#, fuzzy
+msgid ""
+"[Open Source Firmware at "
+"Facebook](https://fosdem.org/2019/schedule/event/open_source_firmware_at_facebook/) "
+"by [David Hendricks](https://github.com/dhendrix) and [Andrea "
+"Barberio](https://github.com/insomniacslk) at [FOSDEM "
+"2019](https://fosdem.org/2019/) "
+"([video](https://video.fosdem.org/2019/K.4.401/open_source_firmware_at_facebook.mp4)) "
+"([slides](https://insomniac.slackware.it/static/2019_fosdem_linuxboot_at_facebook.pdf)) "
+"(2019-02-03)"
+msgstr ""
+"[Facebook "
+"上的開源韌體](https://fosdem.org/2019/schedule/event/open_source_firmware_at_facebook/)，作者：[David "
+"Hendricks](https://github.com/dhendrix) 和 [Andrea "
+"Barberio](https://github.com/insomniacslk)，發佈於 "
+"[FFOm2020202020202020202020202020202020)(FF45535959003(F)/30599003())/3059003())/3059590)(FF)555959559595959)話]。 "
+"([影片](https://video.fosdem.org/2019/K.4.401/open_source_firmware_at_facebook.mp4)) "
+"([投影片](https://insomniac.slackware.it/static/2019_fosdem_linuxboot_at__L.pdf)) "
+"(2019-facebook.pdf"
+
+#: src/talks-news.md:32
+#, fuzzy
+msgid ""
+"[Kexec Evolutions for "
+"LinuxBoot](https://www.osfc.io/2022/talks/kexec-evolutions-for-linuxboot/) "
+"by David Hu at OSFC 2021"
+msgstr "David Hu 在 OSFC 2021 上發表的 Kexec 在 LinuxBoot 上的演進"
+
+#: src/talks-news.md:34
+#, fuzzy
+msgid ""
+"[No more boot loader: Please use the kernel "
+"instead](https://pretalx.com/devconf-cz-2024/talk/W3AVCT/) at 2024 DevConf"
+msgstr ""
+"[不再使用開機載入程式：請使用核心](https://pretalx.com/devconf-cz-2024/talk/W3AVCT/) at 2024 "
+"DevConf"
+
+#: src/talks-news.md:37
+#, fuzzy
+msgid "News"
+msgstr "訊息"
+
+#: src/talks-news.md:39
+#, fuzzy
+msgid "Website"
+msgstr "網站"
+
+#: src/talks-news.md:41
+#, fuzzy
+msgid "01/25/2018"
+msgstr "2018年1月25日"
+
+#: src/talks-news.md:41
+#, fuzzy
+msgid "Linux Foundation"
+msgstr "Linux基金會"
+
+#: src/talks-news.md:41
+#, fuzzy
+msgid ""
+"[System Statup gets a Boost with new LinuxBoot "
+"project](https://www.linuxfoundation.org/blog/system-startup-gets-a-boost-with-new-linuxboot-project/)"
+msgstr ""
+"[新的 LinuxBoot "
+"專案輔助系統啟動](https://www.linuxfoundation.org/blog/system-startup-gets-a-boost-with-new-linuxboot-project/)"
+
+#: src/talks-news.md:42
+#, fuzzy
+msgid "02/15/2018"
+msgstr "2018年2月15日"
+
+#: src/talks-news.md:42
+#, fuzzy
+msgid "Linux Journal"
+msgstr "Linux 雜誌"
+
+#: src/talks-news.md:42
+#, fuzzy
+msgid ""
+"[Linux Journal: FOSS Project Spotlight: "
+"LinuxBoot](https://www.linuxjournal.com/content/foss-project-spotlight-linuxboot/)"
+msgstr ""
+"[Linux 期刊：FOSS "
+"專案聚焦：LinuxBoot](https://www.linuxjournal.com/content/foss-project-spotlight-linuxboot/)"
+
+#: src/talks-news.md:43
+#, fuzzy
+msgid "03/08/2018"
+msgstr "2018年3月8日"
+
+#: src/talks-news.md:43 src/talks-news.md:48
+#, fuzzy
+msgid "LWN"
+msgstr "低週"
+
+#: src/talks-news.md:43
+#, fuzzy
+msgid "[LWN.net: LinuxBoot: Linux as firmware](https://lwn.net/Articles/748586/)"
+msgstr "[LWN.net: LinuxBoot：Linux 作為韌體](https://lwn.net/Articles/748586/)"
+
+#: src/talks-news.md:44
+#, fuzzy
+msgid "06/21/2018"
+msgstr "2018年6月21日"
+
+#: src/talks-news.md:44 src/talks-news.md:45 src/talks-news.md:47
+#, fuzzy
+msgid "Phoronix"
+msgstr "福羅尼克斯"
+
+#: src/talks-news.md:44
+#, fuzzy
+msgid ""
+"[Equus WHITEBOX OPEN: A Line Of Coreboot/LinuxBoot-Ready Xeon Scalable "
+"Servers](https://www.phoronix.com/news/Equus-WHITEBOX-OPEN)"
+msgstr ""
+"[Equus WHITEBOX OPEN：一系列支援 Coreboot/LinuxBoot 的 Xeon "
+"可擴充伺服器](https://www.phoronix.com/news/Equus-WHITEBOX-OPEN)"
+
+#: src/talks-news.md:45
+#, fuzzy
+msgid "02/06/2019"
+msgstr "2019年2月6日"
+
+#: src/talks-news.md:45
+#, fuzzy
+msgid ""
+"[At Just Over One Year Old, LinuxBoot Continues Making Inroads At Facebook & "
+"Elsewhere](https://www.phoronix.com/news/LinuxBoot-2019)"
+msgstr "LinuxBoot 推出僅一年多，持續在 Facebook 及其他領域取得進展"
+
+#: src/talks-news.md:46
+#, fuzzy
+msgid "03/14/2019"
+msgstr "2019年3月14日"
+
+#: src/talks-news.md:46
+#, fuzzy
+msgid "Facebook"
+msgstr "Facebook"
+
+#: src/talks-news.md:46
+#, fuzzy
+msgid ""
+"[Facebook's LinuxBoot-powered F-16 high-performance fabric "
+"network](https://code.fb.com/data-center-engineering/f16-minipack/)"
+msgstr "Facebook 基於 LinuxBoot 的 F-16 高效能結構網絡"
+
+#: src/talks-news.md:47
+#, fuzzy
+msgid "03/10/2023"
+msgstr "2023年3月10日"
+
+#: src/talks-news.md:47
+#, fuzzy
+msgid ""
+"[Lenovo Begins Supporting LinuxBoot Firmware With "
+"ByteDance](https://www.phoronix.com/news/Lenovo-LinuxBoot-ByteDance)"
+msgstr ""
+"[聯想開始與位元組跳動合作支援 LinuxBoot "
+"韌體](https://www.phoronix.com/news/Lenovo-LinuxBoot-ByteDance)"
+
+#: src/talks-news.md:48
+#, fuzzy
+msgid "07/08/2024"
+msgstr "2024年7月8日"
+
+#: src/talks-news.md:48
+#, fuzzy
+msgid "[Giving bootloaders the boot with nmbl](https://lwn.net/Articles/979789)"
+msgstr "使用 nmbl 啟動引導程式"
+
+#: src/components.md:3
+#, fuzzy
+msgid "![image](../images/LinuxBoot-components.svg)"
+msgstr "![圖](../images/LinuxBoot-components.svg)"
+
+#: src/components.md:5
+#, fuzzy
+msgid "LinuxBoot consists of the following components:"
+msgstr "LinuxBoot 由以下元件組成："
+
+#: src/components.md:7 src/components.md:12 src/history.md:3
+#, fuzzy
+msgid "BIOS"
+msgstr "BIOS"
+
+#: src/components.md:8 src/components.md:18
+#, fuzzy
+msgid "Linux kernel"
+msgstr "Linux核心"
+
+#: src/components.md:9
+#, fuzzy
+msgid "u-root -> initramfs"
+msgstr "u-root -> initramfs"
+
+#: src/components.md:14
+msgid ""
+"This does not have to be a specific BIOS; currently LinuxBoot supports UEFI "
+"and [coreboot](https://coreboot.org/)."
+msgstr ""
+
+#: src/components.md:20
+msgid ""
+"LinuxBoot is not intended to be a runtime production kernel; rather, it is "
+"meant to replace specific UEFI functionality using Linux kernel capabilities "
+"and then boot the actual production kernel on the machine. Kernel "
+"configuration files specific to LinuxBoot provide the needed Linux kernel "
+"capabilities without bloating the size of the BIOS with unnecessary drivers."
+msgstr ""
+
+#: src/components.md:26
+#, fuzzy
+msgid ""
+"These config files disable options that are not needed in the LinuxBoot "
+"kernel and add some patches that are needed."
+msgstr "這些設定檔禁用了 LinuxBoot 核心中不需要的選項並添加了一些需要的補丁。"
+
+#: src/components.md:30
+#, fuzzy
+msgid "Initial RAM filesystem  (initramfs)"
+msgstr "初始 RAM 檔案系統 (initramfs)"
+
+#: src/components.md:32
+#, fuzzy
+msgid ""
+"When Linux boots it needs a root file system that provides boot and startup "
+"utilities. LinuxBoot uses [u-root](../glossary) to create an initramfs for "
+"this purpose."
+msgstr ""
+"當 Linux 啟動時，它需要一個提供引導和啟動實用程式的根檔案系統。 LinuxBoot 使用 [u-root](../glossary) "
+"為此目的建立 initramfs。"
+
+#: src/components.md:37
+#, fuzzy
+msgid "What is an initramfs?"
+msgstr "什麼是 initramfs？"
+
+#: src/components.md:39
+#, fuzzy
+msgid ""
+"The initramfs is a root file system that is embedded within the firmware "
+"image itself. It is intended to be placed in a flash device along with the "
+"Linux kernel as part of the firmware image for LinuxBoot. The initramfs is "
+"essentially a set of directories bundled into a single cpio archive."
+msgstr ""
+"initramfs 是嵌入在韌體映像本身內的根檔案系統。它旨在與 Linux 核心一起放置在快閃裝置中，作為 LinuxBoot 韌體映像的一部分。 "
+"initramfs 本質上是一組捆綁到單一 cpio 檔案中的目錄。"
+
+#: src/components.md:44
+#, fuzzy
+msgid ""
+"At boot time, the boot loader or firmware (for example, coreboot) loads the "
+"bzImage and initramfs into memory and starts the kernel. The kernel checks "
+"for the presence of the initramfs and, if found, unpacks it, mounts it as "
+"`/` and runs `/init`."
+msgstr ""
+"在啟動時，引導程式或韌體（例如 coreboot）將 bzImage 和 initramfs 載入到記憶體中並啟動核心。核心檢查 initramfs "
+"是否存在，如果找到，則將其解壓縮，將其掛載為“/”並執行“/init”。"
+
+#: src/components.md:50
+#, fuzzy
+msgid ""
+"There are many types of initramfs, in this topic we focus on u-root. u-root "
+"is a Go user-space (a set of programs and libraries written in Go that are "
+"used to interact with the kernel). It contains a toolset of standard Linux "
+"applications and commands."
+msgstr ""
+"initramfs 有很多種類型，在本主題中我們重點介紹 u-root。 u-root 是一個 Go 使用者空間（一組用 Go "
+"編寫的用於與核心互動的程式和函式庫）。它包含一套標準 Linux 應用程式和命令的工具集。"
+
+#: src/components.md:55
+#, fuzzy
+msgid "u-root can create an initramfs in two different modes:"
+msgstr "u-root 可以透過兩種不同的模式來建立 initramfs："
+
+#: src/components.md:57
+#, fuzzy
+msgid "source mode, which contains:"
+msgstr "源模式，包含："
+
+#: src/components.md:58
+#, fuzzy
+msgid "Go toolchain binaries"
+msgstr "Go 工具鏈二進位文件"
+
+#: src/components.md:59
+#, fuzzy
+msgid "A simple shell"
+msgstr "一個簡單的shell"
+
+#: src/components.md:60
+#, fuzzy
+msgid "Go source for tools to be compiled on the fly by the shell"
+msgstr "尋找由 shell 動態編譯的工具原始碼"
+
+#: src/components.md:61
+#, fuzzy
+msgid ""
+"Busybox (bb) mode: This is one busybox-like binary comprising all the "
+"requested utilities."
+msgstr "Busybox（bb）模式：這是一個類似 busybox 的二進位文件，包含所有請求的實用程式。"
+
+#: src/components.md:64
+#, fuzzy
+msgid ""
+"The initramfs provided by u-root implements the toolchain needed to securely "
+"boot the machine from the network, perform identity verification, "
+"communicate with different internal boot-related components, and kexec the "
+"next kernel."
+msgstr ""
+"u-root 提供的 initramfs 實作了從網路安全啟動機器、執行身份驗證、與不同的內部啟動相關元件通訊以及 kexec 下一個核心所需的工具鏈。"
+
+#: src/components.md:68
+#, fuzzy
+msgid ""
+"u-root is an open source project hosted on GitHub. Within the u-root "
+"repository, we have executable commands in `cmds` and the packages "
+"containing libraries and implementations in `pkg`."
+msgstr ""
+"u-root 是託管在 GitHub 上的開源專案。在 u-root 儲存庫中，我們在「cmds」中擁有可執行命令，在「pkg」中擁有包含庫和實作的套件。"
+
+#: src/tools-evaluation.md:3
+#, fuzzy
+msgid "Three general questions guide all software projects:"
+msgstr "所有軟體專案都應回答三個常見問題："
+
+#: src/tools-evaluation.md:5
+#, fuzzy
+msgid "what exists already? (implementations, tools and build systems)"
+msgstr "什麼已經存在？ （實施、工具和建構系統）"
+
+#: src/tools-evaluation.md:6
+#, fuzzy
+msgid "what needs development? (UIs and such)"
+msgstr "什麼需要發展？ （使用者介面等）"
+
+#: src/tools-evaluation.md:7
+#, fuzzy
+msgid "what is a good environment? (build + runtime)"
+msgstr "什麼是好的環境？ （建置 + 運行時）"
+
+#: src/tools-evaluation.md:9
+#, fuzzy
+msgid ""
+"Not only do we want to answer those questions. We also keep track of the "
+"options and decision process in this book in order for readers to make sense."
+msgstr "我們不僅想回答這些問題。我們也在本書中追蹤選項和決策過程，以便讀者理解。"
+
+#: src/tools-evaluation.md:12
+#, fuzzy
+msgid ""
+"There are many existing tools already that we can leverage to implement the "
+"idea of using Linux to boot into an operating system."
+msgstr "我們可以利用許多現有的工具來實現使用 Linux 啟動作業系統的想法。"
+
+#: src/tools-evaluation.md:15
+#, fuzzy
+msgid "Root filesystem"
+msgstr "根檔案系統"
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+#, fuzzy
+msgid "tool"
+msgstr "工具"
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+#, fuzzy
+msgid "language"
+msgstr "語言"
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+#, fuzzy
+msgid "license"
+msgstr "執照"
+
+#: src/tools-evaluation.md:17 src/tools-evaluation.md:27
+#, fuzzy
+msgid "usage"
+msgstr "用法"
+
+#: src/tools-evaluation.md:19
+#, fuzzy
+msgid "[BusyBox](https://busybox.net/)"
+msgstr "[BusyBox]（https://busybox.net/）"
+
+#: src/tools-evaluation.md:19 src/tools-evaluation.md:20
+#: src/tools-evaluation.md:21 src/tools-evaluation.md:29
+#: src/tools-evaluation.md:30 src/tools-evaluation.md:31
+#, fuzzy
+msgid "C"
+msgstr "碳"
+
+#: src/tools-evaluation.md:19 src/tools-evaluation.md:29
+#: src/tools-evaluation.md:31
+#, fuzzy
+msgid "GPLv2"
+msgstr "GPLv2"
+
+#: src/tools-evaluation.md:19 src/history.md:51
+#, fuzzy
+msgid "Heads"
+msgstr "頭部"
+
+#: src/tools-evaluation.md:20
+#, fuzzy
+msgid "[toybox](http://landley.net/toybox)"
+msgstr "[玩具箱]（http://landley.net/toybox）"
+
+#: src/tools-evaluation.md:20
+#, fuzzy
+msgid "0BSD"
+msgstr "0BSD"
+
+#: src/tools-evaluation.md:20
+#, fuzzy
+msgid "Android"
+msgstr "安卓"
+
+#: src/tools-evaluation.md:21
+#, fuzzy
+msgid "[GNU coreutils](https://www.gnu.org/software/coreutils/)"
+msgstr "[GNU coreutils](https://www.gnu.org/software/coreutils/)"
+
+#: src/tools-evaluation.md:21
+#, fuzzy
+msgid "GPLv3"
+msgstr "GPLv3"
+
+#: src/tools-evaluation.md:21 src/tools-evaluation.md:23
+#, fuzzy
+msgid "not for LinuxBoot"
+msgstr "不適用於 LinuxBoot"
+
+#: src/tools-evaluation.md:22
+#, fuzzy
+msgid "[u-root](https://u-root.org)"
+msgstr "[u-root](https://u-root.org)"
+
+#: src/tools-evaluation.md:22 src/tools-evaluation.md:32
+#, fuzzy
+msgid "Go"
+msgstr "去"
+
+#: src/tools-evaluation.md:22 src/tools-evaluation.md:32
+#, fuzzy
+msgid "BSD 3-Clause"
+msgstr "BSD 3 條款"
+
+#: src/tools-evaluation.md:22
+#, fuzzy
+msgid "ByteDance, Google et al"
+msgstr "位元組跳動、谷歌等"
+
+#: src/tools-evaluation.md:23
+#, fuzzy
+msgid "[uutils/coreutils](http://uutils.github.io/)"
+msgstr "[uutils/coreutils](http://uutils.github.io/)"
+
+#: src/tools-evaluation.md:23 src/tools-evaluation.md:33
+#, fuzzy
+msgid "Rust"
+msgstr "鏽"
+
+#: src/tools-evaluation.md:23
+#, fuzzy
+msgid "MIT"
+msgstr "麻省理工學院"
+
+#: src/tools-evaluation.md:25
+#, fuzzy
+msgid "kexec implementations"
+msgstr "kexec 實作"
+
+#: src/tools-evaluation.md:29
+#, fuzzy
+msgid ""
+"[kexec-tools](https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git) "
+"([GitHub mirror](https://github.com/horms/kexec-tools))"
+msgstr ""
+"kexec-tools（https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git）（GitHub "
+"鏡像（https://github.com/horms/kexec-tools））"
+
+#: src/tools-evaluation.md:29
+#, fuzzy
+msgid "Heads, Petitboot"
+msgstr "頭，小靴子"
+
+#: src/tools-evaluation.md:30
+#, fuzzy
+msgid "[systemd](https://systemd.io/) (wrapper)"
+msgstr "[systemd](https://systemd.io/) (包裝器)"
+
+#: src/tools-evaluation.md:30
+#, fuzzy
+msgid "LGPL-2.1+"
+msgstr "LGPL-2.1+"
+
+#: src/tools-evaluation.md:30
+#, fuzzy
+msgid "systemd on UEFI"
+msgstr "UEFI 上的 systemd"
+
+#: src/tools-evaluation.md:31
+#, fuzzy
+msgid "[kexecboot](https://github.com/kexecboot/kexecboot)"
+msgstr "[kexecboot]（https://github.com/kexecboot/kexecboot）"
+
+#: src/tools-evaluation.md:31 src/tools-evaluation.md:33
+#, fuzzy
+msgid "?"
+msgstr "？"
+
+#: src/tools-evaluation.md:32
+#, fuzzy
+msgid "u-root (CLI+mod)"
+msgstr "u-root（CLI+mod）"
+
+#: src/tools-evaluation.md:32
+#, fuzzy
+msgid "Google et al"
+msgstr "谷歌等"
+
+#: src/tools-evaluation.md:33
+#, fuzzy
+msgid "[kexlinux](https://github.com/im-0/kexlinux)"
+msgstr "[kexlinux]（https://github.com/im-0/kexlinux）"
+
+#: src/tools-evaluation.md:33
+#, fuzzy
+msgid "LGPL-3.0+"
+msgstr "LGPL-3.0+"
+
+#: src/u-root.md:3
+#, fuzzy
+msgid ""
+"U-root is an embeddable root file system intended to be placed in a flash "
+"device as part of the firmware image, along with a Linux kernel. The program "
+"source code is installed in the root file system contained in the firmware "
+"flash part and compiled on demand. All the u-root utilities, roughly "
+"corresponding to standard Unix utilities, are written in Go, a modern, "
+"type-safe language with garbage collection and language-level support for "
+"concurrency and inter-process communication."
+msgstr ""
+"U-root 是一個可嵌入的根檔案系統，旨在作為韌體映像的一部分與 Linux "
+"核心一起放置在快閃裝置中。程式原始碼安裝在韌體flash部分包含的根檔案系統中，並按需編譯。所有 u-root 實用程式（大致對應於標準 Unix "
+"實用程式）都是用 Go 編寫的，Go 是一種現代的、類型安全的語言，具有垃圾收集功能以及對並發和進程間通訊的語言級支援。"
+
+#: src/u-root.md:11
+#, fuzzy
+msgid ""
+"Unlike most embedded root file systems, which consist largely of binaries, "
+"u-root has only 5: an init program and 4 Go compiler binaries. When a "
+"program is first run, it, and any not-yet-built packages it uses are "
+"compiled to a RAM-based file system. The first invocation of a program takes "
+"a fraction of a second, as it is compiled. Packages are only compiled once, "
+"so the slowest build is always the first one, on boot, which takes about 3 "
+"seconds. Subsequent invocations are very fast, usually a millisecond or so."
+msgstr ""
+"與大多數主要由二進位檔案組成的嵌入式根檔案系統不同，u-root 只有 5 個：一個 init 程式和 4 個 Go "
+"編譯器二進位檔案。當程式首次運行時，它和它使用的任何尚未建置的套件都會被編譯到基於 RAM "
+"的檔案系統中。程式的第一次呼叫只需要幾分之一秒的時間，因為它是編譯的。軟體包僅編譯一次，因此最慢的構建始終是在啟動時進行的第一次構建，大約需要 3 "
+"秒。後續呼叫非常快，通常只需一毫秒左右。"
+
+#: src/u-root.md:19
+#, fuzzy
+msgid ""
+"U-root blurs the line between script-based distros such as Perl Linux[^24] "
+"and binary-based distros such as BusyBox[^26]. It has the flexibility of "
+"Perl Linux and the performance of BusyBox. Scripts and builtins are written "
+"in Go, not a shell scripting language. U-root is a new way to package and "
+"distribute file systems for embedded systems, and the use of Go promises a "
+"dramatic improvement in their security."
+msgstr ""
+"U-root 模糊了基於腳本的發行版（如 Perl Linux[^24]）和基於二進位的發行版（如 BusyBox[^26]）之間的界限。它具有 "
+"Perl Linux 的靈活性和 BusyBox 的性能。腳本和內建指令是用 Go 寫的，而不是 shell 腳本語言。 U-root "
+"是一種為嵌入式系統打包和分發檔案系統的新方法，使用 Go 有望顯著提高其安全性。"
+
+#: src/u-root.md:26
+#, fuzzy
+msgid "U-root and embedded systems"
+msgstr "U-root 和嵌入式系統"
+
+#: src/u-root.md:28
+#, fuzzy
+msgid ""
+"Embedding kernels and root file systems in BIOS flash is a common technique "
+"for gaining boot time performance and platform customization[^25][^14][^23]. "
+"Almost all new firmware includes a multiprocess operating system with a full "
+"complement of file systems, network drivers, and protocol stacks, all "
+"contained in an embedded file system. In some cases, the kernel is only "
+"booted long enough to boot another kernel. In others, the kernel that is "
+"booted and the file system it contains constitute the operational "
+"environment of the device[^15]. These so-called “embedded root file systems” "
+"also contain a set of standard Unix-style programs used for both normal "
+"operation and maintenance. Space on the device is at a premium, so these "
+"programs are usually written in C using the BusyBox toolkit[^26], or in an "
+"interpretive language such as Perl[^24] or Forth. BusyBox in particular has "
+"found wide usage in embedded appliance environments, as the entire root file "
+"system can be contained in under one MiB."
+msgstr ""
+"在 BIOS "
+"快閃記憶體中嵌入核心和根檔案系統是提高啟動時間效能和平台客製化的常用技術[^25][^14][^23]。幾乎所有新韌體都包含一個多進程作業系統，該作業系統具有完整的檔案系統、網路驅動程式和協定棧，所有這些都包含在嵌入式檔案系統中。在某些情況下，核心的啟動時間僅夠啟動另一個核心。在其他情況下，啟動的核心及其所包含的檔案系統構成了設備的運作環境[^15]。這些所謂的「嵌入式根檔案系統」還包含一組用於正常操作和維護的標準 "
+"Unix 風格程式。設備上的空間非常寶貴，因此這些程式通常使用 BusyBox 工具包[^26] 以 C 語言編寫，或使用 Perl[^24] 或 "
+"Forth 等解釋性語言編寫。 BusyBox 在嵌入式設備環境中得到了廣泛的應用，因為整個根檔案系統可以包含在一個 MiB 中。"
+
+#: src/u-root.md:42
+#, fuzzy
+msgid ""
+"Embedded systems, which were once standalone, are now almost always network "
+"connected. Network connected systems face a far more challenging security "
+"environment than even a few years ago. In response to the many successful "
+"attacks against shell interpreters[^11] and C programs[^8], we have started "
+"to look at using a more secure, modern language in embedded root file "
+"systems, namely, Go[^21][^16]."
+msgstr ""
+"嵌入式系統曾經是獨立的，但現在幾乎總是透過網路連接。網路連線系統面臨的安全環境比幾年前更加嚴峻。為了回應針對 shell 解釋器[^11] 和 C "
+"程式[^8] 的多次成功攻擊，我們開始研究在嵌入式根檔案系統中使用更安全、更現代的語言，即 Go[^21][^16]。"
+
+#: src/u-root.md:49
+msgid ""
+"Go is a new systems programming language created by Google. Go has strong "
+"typing; language level support for concurrency; inter-process communication "
+"via channels, a la Occam[^13], Limbo[^17], and Alef[^27]; runtime type "
+"safety and other protective measures; dynamic allocation and garbage "
+"collection; closures; and a package syntax, similar to Java, that makes it "
+"easy to determine what packages a given program needs. The modern language "
+"constructs make Go a much safer language than C. This safety is critical for "
+"network-attached embedded systems, which usually have network utilities "
+"written in C, including web servers, network servers including sshd, and "
+"programs that provide access to a command interpreter, itself written in C. "
+"All are proving to be vulnerable to the attack-rich environment that the "
+"Internet has become. Buffer overflow attacks affecting C-based firmware code "
+"(among other things) in 2015 include GHOST and the so-called FSVariable.c "
+"bug in Intel’s UEFI firmware. Buffer overflows in Intel’s UEFI and Active "
+"Management Technology (AMT) have also been discovered in several versions in "
+"recent years."
+msgstr ""
+
+#: src/u-root.md:65
+msgid ""
+"Both UEFI[^12] and AMT[^4] are embedded operating systems, loaded from flash "
+"that run network-facing software. Attacks against UEFI have been extensively "
+"studied[^9]. Most printers are network-attached and are a very popular "
+"exploitation target[^6]. Firmware is not visible to most users and is "
+"updated much less frequently (if at all) than programs. It is the first "
+"software to run, at power on reset. Exploits in firmware are extremely "
+"difficult to detect, because firmware is designed to be as invisible as "
+"possible. Firmware is extremely complex; UEFI is roughly equivalent in size "
+"and capability to a Unix kernel. Firmware is usually closed and proprietary, "
+"with nowhere near the level of testing of kernels. These properties make "
+"firmware an ideal place for so-called advanced persistent "
+"threats[^10][^18][^5]. Once an exploit is installed, it is almost impossible "
+"to remove, since the exploit can inhibit its removal by corrupting the "
+"firmware update process. The only sure way to mitigate a firmware exploit is "
+"to destroy the hardware."
+msgstr ""
+
+#: src/u-root.md:80
+#, fuzzy
+msgid ""
+"U-root is an excellent option for embedded systems. U-root contains only 5 "
+"binaries, 4 of them from the Go toolchain, and the 5th is an init binary. "
+"The rest of the programs are contained in BIOS flash in source form, "
+"including packages. The search path is arranged so that when a command is "
+"invoked, if it is not in `/bin`, an installer is invoked instead which "
+"compiles the program into `/bin`. If the build succeeds, the command is "
+"executed. This first invocation takes a fraction of a second, depending on "
+"program complexity. After that, the RAM-based, statically linked binaries "
+"run in about a millisecond. Scripts are written in Go, not a shell scripting "
+"language, with two benefits: the shell can be simple, with fewer corner "
+"cases, and the scripting environment is substantially improved since Go is "
+"more powerful than most shell scripting languages, but also less fragile and "
+"less prone to parsing bugs."
+msgstr ""
+"U-root 是嵌入式系統的絕佳選擇。 U-root 僅包含 5 個二進位文件，其中 4 個來自 Go 工具鏈，第 5 個是 init "
+"二進位檔案。其餘程式（包括軟體包）以原始碼形式包含在 BIOS "
+"快閃記憶體中。搜尋路徑的安排使得當呼叫命令時，如果它不在“/bin”中，則呼叫安裝程式將程式編譯到“/bin”中。如果建置成功，則執行該命令。第一次呼叫只需幾分之一秒，具體取決於程式的複雜性。此後，基於 "
+"RAM 的靜態連結二進位檔案將在大約一毫秒內運行。腳本是用 Go 編寫的，而不是 shell 腳本語言，這有兩個好處：shell "
+"可以很簡單，極端情況更少，並且由於 Go 比大多數 shell 腳本語言更強大，因此腳本環境得到了顯著改善，而且更不容易脆弱，也不容易出現解析錯誤。"
+
+#: src/u-root.md:93
+#, fuzzy
+msgid "U-root design"
+msgstr "U型根設計"
+
+#: src/u-root.md:95
+msgid ""
+"The u-root boot image is a build toolchain and a set of programs in source "
+"form. When first used, a program and any needed but not-yet-built packages "
+"are built and installed, typically in a fraction of a second. With later "
+"uses, the binary is executed. The root file system is almost entirely "
+"unformed on boot; `/init` sets up the key directories and mounts, including "
+"common ones such as `/etc` and `/proc`."
+msgstr ""
+
+#: src/u-root.md:102
+#, fuzzy
+msgid ""
+"Since the init program itself is only 132 lines of code and is easy to "
+"change, the structure is very flexible and allows for many use cases, for "
+"example:"
+msgstr "由於 init 程式本身只有 132 行程式碼且易於更改，因此結構非常靈活，可用於多種用例，例如："
+
+#: src/u-root.md:105
+#, fuzzy
+msgid ""
+"Additional binaries: if the 3 seconds it takes to get to a shell is too long "
+"(some applications such as automotive computing require 800 ms startup "
+"time), and there is room in flash, some programs can be precompiled into "
+"/bin."
+msgstr ""
+"附加二進位檔案：如果進入 shell 所需的 3 秒時間太長（某些應用程式（例如汽車運算）需要 800 "
+"毫秒的啟動時間），且快閃記憶體中有空間，則可以將某些程式預先編譯到 /bin 中。"
+
+#: src/u-root.md:108
+#, fuzzy
+msgid ""
+"Build it all on boot: if on-demand compilation is not desired, a background "
+"thread in the init process can build all the programs on boot."
+msgstr "啟動時建置所有內容：如果不需要按需編譯，init 進程中的後台執行緒可以在啟動時建置所有程式。"
+
+#: src/u-root.md:110
+#, fuzzy
+msgid ""
+"Selectively remove binaries after use: if RAM space is at a premium, once "
+"booted, a script can remove everything in `/bin`. Utilities or commands that "
+"are used will be rebuilt on demand."
+msgstr ""
+"使用後選擇性地刪除二進位檔案：如果 RAM 空間非常寶貴，一旦啟動，腳本就可以刪除「/bin」中的所有內容。所使用的實用程式或命令將根據需要重建。"
+
+#: src/u-root.md:113
+#, fuzzy
+msgid ""
+"Always build on demand: run in a mode in which programs are never written to "
+"`/bin` and always rebuilt on demand. This is a very practical option given "
+"that program compilation is so fast."
+msgstr "始終按需建置：以程式永遠不會寫入“/bin”並始終按需重建的模式運行。由於程式編譯速度非常快，這是一個非常實用的選擇。"
+
+#: src/u-root.md:116
+#, fuzzy
+msgid ""
+"Lockdown: if desired, the system can be locked down once booted in one of "
+"several ways: the entire `/src` tree can be removed, for example, or just "
+"the compiler toolchain can be deleted."
+msgstr "鎖定：如果需要，系統可以在啟動後以多種方式之一鎖定：例如，可以刪除整個“/src”樹，或只刪除編譯器工具鏈。"
+
+#: src/u-root.md:120
+#, fuzzy
+msgid "U-root functionality"
+msgstr "U-root 功能"
+
+#: src/u-root.md:122
+#, fuzzy
+msgid ""
+"U-root is packaged as an LZMA-compressed initial RAM file system (initramfs) "
+"in cpio format. It is contained in a Linux compressed kernel image, also "
+"know as bzImage. The bootloader (for example, syslinux) or firmware (for "
+"example, coreboot) loads the bzImage into memory and starts it. The Linux "
+"kernel sets up a RAM-based root file system and unpacks the u-root file "
+"system into it. This initial root file system contains the Go toolchain (4 "
+"binaries), an init binary, the u-root program source, and the entire Go "
+"source tree, which provides packages needed for u-root programs."
+msgstr ""
+"U-root 以 cpio 格式打包為 LZMA 壓縮的初始 RAM 檔案系統 (initramfs)。它包含在 Linux 壓縮核心映像中，也稱為 "
+"bzImage。引導程式（例如，syslinux）或韌體（例如，coreboot）將 bzImage 載入到記憶體中並啟動它。 "
+"Linux核心建立基於RAM的根檔案系統，並將u-root檔案系統解壓縮到其中。這個初始根檔案系統包含 Go 工具鏈（4 個二進位檔案）、一個 init "
+"二進位檔案、u-root 程式原始碼和整個 Go 原始碼樹，它提供了 u-root 程式所需的套件。"
+
+#: src/u-root.md:131
+#, fuzzy
+msgid ""
+"All Unix systems start an init process on boot and u-root is no exception. "
+"The init for u-root sets up some basic directories, symlinks, and files. It "
+"builds a command installer and invokes the shell. This process is described "
+"in more detail below. The boot file system layout is shown in Table 1."
+msgstr ""
+"所有 Unix 系統在啟動時都會啟動一個 init 進程，u-root 也不例外。 u-root 的 init "
+"設定了一些基本目錄、符號連結和檔案。它建立一個命令安裝程式並呼叫 shell。下面將更詳細地描述這一過程。啟動檔案系統佈局如表1所示。"
+
+#: src/u-root.md:136
+msgid ""
+"The src directory is where programs and u-root packages reside. The go/bin "
+"directory is for any Go tools built after boot; the go/pkg/tool directory "
+"contains binaries for various architecture/kernel combinations. The "
+"directory in which a compiler toolchain is placed provides information about "
+"the target OS and architecture, for example, the Go build places binaries "
+"for Linux on x86 64 in `/go/pkg/tool/linux` `amd64/`. Note that there is no "
+"`/bin` or many of the other directories expected in a root file system. The "
+"init binary builds them. It creates an empty `/bin` which is filled with "
+"binaries on demand as shown in Table 2.The u-root root file system has very "
+"little state."
+msgstr ""
+
+#: src/u-root.md:146
+#, fuzzy
+msgid ""
+"For most programs to work, the file system must be more complete. Image "
+"space is saved by having init create additional file system structure at "
+"boot time: it fills in the missing parts of the root filesystem. It creates "
+"`/dev` and `/proc` and mounts them. It creates an empty `/bin` which is "
+"filled with binaries on demand."
+msgstr ""
+"為了使大多數程式能夠正常運作，檔案系統必須更加完整。透過讓 init "
+"在啟動時建立額外的檔案系統結構來節省映像空間：它填入根檔案系統缺少的部分。它創建“/dev”和“/proc”並掛載它們。它會建立一個空的“/bin”，並根據需要填入二進位檔案。"
+
+#: src/u-root.md:152
+#, fuzzy
+msgid ""
+"In addition to `/bin`, there is a directory called `/buildbin`. `Buildbin` "
+"and the correct setup of $PATH are the keys to making on-demand compilation "
+"work. The init process sets $PATH to "
+"`/go/bin:/bin:/buildbin:/usr/local/bin`. Init also builds `installcommand` "
+"using the Go bootstrap builder and creates a complete set of symlinks. As a "
+"final step, init execs `sh`."
+msgstr ""
+"除了 `/bin` 之外，還有一個名為 `/buildbin` 的目錄。 `Buildbin` 和 $PATH 的正確設定是使按需編譯工作的關鍵。 "
+"init 程序將 $PATH 設定為 `/go/bin:/bin:/buildbin:/usr/local/bin`。 Init 還使用 Go "
+"引導建構器建立「installcommand」並建立一組完整的符號連結。最後一步，init 執行「sh」。"
+
+#: src/u-root.md:158
+msgid ""
+"There is no `/bin/sh` at this point; the first `sh` found in $PATH is "
+"`/buildbin/sh`. This is a symlink to `installcommand`. `Installcommand`, "
+"once started, examines argv\\[0\\], which is `sh`, and takes this as "
+"instruction to build `/src/cmds/sh/.go` into `/bin` and then exec `/bin/sh`. "
+"There is no difference between starting the first shell and any other "
+"program. Hence, part of the boot process involves the construction of an "
+"installation tool to build a binary for a shell which is then run."
+msgstr ""
+
+#: src/u-root.md:166
+#, fuzzy
+msgid ""
+"If a user wants to examine the source to the shell, they can `cat` "
+"`/src/cmds/sh/.go`. The `cat` command will be built and then show those "
+"files. U-root is intended for network-based devices and hence good network "
+"initialization code is essential. U-root includes a Go version of the IP and "
+"DHCP programs, along with the docker netlink package and a DHCP package."
+msgstr ""
+"如果使用者想要檢查 shell 的源代碼，他們可以 `cat` `/src/cmds/sh/.go`。將建立“cat”命令並顯示這些檔案。 U-root "
+"適用於基於網路的設備，因此良好的網路初始化程式碼至關重要。 U-root 包含 Go 版本的 IP 和 DHCP 程序，以及 docker "
+"netlink 套件和 DHCP 套件。"
+
+#: src/u-root.md:172
+#, fuzzy
+msgid "Table 1 below shows the initial layout of a u-root file system."
+msgstr "下表 1 顯示了 u-root 檔案系統的初始佈局。"
+
+#: src/u-root.md:174
+#, fuzzy
+msgid ""
+"All Go compiler and runtime source is included under `/go/src`. All u-root "
+"source is under `/src` and the compiler toolchain binaries are under "
+"`/go/pkg`."
+msgstr ""
+"所有 Go 編譯器和執行時間來源都包含在“/go/src”下。所有 u-root "
+"來源均位於「/src」下，編譯器工具鏈二進位檔案位於「/go/pkg」下。"
+
+#: src/u-root.md:177 src/u-root.md:229
+#, fuzzy
+msgid "Directory"
+msgstr "目錄"
+
+#: src/u-root.md:177 src/u-root.md:229
+#, fuzzy
+msgid "Subdirectory"
+msgstr "子目錄"
+
+#: src/u-root.md:177 src/u-root.md:229
+#, fuzzy
+msgid "Command"
+msgstr "命令"
+
+#: src/u-root.md:179 src/u-root.md:231
+#, fuzzy
+msgid "/src"
+msgstr "/來源"
+
+#: src/u-root.md:179 src/u-root.md:231
+#, fuzzy
+msgid "cmds/"
+msgstr "命令/"
+
+#: src/u-root.md:180 src/u-root.md:232
+#, fuzzy
+msgid "builtin/builtin.go"
+msgstr "內建/builtin.go"
+
+#: src/u-root.md:181 src/u-root.md:233
+#, fuzzy
+msgid "/cat.go"
+msgstr "/cat.go"
+
+#: src/u-root.md:182 src/u-root.md:234
+#, fuzzy
+msgid "/cmp.go"
+msgstr "/cmp.go"
+
+#: src/u-root.md:183 src/u-root.md:235
+#, fuzzy
+msgid "comm/comm.go"
+msgstr "comm/comm.go"
+
+#: src/u-root.md:184 src/u-root.md:236
+#, fuzzy
+msgid "cp/cp.go"
+msgstr "cp/cp.go"
+
+#: src/u-root.md:185 src/u-root.md:237
+#, fuzzy
+msgid "date/date.go"
+msgstr "日期/date.go"
+
+#: src/u-root.md:186 src/u-root.md:238
+#, fuzzy
+msgid "dmesg/dmesg.go"
+msgstr "dmesg/dmesg.go"
+
+#: src/u-root.md:187 src/u-root.md:239
+#, fuzzy
+msgid "echo/echo.go"
+msgstr "echo/echo.go"
+
+#: src/u-root.md:188 src/u-root.md:240
+#, fuzzy
+msgid "freq/freq.go"
+msgstr "頻率/freq.go"
+
+#: src/u-root.md:189 src/u-root.md:241
+#, fuzzy
+msgid "grep/grep.go"
+msgstr "grep/grep.go"
+
+#: src/u-root.md:190 src/u-root.md:242
+#, fuzzy
+msgid "init/init.go"
+msgstr "初始化/init.go"
+
+#: src/u-root.md:191 src/u-root.md:243
+#, fuzzy
+msgid "installcommand/installcommand.go"
+msgstr "安裝命令/installcommand.go"
+
+#: src/u-root.md:192 src/u-root.md:244
+#, fuzzy
+msgid "ip/ip.go"
+msgstr "ip/ip.go"
+
+#: src/u-root.md:193 src/u-root.md:245
+#, fuzzy
+msgid "ldd/ldd.go"
+msgstr "ldd/ldd.go"
+
+#: src/u-root.md:194 src/u-root.md:246
+#, fuzzy
+msgid "losetup/losetup.go"
+msgstr "losetup/losetup.go"
+
+#: src/u-root.md:195 src/u-root.md:247
+#, fuzzy
+msgid "ls/ls.go"
+msgstr "ls/ls.go"
+
+#: src/u-root.md:196 src/u-root.md:248
+#, fuzzy
+msgid "mkdir/mkdir.go"
+msgstr "mkdir/mkdir.go"
+
+#: src/u-root.md:197 src/u-root.md:249
+#, fuzzy
+msgid "mount/mount.go"
+msgstr "掛載/mount.go"
+
+#: src/u-root.md:198 src/u-root.md:250
+#, fuzzy
+msgid "netcat/netcat.go"
+msgstr "netcat/netcat.go"
+
+#: src/u-root.md:199 src/u-root.md:251
+#, fuzzy
+msgid "ping/ping.go"
+msgstr "ping/ping.go"
+
+#: src/u-root.md:200 src/u-root.md:252
+#, fuzzy
+msgid "printenv/printenv.go"
+msgstr "printenv/printenv.go"
+
+#: src/u-root.md:201 src/u-root.md:253
+#, fuzzy
+msgid "rm/rm.go"
+msgstr "rm/rm.go"
+
+#: src/u-root.md:202 src/u-root.md:254
+#, fuzzy
+msgid "script/script.go"
+msgstr "腳本/script.go"
+
+#: src/u-root.md:203 src/u-root.md:255
+#, fuzzy
+msgid "seq/seq.go"
+msgstr "seq/seq.go"
+
+#: src/u-root.md:204 src/u-root.md:256
+#, fuzzy
+msgid "sh/{cd.go,parse.go,sh.go,time.go}"
+msgstr "sh/{cd.go,parse.go,sh.go,time.go}"
+
+#: src/u-root.md:205 src/u-root.md:257
+#, fuzzy
+msgid "srvfiles/srvfiles.go"
+msgstr "srvfiles/srvfiles.go"
+
+#: src/u-root.md:206 src/u-root.md:258
+#, fuzzy
+msgid "tcz/tcz.go"
+msgstr "tcz/tcz.go"
+
+#: src/u-root.md:207 src/u-root.md:259
+#, fuzzy
+msgid "tee/tee.go"
+msgstr "tee/tee.go"
+
+#: src/u-root.md:208 src/u-root.md:260
+#, fuzzy
+msgid "uniq/uniq.go"
+msgstr "uniq/uniq.go"
+
+#: src/u-root.md:209 src/u-root.md:261
+#, fuzzy
+msgid "wc/wc.go"
+msgstr "wc/wc.go"
+
+#: src/u-root.md:210 src/u-root.md:262
+#, fuzzy
+msgid "wget/wget.go"
+msgstr "wget/wget.go"
+
+#: src/u-root.md:211 src/u-root.md:263
+#, fuzzy
+msgid "which/which.go"
+msgstr "哪個/哪個.go"
+
+#: src/u-root.md:212 src/u-root.md:217 src/u-root.md:264 src/u-root.md:269
+#, fuzzy
+msgid "pkg/"
+msgstr "包/"
+
+#: src/u-root.md:213 src/u-root.md:265
+#, fuzzy
+msgid "dhcp/ (dhcp package source)"
+msgstr "dhcp/（dhcp 包源）"
+
+#: src/u-root.md:214 src/u-root.md:266
+#, fuzzy
+msgid "netlib/ (netlib package source)"
+msgstr "netlib/（netlib 套件來源）"
+
+#: src/u-root.md:215 src/u-root.md:267
+#, fuzzy
+msgid "golang.org (import package source)"
+msgstr "golang.org（導入套件來源）"
+
+#: src/u-root.md:216 src/u-root.md:268
+#, fuzzy
+msgid "/go"
+msgstr "/去"
+
+#: src/u-root.md:216 src/u-root.md:268
+#, fuzzy
+msgid "src/"
+msgstr "原始碼/"
+
+#: src/u-root.md:216 src/u-root.md:268
+#, fuzzy
+msgid "Packages and toolchain"
+msgstr "軟體包和工具鏈"
+
+#: src/u-root.md:217 src/u-root.md:269
+#, fuzzy
+msgid "tool/linux amd64/{6a,6c,6g,6l}"
+msgstr "工具/linux amd64/{6a,6c,6g,6l}"
+
+#: src/u-root.md:218 src/u-root.md:270
+#, fuzzy
+msgid "misc/"
+msgstr "雜項/"
+
+#: src/u-root.md:218 src/u-root.md:219 src/u-root.md:221 src/u-root.md:270
+#: src/u-root.md:271 src/u-root.md:273 src/utilities/UEFI_Tool_Kit.md:489
+#, fuzzy
+msgid "..."
+msgstr "…"
+
+#: src/u-root.md:219 src/u-root.md:271
+#, fuzzy
+msgid "tool/"
+msgstr "工具/"
+
+#: src/u-root.md:220 src/u-root.md:272
+#, fuzzy
+msgid "bin/"
+msgstr "垃圾桶/"
+
+#: src/u-root.md:220 src/u-root.md:272
+#, fuzzy
+msgid "go"
+msgstr "去"
+
+#: src/u-root.md:221 src/u-root.md:273
+#, fuzzy
+msgid "include/"
+msgstr "包括/"
+
+#: src/u-root.md:222 src/u-root.md:274
+#, fuzzy
+msgid "/lib/"
+msgstr "/lib/"
+
+#: src/u-root.md:222 src/u-root.md:274
+#, fuzzy
+msgid "libc.so"
+msgstr "libc.so"
+
+#: src/u-root.md:222 src/u-root.md:274
+#, fuzzy
+msgid "Needed for tinycore linux packages"
+msgstr "tinycore Linux 軟體包所需"
+
+#: src/u-root.md:223 src/u-root.md:275
+#, fuzzy
+msgid "libm.so"
+msgstr "libm.so"
+
+#: src/u-root.md:225
+#, fuzzy
+msgid "**Table 1**: Initial layout of a u-root filesystem"
+msgstr "表 1：u-root 檔案系統的初始佈局"
+
+#: src/u-root.md:227
+#, fuzzy
+msgid "Table 2 below shows the layout after `/init` has run."
+msgstr "下面的表 2 顯示了 `/init` 運行後的佈局。"
+
+#: src/u-root.md:277
+#, fuzzy
+msgid "**Table 2**: Layout after `/init` has run."
+msgstr "**表 2**：`/init` 運行後的佈局。"
+
+#: src/u-root.md:279
+#, fuzzy
+msgid ""
+"`/buildbin` contains symlinks to enable the on-demand compilation, and other "
+"standard directories and mount points are ready."
+msgstr "`/buildbin` 包含符號連結以啟用按需編譯，其他標準目錄和掛載點已準備就緒。"
+
+#: src/u-root.md:282
+#, fuzzy
+msgid "The u-root shell"
+msgstr "u-root shell"
+
+#: src/u-root.md:284
+msgid ""
+"U-root provides a shell that is stripped down to the fundamentals: it can "
+"read commands in using the Go scanner package; it can expand (that is, glob) "
+"the command elements, using the Go filepath package, and it can run the "
+"resulting commands, either programs or shell builtins. It supports pipelines "
+"and IO redirection. At the same time, the shell defines no language of its "
+"own for scripting and builtins. Instead, the u-root shell uses the Go "
+"compiler. In that sense, the u-root shell reflects a break in important ways "
+"with the last few decades of shell development, which has seen shells and "
+"their language grow ever more complex and, partially as a result, ever more "
+"insecure[^19] and fragile[^11]."
+msgstr ""
+
+#: src/u-root.md:295
+#, fuzzy
+msgid ""
+"The shell has several builtin commands, and you can extend it with builtin "
+"commands of your own. First, you need to understand the basic source "
+"structure of u-root shell builtins. Then, you will learn about user-defined "
+"builtins."
+msgstr ""
+"該 shell 有幾個內建命令，您可以使用自己的內建命令來擴展它。首先，您需要了解 u-root shell "
+"內建指令的基本來源結構。然後，您將了解使用者定義的內建函數。"
+
+#: src/u-root.md:299
+#, fuzzy
+msgid ""
+"All shell builtins, including the ones that come with the shell by default, "
+"are written with a standard Go init pattern which installs one or more "
+"builtins."
+msgstr "所有 shell 內建指令（包括預設隨 shell 附帶的內建指令）都是用標準 Go init 模式編寫的，該模式會安裝一個或多個內建指令。"
+
+#: src/u-root.md:302
+#, fuzzy
+msgid ""
+"Builtins in the shell are defined by a name and a function. One or more "
+"builtins can be described in a source file. The name is kept in a map and "
+"the map is searched for a command name before looking in the file system. "
+"The function must accept a string as a name and a (possibly zero-length) "
+"array of string arguments, and return an error. In order to connect the "
+"builtin to the map, a programmer must provide an `init` function which adds "
+"the name and function to the map. The `init` function is special in that it "
+"is run by Go when the program starts up. In this case, the `init` function "
+"just installs a builtin for the time command."
+msgstr ""
+"Shell "
+"中的內建函數由名稱和功能定義。來源檔案中可以描述一個或多個內建函數。該名稱保存在地圖中，並在檔案系統中查找之前在地圖中搜尋命令名稱。函數必須接受一個字串作為名稱和一個（可能是零長度的）字串參數數組，並傳回一個錯誤。為了將內建函數連接到地圖，程式設計師必須提供一個「init」函數，將名稱和函數新增到地圖中。 "
+"`init` 函數比較特殊，它在程式啟動時由 Go 執行。在這種情況下，`init` 函數只是為時間指令安裝一個內建函數。"
+
+#: src/u-root.md:312
+#, fuzzy
+msgid "Figure 1 and Figure 2 below show the shell builtin for time."
+msgstr "下面的圖 1 和圖 2 顯示了時間的 shell 內建函數。"
+
+#: src/u-root.md:315
+#, fuzzy
+msgid ""
+"// Package main is the 'root' of the package hierarchy for a program.\n"
+"// This code is part of the main program, not another package,\n"
+"// and is declared as package main.\n"
+msgstr ""
+"// 套件 main 是程式包層次結構的「根」。\n"
+"// 此程式碼是主程式的一部分，而不是另一個包，\n"
+"// 並宣告為 package main。\n"
+
+#: src/u-root.md:320
+#, fuzzy
+msgid ""
+"// A Go source file list all the packages on which it has a direct\n"
+"// dependency.\n"
+msgstr ""
+"// Go 原始檔列出了它直接關聯的所有包\n"
+"//依賴項。\n"
+
+#: src/u-root.md:325
+#, fuzzy
+msgid "\"fmt\""
+msgstr "“fmt”"
+
+#: src/u-root.md:326
+#, fuzzy
+msgid "\"os\""
+msgstr "\"作業系統\""
+
+#: src/u-root.md:327
+#, fuzzy
+msgid "\"time\""
+msgstr "“時間”"
+
+#: src/u-root.md:329
+#, fuzzy
+msgid ""
+"// init() is an optional function. If init () is present in a file,\n"
+"// the Go compiler and runtime arrange for it to be called at\n"
+"// program startup. It is therefore like a constructor.\n"
+msgstr ""
+"// init() 是一個可選函數。如果檔案中存在 init()，\n"
+"// Go 編譯器和運行時安排它在\n"
+"// 程式啟動。因此它就像一個構造函數。\n"
+
+#: src/u-root.md:335
+#, fuzzy
+msgid ""
+"// addBuiltIn is provided by the u−root shell for the addition of\n"
+"    // builtin commands. Builtins must have a standard type:\n"
+"    // - The first parameter is a string\n"
+"    // - The second is a string array which may be 0 length\n"
+"    // - The return is the Go error type\n"
+"    // In this case, we are creating a builtincalled time that calls\n"
+"    // the timecmd function.\n"
+msgstr ""
+"// addBuiltIn 由 u-root shell 提供，用於添加\n"
+"    // 內建指令。內建函數必須具有標準類型：\n"
+"    // - 第一個參數是一個字串\n"
+"    // - 第二個是字串數組，其長度可能為 0\n"
+"    // - 回傳的是 Go 錯誤類型\n"
+"    // 在這種情況下，我們正在創建一個內建調用時間，它調用\n"
+"    // timecmd 函數。\n"
+
+#: src/u-root.md:343
+#, fuzzy
+msgid "\"time \""
+msgstr "“時間 ”"
+
+#: src/u-root.md:347
+#, fuzzy
+msgid "**Figure 1**: The code for the time builtin, Part I: setup"
+msgstr "**圖 1**：時間內建程式碼，第一部分：設定"
+
+#: src/u-root.md:350
+#, fuzzy
+msgid ""
+"// The timecmd function is passed the name of a command to run,\n"
+"// optional arguments, and returns an error. It:\n"
+"// - gets the starttime using Now from the time package\n"
+"// - runs the command using the u−root shell runit function\n"
+"// - computes a duration using Since from the time package\n"
+"// - if there is an error, prints the error to os.Stderr\n"
+"// - uses fmt. Printf to print the duration to os.Stderr\n"
+"// Note that since runtime always handles the error, by printing\n"
+"// it, it always returns nil. Most builtins return the error.\n"
+"// Here you can see the usage of the imported packages\n"
+"// from the imports statement above.\n"
+msgstr ""
+"// timecmd 函數傳遞要執行的指令的名稱，\n"
+"// 可選參數，並傳回錯誤。它：\n"
+"// - 使用時間包中的 Now 取得開始時間\n"
+"// - 使用 u-root shell runit 函數執行指令\n"
+"// - 使用時間包中的 Since 計算持續時間\n"
+"// - 如果有錯誤，則將錯誤印到 os.Stderr\n"
+"// - 使用 fmt。 Printf 將持續時間列印到 os.Stderr\n"
+"// 注意，由於運行時總是處理錯誤，透過列印\n"
+"// 它，它總是回傳 nil。大多數內建函數都會傳回錯誤。\n"
+"// 這裡可以看到導入包的使用情況\n"
+"// 來自上面的 imports 語句。\n"
+
+#: src/u-root.md:374
+#, fuzzy
+msgid ""
+"// This function is special in that it handles the error, and hence\n"
+"    // does not return an error.\n"
+"    // Most other builtins return the error.\n"
+msgstr ""
+"// 此函數的特殊之處在於它處理錯誤，因此\n"
+"    // 不回傳錯誤。\n"
+"    // 大多數其他內建函數都會傳回錯誤。\n"
+
+#: src/u-root.md:383
+#, fuzzy
+msgid "**Figure 2**: The code for the shell time builtin, Part II"
+msgstr "圖 2：shell time 內建函數的程式碼（第二部分）"
+
+#: src/u-root.md:385
+#, fuzzy
+msgid "Scripting and builtins"
+msgstr "腳本和內建命令"
+
+#: src/u-root.md:387
+msgid ""
+"To support scripting and builtins, u-root provides two programs: script and "
+"builtin. The script program allows users to specify a Go fragment on the "
+"command line, and runs that fragment as a program. The builtin program "
+"allows a Go fragment to be built into the shell as a new command. Builtins "
+"are persistent; the builtin command instantiates a new shell with the new "
+"command built in. Scripts run via the script command are not persistent."
+msgstr ""
+
+#: src/u-root.md:394
+#, fuzzy
+msgid "A basic hello builtin can be defined on the command line:"
+msgstr "可以在命令列上定義基本的 hello 內建指令："
+
+#: src/u-root.md:396
+msgid ""
+"```\n"
+"builtin hello '{ fmt.Printf(\"Hello\\n"
+"\") }'\n"
+"```"
+msgstr ""
+
+#: src/u-root.md:400
+#, fuzzy
+msgid ""
+"The fragment is defined by the {} pair. Given a fragment that starts with a "
+"{, the builtin command generates all the wrapper boiler plate needed. The "
+"builtin command is slightly different from the script command in that the Go "
+"fragment is bundled into one argument. The command accepts multiple pairs of "
+"command name and Go code fragments, allowing multiple new builtin commands "
+"to be installed in the shell."
+msgstr ""
+"該片段由 {} 對定義。給定一個以 { 開頭的片段，內建指令會產生所需的所有包裝器樣板。內建指令與腳本指令略有不同，因為 Go "
+"片段被捆綁到一個參數。該命令接受多對命令名和 Go 程式碼片段，允許在 shell 中安裝多個新的內建命令。"
+
+#: src/u-root.md:407
+#, fuzzy
+msgid ""
+"Builtin creates a new shell at `/bin/sh` with the source at `/src/cmds/sh/`. "
+"Invocations of `/bin/sh` by this shell and its children will use the new "
+"shell."
+msgstr ""
+"Builtin 在 `/bin/sh` 處建立一個新的 shell，其來源位於 `/src/cmds/sh/`。此 shell 及其子 shell "
+"對「/bin/sh」的呼叫將使用新的 shell。"
+
+#: src/u-root.md:410
+#, fuzzy
+msgid ""
+"Processes spawned by this new shell can access the new shell source and can "
+"run the builtin command again and create a shell that further extends the "
+"new shell. Processes outside the new shell’s process hierarchy can not use "
+"this new shell or the builtin source. When the new shell exits, the builtins "
+"are no longer visible in any part of the file system. We use Linux mount "
+"name spaces to create this effect[^22]. Once the builtin command has "
+"verified that the Go fragment is valid, it builds a new, private namespace "
+"with the shell source, including the new builtin source. From that point on, "
+"the new shell and its children will only use the new shell. The parent "
+"process and other processes outside the private namespace continue to use "
+"the old shell."
+msgstr ""
+"這個新shell產生的進程可以存取新的shell來源，並且可以再次執行內建指令並建立進一步擴展新shell的shell。新 shell "
+"的進程層次結構之外的進程不能使用這個新 shell 或內建來源。當新的 shell 退出時，內建指令在檔案系統的任何部分都不再可見。我們使用 Linux "
+"掛載命名空間來創建這種效果[^22]。一旦內建指令驗證了 Go 片段有效，它就會使用 shell "
+"來源（包括新的內建來源）建構一個新的私有命名空間。從那時起，新 shell 及其子 shell 將僅使用新 "
+"shell。父行程和私有命名空間以外的其他行程繼續使用舊的shell。"
+
+#: src/u-root.md:421
+#, fuzzy
+msgid "Figure 3 below shows an example usage of the script command."
+msgstr "下面的圖 3 顯示了腳本指令的範例用法。"
+
+#: src/u-root.md:423
+#, fuzzy
+msgid ""
+"This script implements printenv. Note that it is not a complete Go program "
+"in that it lacks a package statement, imports, a main function declaration, "
+"and a return at the end. All the boilerplate is added by the script command, "
+"which uses the Go imports package to scan the code and create the import "
+"statements required for compilation (in this case, both fmt and os packages "
+"are imported). Because the u-root shell is so simple, there is no need to "
+"escape many of these special characters. The complex parsing tasks have been "
+"offloaded to Go. Builtins are implemented in almost the same way. The "
+"builtin command takes the Go fragment and creates a standard shell builtin "
+"Go source file which conforms to the builtin pattern. This structure is easy "
+"to generate programmatically, building on the techniques used for the script "
+"command."
+msgstr ""
+"該腳本實現了printenv。請注意，它不是一個完整的 Go "
+"程序，因為它缺少套件語句、導入、主函數宣告和最後的返回。所有樣板都由腳本命令添加，該命令使用 Go "
+"導入包掃描程式碼並建立編譯所需的導入語句（在本例中，fmt 和 os 包都被導入）。由於 u-root shell "
+"非常簡單，因此不需要轉義許多這些特殊字元。複雜的解析任務已轉移到 Go。內建函數的實作方式幾乎相同。內建指令採用 Go 片段並建立符合內建模式的標準 "
+"shell 內建 Go 原始檔。基於腳本命令所使用的技術，這種結構很容易透過程式設計產生。"
+
+#: src/u-root.md:435
+msgid ""
+"```\n"
+"script{ fmt.Printf(\"%v\\n"
+"\", os.Environ()) }\n"
+"```"
+msgstr ""
+
+#: src/u-root.md:439
+#, fuzzy
+msgid ""
+"**Figure 3**: Go fragment for a printenv script. Code structure is inserted "
+"and packages are determined automatically."
+msgstr "**圖 3**：printenv 腳本的 Go 片段。插入程式碼結構並自動確定套件。"
+
+#: src/u-root.md:442
+#, fuzzy
+msgid "Environment variables"
+msgstr "環境變數"
+
+#: src/u-root.md:444
+msgid ""
+"The u-root shell supports environment variables, but manages them "
+"differently than most Unix environments. The variables are maintained in a "
+"directory called `/env`; the file name corresponds to the environment "
+"variable name, and the files contents are the value. When it is starting a "
+"new process, the shell populates child process environment variables from "
+"the `/env` directory. The syntax is the same; $ followed by a name directs "
+"the shell to substitute the value of the variable in the argument by "
+"prepending `/env` to the path and reading the file."
+msgstr ""
+
+#: src/u-root.md:453
+msgid ""
+"The shell variables described above are relative paths; `/env` is prepended "
+"to them. In the u-root shell, the name can also be an absolute path. For "
+"example, the command script $`/home/$USER/scripts/hello` will substitute the "
+"value of the `hello` script into the command line and then run the script "
+"command. The ability to place arbitrary text from a file into an argument is "
+"proving to be extremely convenient, especially for script and builtin "
+"commands."
+msgstr ""
+
+#: src/u-root.md:460
+#, fuzzy
+msgid "Using external packages and programs"
+msgstr "使用外部套件和程序"
+
+#: src/u-root.md:462
+#, fuzzy
+msgid ""
+"No root file system can provide all the packages all users want, and u-root "
+"is no exception. You need to have the ability to load external packages from "
+"popular Linux distros. The `tcz` command can be used to load external "
+"packages from the TinyCore Linux distribution, also known as _tinycore_. A "
+"tinycore package is a mountable file system image, containing all the "
+"package files, including a file listing any additional package dependencies. "
+"To load these packages, u-root provides the `tcz` command which fetches the "
+"package and needed dependencies. Hence, if a user wants emacs, they need "
+"merely type `tcz emacs`, and emacs will become available in "
+"`/usr/local/bin`. The tinycore packages directory can be a persistent "
+"directory or it can be empty on each boot."
+msgstr ""
+"沒有任何根檔案系統可以提供所有使用者想要的所有軟體包，u-root 也不例外。您需要具有從流行的 Linux 發行版載入外部套件的能力。 `tcz` "
+"指令可用於從 TinyCore Linux 發行版（也稱為 _tinycore_）載入外部套件。 tinycore "
+"套件是一個可安裝的檔案系統映像，包含所有套件文件，包括列出任何附加套件依賴項的文件。為了載入這些套件，u-root "
+"提供了「tcz」命令來取得套件和所需的依賴項。因此，如果用戶想要 emacs，他們只需輸入“tcz emacs”，emacs "
+"就會在“/usr/local/bin”中可用。 tinycore 套件目錄可以是持久性目錄，也可以在每次啟動時為空。"
+
+#: src/u-root.md:474
+#, fuzzy
+msgid ""
+"The `tcz` command is quite flexible as to what packages it loads and where "
+"they are loaded from. Users can specify the host name which provides the "
+"packages, the TCP port on which to connect, the version of tinycore to use, "
+"and the architecture. The `tcz` command must loopback mount each package as "
+"it is fetched, and hence must cache them locally. It will not refetch "
+"already cached packages. This cache can be volatile or maintained on more "
+"permanent storage. Performance varies depending on the network being used "
+"and the number of packages being loaded, but averages about 1 second per "
+"package on a WIFI-attached laptop. U-root also provides a small web server, "
+"called _srvfiles_, that can be used to serve locally cached tinycore "
+"packages for testing. The entire server is 18 lines of Go."
+msgstr ""
+"`tcz` 命令對於載入哪些套件以及從哪裡載入這些套件非常靈活。使用者可以指定提供軟體包的主機名稱、要連接的 TCP 連接埠、要使用的 tinycore "
+"版本以及架構。 `tcz` "
+"命令必須在取得每個套件時將其回送掛載，因此必須在本機上快取它們。它不會重新取得已經快取的套件。此快取可以是易失性的，也可以保存在更永久的記憶體中。效能取決於所使用的網路和載入的套件數量，但在連接 "
+"WIFI 的筆記型電腦上，每個套件平均需要 1 秒左右。 U-root 還提供了一個名為 _srvfiles_ 的小型 Web "
+"伺服器，可用於提供本地快取的 tinycore 套件以供測試。整個伺服器只有 18 行 Go 程式碼。"
+
+#: src/u-root.md:486
+#, fuzzy
+msgid "On-Demand Compilation"
+msgstr "按需編譯"
+
+#: src/u-root.md:488
+#, fuzzy
+msgid ""
+"On-Demand compilation is one of the oldest ideas in computer science. "
+"Slimline Open Firmware (SLOF)[^7] is a FORTHbased implementation of Open "
+"Firmware developed by IBM for some of its Power and Cell processors. SLOF is "
+"capable of storing all of Open Firmware as source in the flash memory and "
+"compiling components to indirect threading on demand[^2]."
+msgstr ""
+"按需編譯是電腦科學中最古老的思想之一。 Slimline Open Firmware (SLOF)[^7] 是 IBM 為其部分 Power 和 "
+"Cell 處理器開發的基於 FORTH 的開放韌體實作。 SLOF "
+"能夠將所有開放韌體作為原始碼儲存在快閃記憶體中，並根據需要將元件編譯為間接執行緒[^2]。"
+
+#: src/u-root.md:494
+#, fuzzy
+msgid ""
+"In the last few decades, as our compiler infrastructure has gotten slower "
+"and more complex, true on-demand compilation has split into two different "
+"forms. First is the on-demand compilation of source into executable byte "
+"codes, as in Python. The byte codes are not native but are more efficient "
+"than source. If the python interpreter finds the byte code it will interpret "
+"that instead of source to provide improved performance. Java takes the "
+"process one step further with the Just In Time compilation of byte code to "
+"machine code[^20] to boost performance."
+msgstr ""
+"在過去的幾十年裡，隨著我們的編譯器基礎設施變得越來越慢、越來越複雜，真正的按需編譯已經分裂成兩種不同的形式。首先是按需將原始碼編譯為可執行字節碼，就像 "
+"Python 一樣。字節碼不是本機的，但比原始碼更有效率。如果 Python 解釋器找到字節碼，它將解釋字節碼而不是原始程式碼，以提供更好的效能。 "
+"Java 透過將字節碼即時編譯為機器碼[^20]，使流程更進一步，從而提高了效能。"
+
+#: src/u-root.md:503
+#, fuzzy
+msgid "Embedding kernel and root file systems in flash"
+msgstr "在快閃記憶體中嵌入核心和根檔案系統"
+
+#: src/u-root.md:505
+#, fuzzy
+msgid ""
+"The LinuxBIOS project[^14][^1], together with clustermatic[^25], used an "
+"embedded kernel and simple root file system to manage supercomputing "
+"clusters. Due to space constraints of 1 MiB or less of flash, clusters "
+"embedded only a single-processor Linux kernel with a daemon. The daemon was "
+"a network bootloader that downloaded a more complex SMP kernel and root file "
+"system and started them. Clusters built this way were able to boot 1024 "
+"nodes in the time it took the standard PXE network boot firmware to find a "
+"working network interface."
+msgstr ""
+"LinuxBIOS 專案[^14][^1] 與 clustermatic[^25] "
+"一起使用嵌入式核心和簡單的根檔案系統來管理超級運算叢集。由於快閃記憶體的空間限制為 1 MiB 或更少，因此叢集僅嵌入了具有守護程序的單處理器 "
+"Linux 核心。該守護程序是一個網路引導程序，它下載更複雜的 SMP 核心和根檔案系統並啟動它們。透過這種方式建構的叢集能夠在標準 PXE "
+"網路啟動韌體找到工作網路介面的時間內啟動 1024 個節點。"
+
+#: src/u-root.md:514
+#, fuzzy
+msgid ""
+"Early versions of One Laptop Per Child used LinuxBIOS, with Linux in flash "
+"as a boot loader, to boot the eventual target. This system was very handy, "
+"as they were able to embed a full WIFI stack in flash with Linux, and could "
+"boot test OLPC images over WIFI. The continuing growth of the Linux kernel, "
+"coupled with the small flash size on OLPC, eventually led OLPC to move to "
+"Open Firmware."
+msgstr ""
+"「每個孩子一台筆記型電腦」的早期版本使用 LinuxBIOS，以快閃記憶體中的 Linux "
+"作為開機載入程式來啟動最終目標。這個系統非常方便，因為他們能夠在 Linux 快閃記憶體中嵌入完整的 WIFI 堆疊，並且可以透過 WIFI 啟動測試 "
+"OLPC 映像。 Linux 核心的不斷發展，再加上 OLPC 上的快閃記憶體尺寸較小，最終導致 OLPC 轉向開放韌體。"
+
+#: src/u-root.md:520
+#, fuzzy
+msgid ""
+"AlphaPower shipped their Alpha nodes with a so-called Direct Boot Linux, or "
+"DBLX. This work was never published, but the code was partially released on "
+"sourceforge.net just as AlphaPower went out of business.  Compaq also worked "
+"with a Linux-As-Bootloader for the iPaq."
+msgstr ""
+"AlphaPower 在其 Alpha 節點上搭載了所謂的 Direct Boot Linux（DBLX）。這項工作從未發表過，但就在 "
+"AlphaPower 倒閉時，部分程式碼在 sourceforge.net 上發布。  Compaq 也為 iPaq 採用了 "
+"Linux-As-Bootloader。"
+
+#: src/u-root.md:525
+#, fuzzy
+msgid ""
+"Car computers and other embedded ARM systems frequently contain a kernel and "
+"an ext2 formatted file system in NOR flash, that is, flash that can be "
+"treated as memory instead of a block device. Many of these kernels use the "
+"so-called eXecute In Place[^3] (XIP) patch, which allows the kernel to page "
+"binaries directly from the memory-addressable flash rather than copying it "
+"to RAM, providing a significant savings in system startup time. A downside "
+"of this approach is that the executables can not be compressed, which puts "
+"further pressure on the need to optimize binary size. NOR flash is very "
+"slow, and paging from it comes at a significant performance cost. Finally, "
+"an uncompressed binary image stored in NOR flash has a much higher monetary "
+"cost than the same image stored in RAM since the cost per bit is so much "
+"higher."
+msgstr ""
+"車載電腦和其他嵌入式 ARM 系統通常在 NOR 快閃記憶體中包含核心和 ext2 "
+"格式的檔案系統，也就是說，快閃記憶體可以被視為記憶體而不是區塊裝置。許多此類核心使用所謂的 eXecute In Place[^3] (XIP) "
+"補丁，該補丁允許核心直接從記憶體可尋址閃存分頁二進位文件，而不是將其複製到 "
+"RAM，從而大大節省了系統啟動時間。這種方法的缺點是可執行檔不能被壓縮，這給優化二進位大小的需求帶來了進一步的壓力。 NOR "
+"快閃記憶體非常緩慢，並且對其進行分頁會顯著降低效能。最後，儲存在 NOR 快閃記憶體中的未壓縮二進位影像的貨幣成本比儲存在 RAM "
+"中的相同影像高得多，因為每位的成本要高得多。"
+
+#: src/u-root.md:537
+#, fuzzy
+msgid ""
+"UEFI[^12] contains a non-Linux kernel (the UEFI firmware binary) and a full "
+"set of drivers, file systems, network protocol stacks, and command binaries "
+"in the firmware image. It is a full operating system environment realized as "
+"firmware."
+msgstr ""
+"UEFI[^12] 包含非 Linux 核心（UEFI "
+"韌體二進位）以及韌體映像中的一整套驅動程式、檔案系統、網路協定堆疊和命令二進位檔案。它是一個以韌體形式實現的完整作業系統環境。"
+
+#: src/u-root.md:541
+#, fuzzy
+msgid ""
+"The ONIE project[^23] is a more recent realization of the Kernel-in-flash "
+"idea, based on Linux. ONIE packs a Linux kernel and Busybox binaries into a "
+"very small package. Since the Linux build process allows an initial RAM file "
+"system (initramfs) to be built directly into the kernel binary, some "
+"companies are now embedding ONIE images into flash with coreboot. Sage "
+"Engineering has shown a bzImage with a small Busybox packed into a 4M image. "
+"ONIE has brought new life to an old idea: packaging a kernel and small set "
+"of binaries in flash to create a fast, capable boot system."
+msgstr ""
+"ONIE 專案[^23] 是基於 Linux 的 Kernel-in-flash 理念的較新實作。 ONIE 將 Linux 核心和 Busybox "
+"二進位檔案打包到一個非常小的套件中。由於 Linux 建置過程允許將初始 RAM "
+"檔案系統（initramfs）直接建置到核心二進位檔案中，因此一些公司現在使用 coreboot 將 ONIE 映像嵌入到快閃記憶體中。 Sage "
+"Engineering 展示了一個 bzImage，其中有一個小型 Busybox 被打包成一個 4M 圖像。 ONIE "
+"為一個舊想法注入了新的活力：將核心和一小組二進位檔案打包在快閃記憶體中，以創建一個快速、強大的啟動系統。"
+
+#: src/u-root.md:550
+#, fuzzy
+msgid "References"
+msgstr "參考"
+
+#: src/u-root.md:552
+#, fuzzy
+msgid ""
+"AGNEW, A., SULMICKI, A., MINNICH, R., AND ARBAUGH, W. A. Flexibility in rom: "
+"A stackable open source bios. In USENIX Annual Technical Conference, FREENIX "
+"Track (2003), pp. 115–124."
+msgstr ""
+"AGNEW, A.、SULMICKI, A.、MINNICH, R. 和 ARBAUGH, W. A. ROM 中的靈活性：可堆疊的開源 BIOS。在 "
+"USENIX 年度技術會議 FREENIX Track (2003) 中，第 115-124 頁。"
+
+#: src/u-root.md:555
+#, fuzzy
+msgid "(AUTHOR OF SLOF), S. B. Personal conversation."
+msgstr "（SLOF 的作者），S. B. 個人對話。"
+
+#: src/u-root.md:556
+#, fuzzy
+msgid ""
+"BENAVIDES, T., TREON, J., HULBERT, J., AND CHANG, W. The enabling of an "
+"execute-in-place architecture to reduce the embedded system memory footprint "
+"and boot time. Journal of computers 3, 1 (2008), 79–89."
+msgstr ""
+"BENAVIDES, T.、TREON, J.、HULBERT, J. 和 CHANG, W. "
+"啟用就地執行架構以減少嵌入式系統記憶體佔用和啟動時間。電腦雜誌 3, 1 (2008), 79-89。"
+
+#: src/u-root.md:559
+#, fuzzy
+msgid ""
+"BOGOWITZ, B., AND SWINFORD, T. Intel⃝R active management technology reduces "
+"it costs with improved pc manageability. Technology@ Intel Magazine (2004)."
+msgstr ""
+"BOGOWITZ，B.，和 SWINFORD，T. Intel® 主動管理技術透過提高 PC 可管理性來降低 IT 成本。技術@英特爾雜誌（2004 "
+"年）。"
+
+#: src/u-root.md:562
+#, fuzzy
+msgid ""
+"CELEDA, P., KREJCI, R., VYKOPAL, J., AND DRASAR, M. Embedded malware-an "
+"analysis of the chuck norris botnet. In Computer Network Defense (EC2ND), "
+"2010 European Conference on (2010), IEEE, pp. 3–10."
+msgstr ""
+"CELEDA，P.、KREJCI，R.、VYKOPAL，J. 和 DRASAR，M. "
+"嵌入式惡意軟體——對查克·諾里斯殭屍網路的分析。在電腦網路防禦（EC2ND）中，2010 年歐洲會議（2010），IEEE，第 3-10 頁。"
+
+#: src/u-root.md:565
+#, fuzzy
+msgid ""
+"CUI, A., COSTELLO, M., AND STOLFO, S. J. When firmware modifications attack: "
+"A case study of embedded exploitation. In NDSS (2013)."
+msgstr "CUI, A.、COSTELLO, M. 和 STOLFO, S. J. 當韌體修改受到攻擊：嵌入式利用的案例研究。在 NDSS（2013）中。"
+
+#: src/u-root.md:567
+#, fuzzy
+msgid ""
+"DALY, D., CHOI, J. H., MOREIRA, J. E., AND WATERLAND, A. Base operating "
+"system provisioning and bringup for a commercial supercomputer. In Parallel "
+"and Distributed Processing Symposium, 2007. IPDPS 2007. IEEE International "
+"(2007), IEEE, pp. 1–7."
+msgstr ""
+"DALY, D.、CHOI, J. H.、MOREIRA, J. E. 和 WATERLAND, A. "
+"為商業超級電腦提供基礎作業系統設定和啟動。在平行與分散式處理研討會上，2007 年。 IPDPS 2007。 IEEE 國際（2007），IEEE，第 "
+"1-7 頁。"
+
+#: src/u-root.md:571
+#, fuzzy
+msgid ""
+"DURUMERIC, Z., KASTEN, J., ADRIAN, D., HALDERMAN, J. A., BAILEY, M., LI, F., "
+"WEAVER, N., AMANN, J., BEEKMAN, J., PAYER, M., ET AL. The matter of "
+"heartbleed. In Proceedings of the 2014 Conference on Internet Measurement "
+"Conference (2014), ACM, pp. 475–488."
+msgstr ""
+"DURUMERIC, Z.、KASTEN, J.、ADRIAN, D.、HALDERMAN, J. A.、BAILEY, M.、LI, "
+"F.、WEAVER, N.、AMANN, J.、BEEKMAN, J.、PAYER, M. 等。心血問題。在 2014 年網路測量會議論文集 "
+"(2014) 中，ACM，第 475-488 頁。"
+
+#: src/u-root.md:575
+#, fuzzy
+msgid ""
+"KALLENBERG, C., AND BULYGIN, Y. All your boot are belong to us intel, mitre. "
+"cansecwest 2014."
+msgstr "KALLENBERG，C.，和BULYGIN，Y. 你的所有靴子都屬於我們英特爾，mitre。加拿大西部 2014。"
+
+#: src/u-root.md:577
+#, fuzzy
+msgid ""
+"KALLENBERG, C., KOVAH, X., BUTTERWORTH, J., AND CORNWELL, S. Extreme "
+"privilege escalation on windows 8/uefi systems."
+msgstr ""
+"KALLENBERG，C.、KOVAH，X.、BUTTERWORTH，J. 和 CORNWELL，S. Windows 8/uefi "
+"系統上的極端權限提升。"
+
+#: src/u-root.md:579
+#, fuzzy
+msgid ""
+"KOZIOL, J., LITCHFIELD, D., AITEL, D., ANLEY, C., EREN, S., MEHTA, N., AND "
+"HASSELL, R. The Shellcoder’s Handbook. Wiley Indianapolis, 2004."
+msgstr ""
+"KOZIOL, J.、LITCHFIELD, D.、AITEL, D.、ANLEY, C.、EREN, S.、MEHTA, N. 和 HASSELL, "
+"R. Shellcoder 手冊。威利印第安納波利斯，2004 年。"
+
+#: src/u-root.md:581
+#, fuzzy
+msgid "LEWIS, T. Uefi overview, 2007."
+msgstr "LEWIS，T.Uefi 概述，2007 年。"
+
+#: src/u-root.md:582
+#, fuzzy
+msgid "MAY,D.Occam.ACMSigplanNotices18,4(1983),69–79."
+msgstr "MAY，D.Occam.ACMSigplanNotices18,4(1983),69–79。"
+
+#: src/u-root.md:583
+#, fuzzy
+msgid "MINNICH, R. G. Linuxbios at four. Linux J. 2004, 118 (Feb. 2004), 8–."
+msgstr "MINNICH, R. G. Linuxbios 四點。 Linux J. 2004, 118 (2004 年 2 月), 8-。"
+
+#: src/u-root.md:584
+#, fuzzy
+msgid ""
+"MOON, S.-P., KIM, J.-W., BAE, K.-H., LEE, J.-C., AND SEO, D.-W. Embedded "
+"linux implementation on a commercial digital tv system. Consumer "
+"Electronics, IEEE Transactions on 49, 4 (Nov 2003), 1402–1407."
+msgstr ""
+"MOON, S.-P.、KIM, J.-W.、BAE, K.-H.、LEE, J.-C. 和 SEO, "
+"D.-W.嵌入式Linux在商業數位電視系統上的實現。消費性電子產品，IEEE 期刊 49，4（2003 年 11 月），1402–1407。"
+
+#: src/u-root.md:587
+#, fuzzy
+msgid ""
+"PIKE, R. Another go at language design. Stanford University Computer Systems "
+"Laboratory Colloquium."
+msgstr "PIKE，R. 另一種語言設計方式。史丹佛大學電腦系統實驗室座談會。"
+
+#: src/u-root.md:589
+#, fuzzy
+msgid ""
+"RITCHIE, D. M. The limbo programming language. Inferno Programmer’s Manual 2 "
+"(1997)."
+msgstr "RITCHIE，D. M. 邊緣程式語言。 Inferno 程式設計師手冊 2 (1997)。"
+
+#: src/u-root.md:591
+#, fuzzy
+msgid ""
+"SACCO, A. L., AND ORTEGA, A. A. Persistent bios infection. In CanSecWest "
+"Applied Security Conference (2009)."
+msgstr "SACCO，A. L.，AND ORTEGA，A. A.持續性 bios 感染。在 CanSecWest 應用安全會議 (2009) 上。"
+
+#: src/u-root.md:593
+#, fuzzy
+msgid ""
+"SAMPATHKUMAR, R. Vulnerability Management for Cloud Computing-2014: A Cloud "
+"Computing Security Essential. Rajakumar Sampathkumar, 2014."
+msgstr "SAMPATHKUMAR，R.雲端運算漏洞管理-2014：雲端運算安全要點。拉賈庫馬爾桑帕特庫馬爾，2014 年。"
+
+#: src/u-root.md:595
+#, fuzzy
+msgid ""
+"SUGANUMA, T., OGASAWARA, T., TAKEUCHI, M., YASUE, T., KAWAHITO, M., "
+"ISHIZAKI, K., KOMATSU, H., AND NAKATANI, T. Overview of the ibm java "
+"just-in-time compiler. IBM systems Journal 39, 1 (2000), 175–193."
+msgstr ""
+"SUGANUMA, T.、OGASAWARA, T.、TAKEUCHI, M.、YASUE, T.、KAWAHITO, M.、ISHIZAKI, "
+"K.、KOMATSU, H. 和 NAKATANI, T. IBM Java 即時編譯器概述。 IBM 系統雜誌 39, 1 (2000), "
+"175–193。"
+
+#: src/u-root.md:598
+#, fuzzy
+msgid ""
+"TEAM, G. The go programming language specification. Tech. rep., Technical "
+"Report [http://golang](http://golang/). org/doc/doc/go spec. html, Google "
+"Inc, 2009."
+msgstr ""
+"TEAM, G. Go 程式語言規範。技術。報告，技術報告[http://golang](http://golang/)。 org/doc/doc/go "
+"規格。 html，Google 公司，2009 年。"
+
+#: src/u-root.md:601
+#, fuzzy
+msgid ""
+"VAN HENSBERGEN, E., AND MINNICH, R. Grave robbers from outer space: Using "
+"9p2000 under linux. In USENIX Annual Technical Conference, FREENIX Track "
+"(2005), pp. 83–94."
+msgstr ""
+"VAN HENSBERGEN，E.，和MINNICH，R.來自外太空的盜墓者：在Linux下使用9p2000。在 USENIX 年度技術會議 "
+"FREENIX Track (2005) 中，第 83-94 頁。"
+
+#: src/u-root.md:604
+msgid "VARIOUS. No papers have been published on onie; see onie.org."
+msgstr ""
+
+#: src/u-root.md:605
+msgid "VARIOUS. No papers were published; see perllinux.sourceforge.net."
+msgstr ""
+
+#: src/u-root.md:606
+#, fuzzy
+msgid ""
+"WATSON, G. R., SOTTILE, M. J., MINNICH, R. G., CHOI, S.-E., AND HERTDRIKS, "
+"E. Pink: A 1024-node single-system image linux cluster. In High Performance "
+"Computing and Grid in Asia Pacific Region, 2004. Proceedings. Seventh "
+"International Conference on (2004), IEEE, pp. 454–461."
+msgstr ""
+"WATSON, G. R.、SOTTILE, M. J.、MINNICH, R. G.、CHOI, S.-E. 和 HERTDRIKS, E. "
+"Pink：1024 節點單系統映像 Linux 叢集。在2004 年亞太地區的高效能運算和網格中。會議記錄。第七屆國際會議（2004 年），IEEE，第 "
+"454-461 頁。"
+
+#: src/u-root.md:610
+#, fuzzy
+msgid ""
+"WELLS, N. Busybox: A swiss army knife for linux. Linux J. 2000, 78es (Oct. "
+"2000)."
+msgstr "WELLS，N. Busybox：Linux 的瑞士軍刀。 Linux J. 2000, 78es (2000 年 10 月)。"
+
+#: src/u-root.md:612
+#, fuzzy
+msgid ""
+"WINTERBOTTOM, P. Alef language reference manual. Plan 9 Programmer’s Man "
+"(1995)."
+msgstr "WINTERBOTTOM，P.Alef 語言參考手冊。 9號計畫程式設計師（1995年）。"
+
+#: src/u-root-qemu-demo.md:3
+#, fuzzy
+msgid ""
+"You can try out LinuxBoot without needing to build anything! You can try out "
+"LinuxBoot needing only 3 commands."
+msgstr "您無需建立任何東西即可試用 LinuxBoot！您只需 3 個命令即可試用 LinuxBoot。"
+
+#: src/u-root-qemu-demo.md:6
+#, fuzzy
+msgid ""
+"We have made Initial Ram File System (initramfs) images available for four "
+"architectures: arm, aarch64, amd64 (a.k.a. x86_64), and riscv64."
+msgstr ""
+"我們已為四種架構提供了初始 Ram 檔案系統 (initramfs) 映像：arm、aarch64、amd64（又名 x86_64）和 riscv64。"
+
+#: src/u-root-qemu-demo.md:9
+#, fuzzy
+msgid ""
+"For now, we only have a kernel ready for x86_64, so the instructions below "
+"apply to that."
+msgstr "目前，我們只有一個適用於 x86_64 的內核，因此以下說明適用於該內核。"
+
+#: src/u-root-qemu-demo.md:12
+#, fuzzy
+msgid ""
+"First, you can get the initramfs image, which mainly contains Go programs "
+"from the u-root project."
+msgstr "首先，您可以取得 initramfs 映像，其中主要包含來自 u-root 專案的 Go 程式。"
+
+#: src/u-root-qemu-demo.md:19
+#, fuzzy
+msgid ""
+"Next, you will need to get a kernel. We use a pre-built kernel from Arch "
+"Linux."
+msgstr "接下來，您需要取得一個內核。我們使用 Arch Linux 的預先建置核心。"
+
+#: src/u-root-qemu-demo.md:26
+#, fuzzy
+msgid "Now you are ready to test LinuxBoot out."
+msgstr "現在您已準備好測試 LinuxBoot。"
+
+#: src/u-root-qemu-demo.md:29 src/u-root-qemu-demo.md:36
+#, fuzzy
+msgid "\"console=ttyS0\""
+msgstr "“控制台=ttyS0”"
+
+#: src/u-root-qemu-demo.md:33
+#, fuzzy
+msgid "Or, for example, on Darwin:"
+msgstr "或者，例如關於達爾文："
+
+#: src/u-root-qemu-demo.md:40
+#, fuzzy
+msgid "You will see the following:"
+msgstr "您將看到以下內容："
+
+#: src/u-root-qemu-demo.md:54
+#, fuzzy
+msgid "You can type uname:"
+msgstr "您可以輸入 uname："
+
+#: src/u-root-qemu-demo.md:62
+#, fuzzy
+msgid "To exit qemu, just run the poweroff command:"
+msgstr "要退出 qemu，只需執行 poweroff 命令："
+
+#: src/u-root-qemu-demo.md:69
+#, fuzzy
+msgid "You have just run your first LinuxBoot kernel."
+msgstr "您剛剛運行了您的第一個 LinuxBoot 核心。"
+
+#: src/utilities/index.md:1
+#, fuzzy
+msgid "LinuxBoot Utilities"
+msgstr "Linux啟動實用程式"
+
+#: src/utilities/index.md:3
+#, fuzzy
+msgid ""
+"In order to bootstrap, build and maintain LinuxBoot projects, we provide a "
+"handful of utilities for extracting, reducing, reworking, and stitching "
+"firmware images."
+msgstr "為了引導、建置和維護 LinuxBoot 項目，我們提供了一些用於提取、減少、重新加工和拼接韌體映像的實用程式。"
+
+#: src/utilities/UEFI_Tool_Kit.md:3
+#, fuzzy
+msgid "Authors: Ryan O'Leary, Gan Shun Lim and Andrea Barberio"
+msgstr "作者：Ryan O'Leary、Gan Shun Lim 和 Andrea Barberio"
+
+#: src/utilities/UEFI_Tool_Kit.md:5
+#, fuzzy
+msgid ""
+"In previous chapters, you learned how to read a raw ROM image from a flash "
+"part. If you've been following along, you know the next step is to insert a "
+"Linux kernel."
+msgstr "在前面的章節中，您學習如何從快閃記憶體部分讀取原始 ROM 映像。如果您一直在關注，您就會知道下一步是插入 Linux 核心。"
+
+#: src/utilities/UEFI_Tool_Kit.md:9
+#, fuzzy
+msgid ""
+"Inspecting and modifying ROM images is tricky and can involve a fair amount "
+"of tinkering. These images typically contain a number of file systems, "
+"drivers, tables, data structures and opaque blobs. They also differ "
+"significantly from the UNIX model of a file systems, thus cannot be "
+"reasonably mounted in Linux."
+msgstr ""
+"檢查和修改 ROM 圖像很棘手，可能涉及大量的修補。這些圖像通常包含許多檔案系統、驅動程式、表格、資料結構和不透明的斑點。它們與檔案系統的 UNIX "
+"模型也有很大不同，因此無法在 Linux 中合理安裝。"
+
+#: src/utilities/UEFI_Tool_Kit.md:14
+#, fuzzy
+msgid ""
+"UEFI Tool Kit (UTK) is intended to be a one-stop-shop for reading, writing "
+"and modifying UEFI images -- the most common type of firmware image for x86 "
+"systems. UTK can parse a number of data structures including UEFI firmware "
+"volumes, Intel firmware descriptors and FIT."
+msgstr ""
+"UEFI 工具包 (UTK) 設計為讀取、寫入和修改 UEFI 映像（x86 系統最常見的韌體映像類型）的一站式服務。 UTK "
+"可以解析許多資料結構，包括 UEFI 韌體磁碟區、英特爾韌體描述符和 FIT。"
+
+#: src/utilities/UEFI_Tool_Kit.md:19
+#, fuzzy
+msgid "In this chapter, we'll go over how to:"
+msgstr "在本章中，我們將介紹如何："
+
+#: src/utilities/UEFI_Tool_Kit.md:21
+#, fuzzy
+msgid "Install UTK"
+msgstr "安裝 UTK"
+
+#: src/utilities/UEFI_Tool_Kit.md:22
+#, fuzzy
+msgid "Inspect ROMs"
+msgstr "檢查 ROM"
+
+#: src/utilities/UEFI_Tool_Kit.md:23
+#, fuzzy
+msgid "Modify ROMs"
+msgstr "修改ROM"
+
+#: src/utilities/UEFI_Tool_Kit.md:24
+#, fuzzy
+msgid "Common pitfalls"
+msgstr "常見的陷阱"
+
+#: src/utilities/UEFI_Tool_Kit.md:25
+#, fuzzy
+msgid "Extend UTK with additional commands"
+msgstr "使用附加命令擴展 UTK"
+
+#: src/utilities/UEFI_Tool_Kit.md:27
+#, fuzzy
+msgid "Synopsis"
+msgstr "概要"
+
+#: src/utilities/UEFI_Tool_Kit.md:36
+#, fuzzy
+msgid "Quick start"
+msgstr "快速啟動"
+
+#: src/utilities/UEFI_Tool_Kit.md:38
+#, fuzzy
+msgid "We assume you have a way to read and write the FLASH into a file."
+msgstr "我們假設您有辦法讀取 FLASH 並將其寫入檔案。"
+
+#: src/utilities/UEFI_Tool_Kit.md:40
+msgid ""
+"Let's assume you have read FLASH into an image called ROM.bin and you have a "
+"kernel, called bzImage, which you want to insert into ROM.bin. Be sure the "
+"kernel is buildable as an EFI driver (DXE); see the pitfalls section. The "
+"easiest option is to replace the UEFI shell. This is a quick and easy way to "
+"get started. In the long term, you want to remove as much of UEFI as "
+"possible, but replacing the shell is always our first step on a new board."
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:48
+#, fuzzy
+msgid "Get the tool:"
+msgstr "取得工具："
+
+#: src/utilities/UEFI_Tool_Kit.md:54
+#, fuzzy
+msgid "Replace the shell:"
+msgstr "更換外殼："
+
+#: src/utilities/UEFI_Tool_Kit.md:60
+#, fuzzy
+msgid ""
+"After that, you can flash NEWROM.bin and test. If anything goes wrong, such "
+"as not enough space, you will need to refer to the more detailed "
+"instructions below."
+msgstr "之後，您可以刷新 NEWROM.bin 並進行測試。如果出現任何問題，例如空間不足，您將需要參考下面更詳細的說明。"
+
+#: src/utilities/UEFI_Tool_Kit.md:64
+#, fuzzy
+msgid "Installation"
+msgstr "安裝"
+
+#: src/utilities/UEFI_Tool_Kit.md:66
+#, fuzzy
+msgid ""
+"At the time of writing, you must clone and build UTK from source -- binary "
+"distributions are not officially available. The source code resides in the "
+"[Fiano Github project](https://github.com/linuxboot/fiano/)."
+msgstr ""
+"在撰寫本文時，您必須從原始程式碼複製和建置 UTK——二進位分佈尚未正式提供。原始碼位於 [Fiano Github "
+"專案](https://github.com/linuxboot/fiano/) 中。"
+
+#: src/utilities/UEFI_Tool_Kit.md:70
+#, fuzzy
+msgid ""
+"Aside: what is the difference between Fiano and UTK? The Fiano project "
+"contains a few more tools besides UTK, but UTK is a big element."
+msgstr "P.S.：Fiano 和 UTK 有什麼不同？ Fiano 計畫除了 UTK 之外還包含一些其他工具，但 UTK 是重要元素。"
+
+#: src/utilities/UEFI_Tool_Kit.md:73
+#, fuzzy
+msgid "We'll assume you already have Go installed. Check your installation with:"
+msgstr "我們假設您已經安裝了 Go。使用以下命令檢查您的安裝："
+
+#: src/utilities/UEFI_Tool_Kit.md:80
+#, fuzzy
+msgid ""
+"Linux and the latest stable version of Go are recommended. Either download "
+"the official binary distributions of Go or install from source. See "
+"[https://golang.org/](https://golang.org/) for details."
+msgstr ""
+"建議使用 Linux 和最新穩定版本的 Go。下載 Go "
+"的官方二進位發行版或從原始碼安裝。詳情請參閱[https://golang.org/](https://golang.org/)。"
+
+#: src/utilities/UEFI_Tool_Kit.md:84
+#, fuzzy
+msgid "With Go, download and install UTK:"
+msgstr "使用 Go 下載並安裝 UTK："
+
+#: src/utilities/UEFI_Tool_Kit.md:90
+#, fuzzy
+msgid ""
+"Running the above line installs `utk` to your `$GOPATH/bin` directory (or "
+"`$HOME/go/bin` if the `GOPATH` environment variable is not set). Adding this "
+"directory to your `$PATH` is recommended."
+msgstr ""
+"執行上述程式碼將“utk”安裝到您的“$GOPATH/bin”目錄（如果未設定“GOPATH”環境變量，則安裝到“$HOME/go/bin”）。建議將此目錄新增至您的“$PATH”。"
+
+#: src/utilities/UEFI_Tool_Kit.md:94
+#, fuzzy
+msgid "Make sure it works with:"
+msgstr "確保其適用於："
+
+#: src/utilities/UEFI_Tool_Kit.md:124
+#, fuzzy
+msgid ""
+"Don't fret if your list of operations differs. UTK is an evolving project!"
+msgstr "如果您的操作清單有所不同，請不要擔心。 UTK 是一個不斷發展的計畫！"
+
+#: src/utilities/UEFI_Tool_Kit.md:126
+#, fuzzy
+msgid "Inspecting ROMs"
+msgstr "檢查ROM"
+
+#: src/utilities/UEFI_Tool_Kit.md:128
+#, fuzzy
+msgid ""
+"Throughout this section, we'll demonstrate commands for inspecting a UEFI "
+"image. When confronted with a new image, run these commands to get a \"lay "
+"of the land\"."
+msgstr "在本節中，我們將示範檢查 UEFI 映像的命令。當面對新影像時，請執行這些命令以獲取“地形”。"
+
+#: src/utilities/UEFI_Tool_Kit.md:132
+#, fuzzy
+msgid "Start by downloading the UEFI image used in these examples:"
+msgstr "首先下載這些範例中使用的 UEFI 映像："
+
+#: src/utilities/UEFI_Tool_Kit.md:134
+msgid ""
+"```\n"
+"wget "
+"https://github.com/linuxboot/fiano/raw/master/integration/roms/OVMF.rom\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:138
+#, fuzzy
+msgid ""
+"Aside: alternatively, all UTK operations should work with your own UEFI "
+"images. Simply substitute \"OVMF.rom\" with your own UEFI image in all the "
+"examples below. If you encounter any problems, please file an issue at "
+"[https://github.com/linuxboot/fiano/issues](https://github.com/linuxboot/fiano/issues)."
+msgstr ""
+"另外：另外，所有 UTK 操作都應該與您自己的 UEFI 映像一起使用。在下面的所有範例中，只需用您自己的 UEFI "
+"映像取代「OVMF.rom」即可。如果您遇到任何問題，請在 "
+"[https://github.com/linuxboot/fiano/issues](https://github.com/linuxboot/fiano/issues) "
+"上提交問題。"
+
+#: src/utilities/UEFI_Tool_Kit.md:143
+#, fuzzy
+msgid "First, it is advisable to print a count of each firmware element:"
+msgstr "首先，建議列印每個韌體元素的數量："
+
+#: src/utilities/UEFI_Tool_Kit.md:145
+msgid ""
+"```\n"
+"$ utk OVMF.rom count\n"
+"{\n"
+"        \"FirmwareTypeCount\": {\n"
+"                \"BIOSRegion\": 1,\n"
+"                \"File\": 118,\n"
+"                \"FirmwareVolume\": 5,\n"
+"                \"Section\": 365\n"
+"        },\n"
+"        \"FileTypeCount\": {\n"
+"                \"EFI_FV_FILETYPE_APPLICATION\": 2,\n"
+"                \"EFI_FV_FILETYPE_DRIVER\": 94,\n"
+"                \"EFI_FV_FILETYPE_DXE_CORE\": 1,\n"
+"                \"EFI_FV_FILETYPE_FFS_PAD\": 7,\n"
+"                \"EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE\": 1,\n"
+"                \"EFI_FV_FILETYPE_FREEFORM\": 3,\n"
+"                \"EFI_FV_FILETYPE_PEIM\": 7,\n"
+"                \"EFI_FV_FILETYPE_PEI_CORE\": 1,\n"
+"                \"EFI_FV_FILETYPE_RAW\": 1,\n"
+"                \"EFI_FV_FILETYPE_SECURITY_CORE\": 1\n"
+"        },\n"
+"        \"SectionTypeCount\": {\n"
+"                \"EFI_SECTION_DXE_DEPEX\": 44,\n"
+"                \"EFI_SECTION_FIRMWARE_VOLUME_IMAGE\": 2,\n"
+"                \"EFI_SECTION_GUID_DEFINED\": 1,\n"
+"                \"EFI_SECTION_PE32\": 99,\n"
+"                \"EFI_SECTION_RAW\": 21,\n"
+"                \"EFI_SECTION_USER_INTERFACE\": 99,\n"
+"                \"EFI_SECTION_VERSION\": 99\n"
+"        }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:178
+#, fuzzy
+msgid ""
+"The definition of a \"Firmware Element\" is in order. Firmware images are "
+"hierarchical and can be represented as a tree. Each node in the tree is a "
+"\"Firmware Element\". Each element has a type such as \"BIOSRegion\", "
+"\"FirmwareVolume\", \"File\" and \"Section\" as seen above. Files (and "
+"sections) themselves have an additional type dictated by the UEFI spec. "
+"There are three major file types you should be aware of:"
+msgstr ""
+"「韌體元素」的定義是有序的。韌體映像是分層的，可以表示為樹。樹中的每個節點都是一個「韌體元素」。每個元素都有一個類型，例如如上所示的「BIOSRegion」、「FirmwareVolume」、「File」和「Section」。文件（和部分）本身俱有由 "
+"UEFI 規範規定的附加類型。您應該了解三種主要文件類型："
+
+#: src/utilities/UEFI_Tool_Kit.md:185
+#, fuzzy
+msgid ""
+"`EFI_FV_FILETYPE_DRIVER`: This is the most numerous file type and is often "
+"called a \"DXE\". They persist in memory even after their main function "
+"exits."
+msgstr "`EFI_FV_FILETYPE_DRIVER`：這是最常見的檔案類型，通常稱為「DXE」。即使其主函數退出後，它們仍會保留在記憶體中。"
+
+#: src/utilities/UEFI_Tool_Kit.md:187
+#, fuzzy
+msgid ""
+"`EFI_FV_FILETYPE_APPLICATION`: Applications do not persist in memory after "
+"exiting. For example, the EFI Shell is an EFI Application."
+msgstr ""
+"`EFI_FV_FILETYPE_APPLICATION`：應用程式退出後不會保留在記憶體中。例如，EFI Shell 是一個 EFI 應用程式。"
+
+#: src/utilities/UEFI_Tool_Kit.md:189
+#, fuzzy
+msgid ""
+"`EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE`: These file types allow nesting "
+"firmware volumes. You will see this when an entire firmware volume is "
+"compressed."
+msgstr ""
+"`EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE`：這些檔案類型允許巢狀韌體磁碟區。當整個韌體磁碟區被壓縮時，您將看到這一點。"
+
+#: src/utilities/UEFI_Tool_Kit.md:193
+#, fuzzy
+msgid "TODO: Diagram showing a tree of these firmware elements."
+msgstr "TODO：圖表顯示了這些韌體元素的樹。"
+
+#: src/utilities/UEFI_Tool_Kit.md:195
+#, fuzzy
+msgid ""
+"To view a human-readable tree of all the firmware elements, types and sizes, "
+"run:"
+msgstr "若要查看所有韌體元素、類型和大小的可讀樹，請執行："
+
+#: src/utilities/UEFI_Tool_Kit.md:221
+#, fuzzy
+msgid ""
+"This format is compact and easy for humans reading, but not ideal for "
+"machine consumption. Use the `json` command to print everything (including "
+"much more metadata) as JSON:"
+msgstr "這種格式緊湊且易於人類閱讀，但不適合機器使用。使用 `json` 指令將所有內容（包括更多元資料）列印為 JSON："
+
+#: src/utilities/UEFI_Tool_Kit.md:229
+#, fuzzy
+msgid ""
+"Combine `utk` with the JSON query command, `jq` (`sudo apt-get install jq`), "
+"and other UNIX commands to quickly write powerful queries. For example, the "
+"following lists all the GUIDs, sorted and without duplicates:"
+msgstr ""
+"將 `utk` 與 JSON 查詢命令、`jq`（`sudo apt-get install jq`）以及其他 UNIX "
+"命令結合起來，可以快速編寫強大的查詢。例如，下面列出了所有 GUID，已排序且沒有重複："
+
+#: src/utilities/UEFI_Tool_Kit.md:233
+msgid ""
+"```\n"
+"$ utk OVMF.rom json | jq -r '..|.GUID?|select(type==\"string\")' | sort -u\n"
+"00000000-0000-0000-0000-000000000000\n"
+"0167CCC4-D0F7-4F21-A3EF-9E64B7CDCE8B\n"
+"0170F60C-1D40-4651-956D-F0BD9879D527\n"
+"021722D8-522B-4079-852A-FE44C2C13F49\n"
+"025BBFC7-E6A9-4B8B-82AD-6815A1AEAF4A\n"
+"...\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:243
+#, fuzzy
+msgid "To only print the JSON for specific files, use the find command:"
+msgstr "若要僅列印特定檔案的 JSON，請使用 find 指令："
+
+#: src/utilities/UEFI_Tool_Kit.md:245
+msgid ""
+"```\n"
+"# The find command uses a regex to match on the name or GUID.\n"
+"# These three examples find and print the JSON for the same file:\n"
+"$ utk OVMF.rom find 'Sh.*'\n"
+"$ utk OVMF.rom find 'Shell'\n"
+"$ utk OVMF.rom find 7C04A583-9E3E-4F1C-AD65-E05268D0B4D1\n"
+"{\n"
+"        \"Header\": {\n"
+"                \"UUID\": {\n"
+"                        \"UUID\": \"7C04A583-9E3E-4F1C-AD65-E05268D0B4D1\"\n"
+"                },\n"
+"                \"Type\": 9,\n"
+"                \"Attributes\": 0\n"
+"        },\n"
+"        \"Type\": \"EFI_FV_FILETYPE_APPLICATION\",\n"
+"        \"Sections\": [\n"
+"                {\n"
+"                        \"Header\": {\n"
+"                                \"Type\": 21\n"
+"                        },\n"
+"                        \"Type\": \"EFI_SECTION_USER_INTERFACE\",\n"
+"                        \"ExtractPath\": \"\",\n"
+"                        \"Name\": \"Shell\"\n"
+"                },\n"
+"                ...\n"
+"        ],\n"
+"        \"ExtractPath\": \"\",\n"
+"        \"DataOffset\": 24\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/utilities/UEFI_Tool_Kit.md:276
+#, fuzzy
+msgid ""
+"Note that UEFI uses GUIDs to identify files. Some files also have a name "
+"which is stored within the file's UI section. Like `find`, most of UTKs "
+"commands let you match a file by its name or GUID."
+msgstr ""
+"請注意，UEFI 使用 GUID 來識別檔案。有些檔案還有一個名稱，該名稱儲存在檔案的 UI 部分中。與「find」類似，大多數 UTK "
+"命令允許您透過檔案名稱或 GUID 來匹配檔案。"
+
+#: src/utilities/UEFI_Tool_Kit.md:280
+#, fuzzy
+msgid ""
+"The examples up until now have only dealt with file metadata and not the "
+"file's contents. The `extract <DIR>` command extracts all the files from the "
+"image and saves them to `<DIR>`. `<DIR>/summary.json` lists all the paths to "
+"the extracted files along with their metadata."
+msgstr ""
+"到目前為止的範例僅處理文件元數據，而不是文件的內容。 `extract <DIR>` 命令從映像中提取所有檔案並將其儲存到 `<DIR>`。 "
+"`<DIR>/summary.json` 列出了提取檔案的所有路徑及其元資料。"
+
+#: src/utilities/UEFI_Tool_Kit.md:289
+#, fuzzy
+msgid "After modifying the files, they can be reassembled with:"
+msgstr "修改檔案後，可以使用以下命令重新組裝它們："
+
+#: src/utilities/UEFI_Tool_Kit.md:295
+#, fuzzy
+msgid "Modifying ROMs"
+msgstr "修改ROM"
+
+#: src/utilities/UEFI_Tool_Kit.md:297
+#, fuzzy
+msgid ""
+"First, let's verify the image works by running it inside QEMU. This step is "
+"not absolutely necessary, but gives us confidence the image works before and "
+"after each change we make."
+msgstr "首先，讓我們透過在 QEMU 中運行它來驗證映像是否有效。此步驟並非絕對必要，但可以讓我們相信圖像在每次更改之前和之後都能正常運作。"
+
+#: src/utilities/UEFI_Tool_Kit.md:305
+#, fuzzy
+msgid "For the provided OVMF.rom image, this should boot to the EDK2 shell."
+msgstr "對於提供的 OVMF.rom 映像，這應該會啟動到 EDK2 shell。"
+
+#: src/utilities/UEFI_Tool_Kit.md:307
+#, fuzzy
+msgid "TODO: include screenshot of the EDK2 shell"
+msgstr "TODO：包括 EDK2 shell 的螢幕截圖"
+
+#: src/utilities/UEFI_Tool_Kit.md:309
+#, fuzzy
+msgid ""
+"Multiple commands can be used together to form a pipeline. The first "
+"argument always loads the image into memory and the last argument typically "
+"writes the output. The commands in between operate on the image in memory "
+"and are reminiscent of a UNIX pipeline. The general syntax is:"
+msgstr ""
+"多個命令可以一起使用來形成管道。第一個參數總是將圖像載入到記憶體中，最後一個參數通常寫入輸出。中間的指令對記憶體中的影像進行操作，讓人聯想到 UNIX "
+"管道。一般語法是："
+
+#: src/utilities/UEFI_Tool_Kit.md:321
+#, fuzzy
+msgid "To see the pipeline in action, we introduce two new commands:"
+msgstr "為了查看管道的運作情況，我們引入了兩個新命令："
+
+#: src/utilities/UEFI_Tool_Kit.md:323
+#, fuzzy
+msgid ""
+"`remove <file GUID or NAME regex>`: Remove a file from a firmware volume. "
+"The search has the same semantics as `find`."
+msgstr "`remove <file GUID or NAME regex>`：從韌體磁碟區移除檔案。搜尋具有與“查找”相同的語義。"
+
+#: src/utilities/UEFI_Tool_Kit.md:325
+#, fuzzy
+msgid ""
+"`replace_pe32 <file GUID or NAME regex> <FILE>`: Replace the pe32 section of "
+"a file with the given file. The search has the same semantics as `find`. The "
+"file must be a valid pe32 binary."
+msgstr ""
+"`replace_pe32 <檔案 GUID 或 NAME regex> <FILE>`：用給定的檔案取代檔案的 pe32 "
+"部分。搜尋具有與“查找”相同的語義。該檔案必須是有效的 pe32 二進位。"
+
+#: src/utilities/UEFI_Tool_Kit.md:328
+#, fuzzy
+msgid ""
+"`save <FILE>`: Save the firmware image to the given file. Usually, this is "
+"the last command in a pipeline."
+msgstr "`save <FILE>`：將韌體映像儲存到給定的檔案。通常，這是管道中的最後一個命令。"
+
+#: src/utilities/UEFI_Tool_Kit.md:331
+#, fuzzy
+msgid ""
+"The following pipeline removes some unnecessary drivers (anything that "
+"starts with Usb and the Legacy8259 driver which has the GUID "
+"79ca4208-bba1-4a9a-8456-e1e66a81484e) and replaces the Shell with Linux. "
+"Often you need to remove drivers to make room for Linux which makes the "
+"pipeline convenient. This is the essence of LinuxBoot:"
+msgstr ""
+"以下管道刪除了一些不必要的驅動程式（以 Usb 開頭的任何驅動程式以及具有 GUID "
+"79ca4208-bba1-4a9a-8456-e1e66a81484e 的 Legacy8259 驅動程式）並用 Linux 取代 "
+"Shell。通常您需要刪除驅動程式以便為 Linux 騰出空間，從而使管道變得方便。這就是LinuxBoot的本質："
+
+#: src/utilities/UEFI_Tool_Kit.md:347
+#, fuzzy
+msgid ""
+"That's all there to it! Try experimenting with the other commands such as "
+"insert."
+msgstr "就這些！嘗試使用其他命令（例如插入）。"
+
+#: src/utilities/UEFI_Tool_Kit.md:350
+#, fuzzy
+msgid "Common Pitfalls"
+msgstr "常見陷阱"
+
+#: src/utilities/UEFI_Tool_Kit.md:352
+#, fuzzy
+msgid "Kernel is not built as a DXE or has not enabled UEFI stub mode"
+msgstr "核心未建置為 DXE 或未啟用 UEFI 存根模式"
+
+#: src/utilities/UEFI_Tool_Kit.md:354
+#, fuzzy
+msgid ""
+"In order to be properly bootable as a DXE, kernels must have the following "
+"enabled:"
+msgstr "為了能夠作為 DXE 正確啟動，核心必須啟用以下功能："
+
+#: src/utilities/UEFI_Tool_Kit.md:362
+#, fuzzy
+msgid "Files are missing from the Firmware Volume"
+msgstr "韌體卷中缺少文件"
+
+#: src/utilities/UEFI_Tool_Kit.md:364
+#, fuzzy
+msgid ""
+"When UTK does not recognize the compression format used by the particular "
+"image, the files within it are not listed."
+msgstr "當 UTK 無法辨識特定影像所使用的壓縮格式時，其中的檔案不會列出。"
+
+#: src/utilities/UEFI_Tool_Kit.md:367
+#, fuzzy
+msgid "In the wild, three compression schemes are common:"
+msgstr "在實際應用中，有三種常見的壓縮方案："
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+#, fuzzy
+msgid "Compression"
+msgstr "壓縮"
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+#, fuzzy
+msgid "GUID"
+msgstr "全域唯一識別符"
+
+#: src/utilities/UEFI_Tool_Kit.md:369
+#, fuzzy
+msgid "UTK Support"
+msgstr "UTK 支援"
+
+#: src/utilities/UEFI_Tool_Kit.md:371
+#, fuzzy
+msgid "Uncompressed"
+msgstr "未壓縮"
+
+#: src/utilities/UEFI_Tool_Kit.md:371 src/utilities/UEFI_Tool_Kit.md:372
+#, fuzzy
+msgid "Fully supported"
+msgstr "完全支持"
+
+#: src/utilities/UEFI_Tool_Kit.md:372
+#, fuzzy
+msgid "LZMA"
+msgstr "LZMA"
+
+#: src/utilities/UEFI_Tool_Kit.md:372
+#, fuzzy
+msgid "EE4E5898-3914-4259-9D6E-DC7BD79403CF"
+msgstr "EE4E5898-3914-4259-9D6E-DC7BD79403CF"
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+#, fuzzy
+msgid "LZMA + x86"
+msgstr "LZMA + x86"
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+#, fuzzy
+msgid "D42AE6BD-1352-4BFB-909A-CA72A6EAE889"
+msgstr "D42AE6BD-1352-4BFB-909A-CA72A6EAE889"
+
+#: src/utilities/UEFI_Tool_Kit.md:373
+#, fuzzy
+msgid "Supported, but not tested"
+msgstr "支持，但未經測試"
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+#, fuzzy
+msgid "Tianocore"
+msgstr "天奧科"
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+#, fuzzy
+msgid "A31280AD-481E-41B6-95E8-127F4C984779"
+msgstr "A31280AD-481E-41B6-95E8-127F4C984779"
+
+#: src/utilities/UEFI_Tool_Kit.md:374
+#, fuzzy
+msgid ""
+"Not supported, see [\\#226](https://github.com/linuxboot/fiano/issues/226)"
+msgstr "不支持，請參閱[\\#226](https://github.com/linuxboot/fiano/issues/226)"
+
+#: src/utilities/UEFI_Tool_Kit.md:376
+#, fuzzy
+msgid ""
+"To determine which compression scheme you are using, search for the "
+"respective GUID in the json summary."
+msgstr "若要確定您正在使用哪種壓縮方案，請在 json 摘要中搜尋對應的 GUID。"
+
+#: src/utilities/UEFI_Tool_Kit.md:379
+#, fuzzy
+msgid "File size too big"
+msgstr "檔案大小過大"
+
+#: src/utilities/UEFI_Tool_Kit.md:385
+#, fuzzy
+msgid ""
+"When saving a UEFI image, files are added successively to each firmware "
+"volume. The first file which overflows the volume's size causes this error."
+msgstr "儲存 UEFI 映像時，檔案會依序新增至每個韌體磁碟區。第一個超出磁碟區大小的檔案會導致此錯誤。"
+
+#: src/utilities/UEFI_Tool_Kit.md:388
+#, fuzzy
+msgid ""
+"If you were inserting files, you will need to delete existing files to make "
+"room."
+msgstr "如果您正在插入文件，則需要刪除現有文件以騰出空間。"
+
+#: src/utilities/UEFI_Tool_Kit.md:390
+#, fuzzy
+msgid ""
+"There is a special cases where this error is generated without any "
+"operations:"
+msgstr "有一種特殊情況，在未進行任何操作的情況下也會產生此錯誤："
+
+#: src/utilities/UEFI_Tool_Kit.md:396
+#, fuzzy
+msgid "How can this be? No changes should be made to the image!"
+msgstr "怎麼會這樣？不應對該圖像進行任何更改！"
+
+#: src/utilities/UEFI_Tool_Kit.md:398
+#, fuzzy
+msgid ""
+"Not quite (and the complete list of differences can be found in the \"binary "
+"equality section\") -- compressed volumes are recompressed."
+msgstr "不完全是（完整的差異列表可以在“二進制平等部分”找到）——壓縮卷被重新壓縮。"
+
+#: src/utilities/UEFI_Tool_Kit.md:401
+#, fuzzy
+msgid ""
+"By default, UTK uses the Go compressor, which is generally worse than the "
+"compression found in most UEFI images. Pass `--systemXZ=xz` as the first "
+"argument to UTK to use a better compressor."
+msgstr ""
+"預設情況下，UTK 使用 Go 壓縮器，其壓縮效果通常比大多數 UEFI 映像中的壓縮效果差。將“--systemXZ=xz”作為第一個參數傳遞給 "
+"UTK 以使用更好的壓縮器。"
+
+#: src/utilities/UEFI_Tool_Kit.md:405
+#, fuzzy
+msgid ""
+"(TODO for everything after this point) Arbitrary data before or after the "
+"image"
+msgstr "（此處之後的所有內容均為 TODO）圖像之前或之後的任意數據"
+
+#: src/utilities/UEFI_Tool_Kit.md:407
+#, fuzzy
+msgid ""
+"Find a general solution which works for all images is a topic of research: "
+"[\\#200](https://github.com/linuxboot/fiano/issues/200)."
+msgstr ""
+"找到適用於所有圖像的通用解決方案是一個研究主題：[\\#200](https://github.com/linuxboot/fiano/issues/200)。"
+
+#: src/utilities/UEFI_Tool_Kit.md:410
+#, fuzzy
+msgid "Hard-coded addresses"
+msgstr "硬編碼地址"
+
+#: src/utilities/UEFI_Tool_Kit.md:412
+#, fuzzy
+msgid "Binary equality"
+msgstr "二元平等"
+
+#: src/utilities/UEFI_Tool_Kit.md:414
+#: src/coreboot.u-root.systemboot/index.md:404
+#: src/coreboot.u-root.systemboot/index.md:408
+#: src/coreboot.u-root.systemboot/index.md:434
+#, fuzzy
+msgid "TODO"
+msgstr "待辦事項"
+
+#: src/utilities/UEFI_Tool_Kit.md:416
+#, fuzzy
+msgid "Extending UTK"
+msgstr "擴展 UTK"
+
+#: src/utilities/UEFI_Tool_Kit.md:418
+#, fuzzy
+msgid "Visitor pattern means decoupling the structure from the operations."
+msgstr "訪問者模式意味著將結構與操作分開。"
+
+#: src/utilities/UEFI_Tool_Kit.md:420
+#, fuzzy
+msgid "pkg/uefi: structure"
+msgstr "pkg/uefi：結構"
+
+#: src/utilities/UEFI_Tool_Kit.md:421
+#, fuzzy
+msgid "pkg/visitors: operations"
+msgstr "pkg/visitors：操作"
+
+#: src/utilities/UEFI_Tool_Kit.md:423
+#, fuzzy
+msgid "Good resources:"
+msgstr "優質資源："
+
+#: src/utilities/UEFI_Tool_Kit.md:425
+#, fuzzy
+msgid "https://sourcemaking.com/design_patterns/visitor"
+msgstr "https://sourcemaking.com/design_patterns/visitor"
+
+#: src/utilities/UEFI_Tool_Kit.md:426
+#, fuzzy
+msgid "https://en.wikipedia.org/wiki/Visitor_pattern"
+msgstr "https://en.wikipedia.org/wiki/Visitor_pattern"
+
+#: src/utilities/UEFI_Tool_Kit.md:428
+#, fuzzy
+msgid ""
+"A good visitor still works when new Firmware are introduced. A good Firmware "
+"still works when a new visitor is introduced."
+msgstr "當引入新的韌體時，好的訪客仍然可以工作。當有新訪客到來時，良好的韌體仍然有效。"
+
+#: src/utilities/UEFI_Tool_Kit.md:431
+#, fuzzy
+msgid "AST"
+msgstr "AST"
+
+#: src/utilities/UEFI_Tool_Kit.md:433
+#, fuzzy
+msgid ""
+"Abstract Syntax Tree -- this is a concept borrowed from compilers. When "
+"you're extracting the DXE to create a tree of structs containing a "
+"simplified model, you're essentially creating an AST. Then think about how "
+"patterns used in compiler architecture might apply to UTK."
+msgstr ""
+"抽象語法樹－這是從編譯器借用的概念。當您提取 DXE 來建立包含簡化模型的結構樹時，您實際上是在建立 AST。然後思考編譯器架構中使用的模式如何應用在 "
+"UTK。"
+
+#: src/utilities/UEFI_Tool_Kit.md:438
+#, fuzzy
+msgid "Visitor Interface"
+msgstr "訪客介面"
+
+#: src/utilities/UEFI_Tool_Kit.md:440
+#, fuzzy
+msgid "Each visitor implements the following:"
+msgstr "每個訪客都執行以下操作："
+
+#: src/utilities/UEFI_Tool_Kit.md:447
+#, fuzzy
+msgid "// ...\n"
+msgstr "// ..."
+
+#: src/utilities/UEFI_Tool_Kit.md:451
+#, fuzzy
+msgid ""
+"Think of a visitor as an \"action\" or a \"transformation\" being applied on "
+"the AST."
+msgstr "將訪客視為在 AST 上套用的「動作」或「轉換」。"
+
+#: src/utilities/UEFI_Tool_Kit.md:454
+#, fuzzy
+msgid "Visitor"
+msgstr "遊客"
+
+#: src/utilities/UEFI_Tool_Kit.md:456
+#, fuzzy
+msgid ""
+"A struct implementing Visitor performs a transformation on the AST, for "
+"example:"
+msgstr "實作 Visitor 的結構對 AST 執行轉換，例如："
+
+#: src/utilities/UEFI_Tool_Kit.md:463
+#, fuzzy
+msgid "// Recursively apply on files in the FV.\n"
+msgstr "// 遞歸應用於 FV 中的檔案。\n"
+
+#: src/utilities/UEFI_Tool_Kit.md:480
+#, fuzzy
+msgid "You can imagine visitors being implemented for other actions, such as:"
+msgstr "您可以想像訪客正在執行其他操作，例如："
+
+#: src/utilities/UEFI_Tool_Kit.md:482
+#, fuzzy
+msgid "Remove a DXE with the given GUID from the AST"
+msgstr "從 AST 中刪除具有給定 GUID 的 DXE"
+
+#: src/utilities/UEFI_Tool_Kit.md:483
+#, fuzzy
+msgid "Replace a GUID with a file"
+msgstr "用檔案取代 GUID"
+
+#: src/utilities/UEFI_Tool_Kit.md:484
+#, fuzzy
+msgid "Validate that all the nodes in the tree are valid"
+msgstr "驗證樹中的所有節點是否有效"
+
+#: src/utilities/UEFI_Tool_Kit.md:485
+#, fuzzy
+msgid "Find compressed files in the tree and decompress them"
+msgstr "在樹中尋找壓縮檔案並解壓縮"
+
+#: src/utilities/UEFI_Tool_Kit.md:486
+#, fuzzy
+msgid "Assemble the AST back into an image."
+msgstr "將 AST 重新組裝成影像。"
+
+#: src/utilities/UEFI_Tool_Kit.md:487
+#, fuzzy
+msgid ""
+"Recursively write the AST to the filesystem (what you currently do with "
+"extract)"
+msgstr "以遞歸方式將 AST 寫入檔案系統（目前使用提取操作）"
+
+#: src/utilities/UEFI_Tool_Kit.md:488
+#, fuzzy
+msgid "Print an overview of the files to the terminal for debugging"
+msgstr "將文件概覽列印到終端進行偵錯"
+
+#: src/utilities/UEFI_Tool_Kit.md:491
+#, fuzzy
+msgid ""
+"It is easy to add more visitors without modifying existing code. Each action "
+"can be in a separate file."
+msgstr "無需修改現有程式碼即可輕鬆新增更多訪客。每個動作都可以放在單獨的文件中。"
+
+#: src/utilities/UEFI_Tool_Kit.md:494
+#, fuzzy
+msgid "Applying"
+msgstr "申請"
+
+#: src/utilities/UEFI_Tool_Kit.md:496
+#, fuzzy
+msgid ""
+"Visitors are applied to the AST. Each node in the AST has an \"Apply\" "
+"method, for example:"
+msgstr "訪客已申請加入 AST。 AST 中的每個節點都有一個「Apply」方法，例如："
+
+#: src/utilities/UEFI_Tool_Kit.md:505
+#, fuzzy
+msgid "This is so the visitors can be applied recursively over the AST."
+msgstr "這樣，訪客就可以在 AST 上遞歸應用程式。"
+
+#: src/utilities/UEFI_Tool_Kit.md:507
+#, fuzzy
+msgid "To apply the above RenameDXE visitor, you'd run:"
+msgstr "要應用上述 RenameDXE 訪客，您需要運行："
+
+#: src/utilities/UEFI_Tool_Kit.md:510
+#, fuzzy
+msgid "\"Shell\""
+msgstr "“殼”"
+
+#: src/utilities/UEFI_Tool_Kit.md:510
+#, fuzzy
+msgid "\"NotShell\""
+msgstr "“NotShell”"
+
+#: src/utilities/UEFI_Tool_Kit.md:514
+#, fuzzy
+msgid "Chaining Visitors Together"
+msgstr "將訪客連接在一起"
+
+#: src/utilities/UEFI_Tool_Kit.md:516
+#, fuzzy
+msgid ""
+"It would be exciting/useful to be able to chain these small actions together "
+"through the command line. For example:"
+msgstr "能夠透過命令列將這些小動作連結在一起會很令人興奮/有用。例如："
+
+#: src/utilities/UEFI_Tool_Kit.md:528
+#, fuzzy
+msgid ""
+"Again, it is easy to write new actions in Go which modify nodes in the AST. "
+"Create a new file, new struct, and implement the "
+"visitFV/visitFile/visitSection methods to modify the AST."
+msgstr ""
+"再次，在 Go 中編寫修改 AST 中的節點的新操作很容易。建立一個新檔案、新結構，並實作 visitFV/visitFile/visitSection "
+"方法來修改 AST。"
+
+#: src/utilities/UEFI_Tool_Kit.md:532
+#, fuzzy
+msgid "TODO: reference the UEFI spec."
+msgstr "TODO：參考 UEFI 規格。"
+
+#: src/utilities/UEFI_Tool_Kit.md:534
+#, fuzzy
+msgid "TODO: mention alternatives"
+msgstr "TODO：提及替代方案"
+
+#: src/utilities/UEFI_Tool_Kit.md:536
+#, fuzzy
+msgid "binwalk"
+msgstr "賓沃克"
+
+#: src/utilities/UEFI_Tool_Kit.md:537
+#, fuzzy
+msgid "fresh0r/romdump"
+msgstr "fresh0r/romdump"
+
+#: src/utilities/UEFI_Tool_Kit.md:538
+#, fuzzy
+msgid "UEFITool"
+msgstr "UEFI工具"
+
+#: src/utilities/UEFI_Tool_Kit.md:539
+#, fuzzy
+msgid "uefi-firmware-parser"
+msgstr "uefi 韌體解析器"
+
+#: src/utilities/cpu.md:1
+#, fuzzy
+msgid "The u-root `cpu` command"
+msgstr "u-root `cpu` 指令"
+
+#: src/utilities/cpu.md:3
+#, fuzzy
+msgid ""
+"Do you want to have all the tools on your  system that you have on your "
+"desktop, but you can't get them to fit in your tiny flash part? Do you want "
+"all your desktop files visible on your  system, but just remembered there's "
+"no disk on your  system? Are you tired of using `scp` or `wget` to move "
+"files around? Do you want to run `emacs` or `vim` on the  machine, but know "
+"they can't ever fit? What about `zsh`? How about being able to run commands "
+"on your  machine and have the output appear on your home file system? You "
+"say you'd like to make this all work without having to fill out web forms in "
+"triplicate to get your organization to Do Magic to your desktop?"
+msgstr ""
+"您是否希望在系統中擁有桌面上的所有工具，但卻無法將它們放入小小的閃存部件中？您是否希望所有桌面檔案都在您的系統上可見，但卻記得您的系統上沒有磁碟？您是否厭倦了使用“scp”或“wget”來移動檔案？您是否想在機器上運行“emacs”或“vim”，但知道它們無法適應？那麼 "
+"`zsh` 怎麼樣呢？如何在機器上運行命令並讓輸出出現在主檔案系統上？您說您想讓這一切正常運轉，而不必填寫三份網頁表格來讓您的組織在您的桌面上施展魔法？"
+
+#: src/utilities/cpu.md:13
+#, fuzzy
+msgid ""
+"**Your search is over: `cpu` is here to answer all your usability needs.**"
+msgstr "**您的搜尋結束了：「cpu」可以滿足您所有的可用性需求。 **"
+
+#: src/utilities/cpu.md:15
+#, fuzzy
+msgid "The problem: running your program on some other system"
+msgstr "問題：在其他系統上運行你的程序"
+
+#: src/utilities/cpu.md:17
+msgid ""
+"People often need to run a command on a remote system. That is easy when the "
+"remote system is the same as the system you are on, e.g., both systems are "
+"Ubuntu 16.04; and all the libraries, packages, and files are roughly the "
+"same. But what if the systems are different, say, Ubuntu 16.04 and Ubuntu "
+"18.10? What if one is Centos, the other Debian? What if a required package "
+"is missing on the remote system, even though in all other ways they are the "
+"same?"
+msgstr ""
+
+#: src/utilities/cpu.md:24
+#, fuzzy
+msgid ""
+"While these systems are both Linux, and hence can provide Application Binary "
+"Interface (ABI) stability at the system call boundary, above that boundary "
+"stability vanishes. Even small variations between Ubuntu versions matter: "
+"symbol versions in C libraries differ, files are moved, and so on."
+msgstr ""
+"雖然這些系統都是 Linux，因此可以在系統呼叫邊界提供應用程式二進位介面 (ABI) 穩定性，但在該邊界之上穩定性就會消失。即使 Ubuntu "
+"版本之間的細微差異也很重要：C 庫中的符號版本不同、檔案被移動等等。"
+
+#: src/utilities/cpu.md:29
+#, fuzzy
+msgid ""
+"What is a user to do if they want to build a binary on one system, and run "
+"it on another system?"
+msgstr "如果使用者想要在一個系統上建置二進位檔案並在另一個系統上運行它，他們該怎麼做？"
+
+#: src/utilities/cpu.md:32
+msgid ""
+"The simplest approach is to copy the source to that other system and compile "
+"it. That works sometimes. But there are limits: copying the source might not "
+"be allowed; the code might not even compile on the remote system; some "
+"support code might not be available, as for a library; and for embedded "
+"systems, there might not be a compiler on the remote system. Copy and "
+"compile is not always an option. In fact it rarely works nowadays, when even "
+"different Linux distributions are incompatible."
+msgstr ""
+
+#: src/utilities/cpu.md:40
+#, fuzzy
+msgid ""
+"The next option is to use static linking. Static linking is the oldest form "
+"of binary on Linux systems. While it has the downside of creating larger "
+"binaries, in an age of efficient compilers that remove dead code, 100 "
+"gigabit networks, and giant disks and memory, that penalty is not the "
+"problem it once was. The growth in size of static binaries is nothing like "
+"the growth in efficiency and scale of our resources. Nevertheless, static "
+"linking is frowned upon nowadays and many libraries are only made available "
+"for dynamic linking."
+msgstr ""
+"下一個選項是使用靜態連結。靜態連結是 Linux "
+"系統上最古老的二進位形式。雖然它的缺點是需要創建更大的二進位文件，但在高效編譯器可以刪除死程式碼、100 "
+"千兆網路以及巨型磁碟和記憶體的時代，這種損失不再是問題了。靜態二進位檔案大小的成長與我們的資源效率和規模的成長完全不同。然而，靜態連結如今已不受歡迎，許多函式庫僅可用於動態連結。"
+
+#: src/utilities/cpu.md:48
+#, fuzzy
+msgid ""
+"Our user might use one of the many tools that package a binary and all its "
+"libraries into a single file, to be executed elsewhere. The u-root project "
+"even offers one such tool, called `pox`, for portable executables. `Pox` "
+"uses the dynamic loader to figure out all the shared libraries a program "
+"uses, and place them into the archive as well. Further, the user can specify "
+"additional files to carry along in case they are needed."
+msgstr ""
+"我們的用戶可能會使用眾多工具之一將二進位檔案及其所有庫打包成一個文件，然後在其他地方執行。 u-root "
+"專案甚至為可移植執行檔提供了一個名為「pox」的工具。 "
+"「Pox」使用動態載入器找出程式使用的所有共用程式庫，並將它們放入檔案中。此外，使用者可以指定要隨身攜帶的附加文件，以備不時之需。"
+
+#: src/utilities/cpu.md:55
+msgid ""
+"The problem here is that, if our user cares about binary size, this option "
+"is even worse. Dead code removal won’t work; the whole shared library has to "
+"be carried along. Nevertheless, this can work, in some cases."
+msgstr ""
+
+#: src/utilities/cpu.md:59
+#, fuzzy
+msgid ""
+"So our user packages up their executable using `pox` or a similar tool, uses "
+"`scp` to get it to the remote machine, logs in via `ssh`, and all seems to "
+"be well, until at some point there is another message about a missing shared "
+"library! How can this be? The program that packaged it up checked for all "
+"possible shared libraries."
+msgstr ""
+"因此，我們的用戶使用“pox”或類似工具打包他們的可執行文件，使用“scp”將其發送到遠端機器，通過“ssh”登錄，一切似乎都很順利，直到某個時候出現另一條關於缺少共享庫的消息！怎麼會這樣？打包它的程式檢查了所有可能的共享庫。"
+
+#: src/utilities/cpu.md:65
+msgid ""
+"Unfortunately, shared libraries are now in the habit of loading other shared "
+"libraries, as determined by reading text files. It’s no longer possible to "
+"know what shared libraries are used; they can even change from one run of "
+"the program to the next. One can not find them all just by reading the "
+"shared library itself. A good example is the name service switch library, "
+"which uses `/etc/nsswitch.conf` to find other shared libraries. If "
+"`nsswitch.conf` is missing, or a library is missing, some versions of the "
+"name service switch library will core dump."
+msgstr ""
+
+#: src/utilities/cpu.md:74
+#, fuzzy
+msgid ""
+"Not only must our user remember to bring along `/etc/nsswitch.conf`, they "
+"must also remember to bring along all the libraries it might use. This is "
+"also true of other services such as Pluggable Authentication Modules (PAM). "
+"And, further, the program they bring along might run other programs, with "
+"their own dependencies. At some point, as the set of files grows, frustrated "
+"users might decide to gather up all of `/etc/`, `/bin`, and other "
+"directories, in the hope that a wide enough net might bring along all that’s "
+"needed. The remote system will need lots of spare disk or memory! We’re "
+"right back where we started, with too many files for too little space."
+msgstr ""
+"我們的用戶不僅必須記得帶上“/etc/nsswitch.conf”，還必須記得帶上它可能使用的所有庫。對於其他服務（例如可插入身份驗證模組 "
+"(PAM)）也是如此。而且，他們帶來的程式可能會運行其他程序，並具有它們自己的依賴關係。在某些時候，隨著文件集的成長，沮喪的使用者可能會決定收集所有「/etc/」、「/bin」和其他目錄，希望足夠寬的網路可以帶來所需的一切。遠端系統將需要大量備用磁碟或記憶體！我們又回到了原點，文件太多，空間太小。"
+
+#: src/utilities/cpu.md:84
+#, fuzzy
+msgid ""
+"In the worst case, to properly run a binary from one system, on another "
+"system, one must copy everything in the local file system to the remote "
+"system. That is obviously difficult, and might be impossible if the remote "
+"system has no disk, only memory."
+msgstr ""
+"在最壞的情況下，為了在另一個系統上正確運行一個系統的二進位文件，必須將本機檔案系統中的所有內容複製到遠端系統。這顯然很困難，如果遠端系統沒有磁碟，只有內存，那可能就不可能了。"
+
+#: src/utilities/cpu.md:89
+msgid ""
+"One might propose having the remote system mount the local system via NFS or "
+"Samba. While this was a common approach years ago, it comes with its own set "
+"of problems: all the remote systems are now hostage to the reliability of "
+"the NFS or Samba server. But there’s a bigger problem: there is still no "
+"guarantee that the remote system is using the same library versions and "
+"files that the user’s desktop is using. The NFS server might provide, e.g. "
+"SUSE, to the remote system; the user’s desktop might be running Ubuntu. If "
+"the user compiles on their desktop, the binary might still not run on the "
+"remote system, as the SUSE libraries might be different. This is a common "
+"problem."
+msgstr ""
+
+#: src/utilities/cpu.md:99
+#, fuzzy
+msgid ""
+"Still worse, with an NFS root, everyone can see everyone’s files. It’s like "
+"living in an apartment building with glass walls. Glass houses only look "
+"good in architecture magazines. People want privacy."
+msgstr "更糟的是，有了 NFS 根，每個人都可以看到每個人的檔案。這就像住在一棟有玻璃牆的公寓大樓裡一樣。玻璃屋只有在建築雜誌上才好看。人們想要隱私。"
+
+#: src/utilities/cpu.md:103
+#, fuzzy
+msgid "What SSH does not provide"
+msgstr "SSH 不提供什麼"
+
+#: src/utilities/cpu.md:105
+#, fuzzy
+msgid ""
+"`ssh` solves the problem of safely getting logged in to a remote machine. "
+"While this is no small accomplishment, it is a lot like being parachuted "
+"into a foreign land, where the rules are changed. It’s a lot nicer, when "
+"going to a new place, to be able to bring along some survival gear, if not "
+"your whole house!"
+msgstr ""
+"`ssh` "
+"解決了安全登入遠端機器的問題。雖然這不是一個小小的成就，但它就像是被空降到一個陌生的國度，而那裡的規則已經改變了。當去一個新地方時，如果能帶一些生存裝備（即使不是整棟房子）就更好了！"
+
+#: src/utilities/cpu.md:110
+msgid ""
+"Users need a way to log in to a machine, in a way similar to `ssh`, but they "
+"need to bring their environment with them. They need their login directory; "
+"their standard commands; their configuration files; and they need some "
+"privacy. Other users on the machine should not be able to see any of the "
+"things they bring with them. After all, everyone who goes camping wants to "
+"believe they are the only people at that campground!"
+msgstr ""
+
+#: src/utilities/cpu.md:117
+#, fuzzy
+msgid "How `cpu` provides what we need"
+msgstr "`cpu` 如何提供我們所需要的"
+
+#: src/utilities/cpu.md:119
+#, fuzzy
+msgid ""
+"`cpu` is a Go-based implementation of Plan 9's `cpu` command. It uses the go "
+"`ssh` package, so all your communications are as secure as `ssh`. It can be "
+"started from `/sbin/init` or even replace `/sbin/init`, so you have a tiny "
+"flash footprint. You can see the code at "
+"[github.com:u-root/cpu](https://github.com/u-root/cpu). It's also small: "
+"less than 20 files, including tests."
+msgstr ""
+"`cpu` 是 Plan 9 的 `cpu` 指令的基於 Go 的實作。它使用 go `ssh` 包，因此您的所有通訊都與 `ssh` "
+"一樣安全。它可以從“/sbin/init”啟動，甚至可以替換“/sbin/init”，因此您只需要很小的閃存空間。您可以在 "
+"[github.com:u-root/cpu](https://github.com/u-root/cpu) "
+"上查看程式碼。它也很小：包括測試在內，文件少於 20 個。"
+
+#: src/utilities/cpu.md:126
+#, fuzzy
+msgid ""
+"`cpu` runs as both a client (on your desktop) and an `ssh` server (on your "
+"machine). On your desktop, it needs no special privilege. On the system, "
+"there is only one binary needed: the `cpu` daemon (`cpud`). As part of "
+"setting up a session, in addition to normal `ssh` operations, `cpu` sets up "
+"private name space at important places like `/home/$USER`, `/bin, /usr,`and "
+"so on. Nobody gets to see what other people’s files are."
+msgstr ""
+"`cpu` 既作為客戶端（在您的桌面上）運行，又作為 `ssh` "
+"伺服器（在您的機器上）運行。在您的桌面上，它不需要特殊權限。在系統上，只需要一個二進位檔案：`cpu` "
+"守護程式（`cpud`）。作為設定會話的一部分，除了正常的 `ssh` 操作之外，`cpu` 還在重要位置（如 "
+"`/home/$USER`、`/bin、/usr` 等）設定私有名稱空間。沒有人可以看到其他人的文件是什麼。"
+
+#: src/utilities/cpu.md:133
+msgid ""
+"`Ssh` provides remote access. `cpu` goes one step further, providing what is "
+"called _resource sharing_ -- resources, i.e., files from the client machine "
+"can be used directly on the remote machine, without needing to manually copy "
+"them. `cpud` implements resource sharing by setting up a `file system`mount "
+"on the remote machine and relaying file I/O requests back to the desktop "
+"`cpu` process. The desktop command services those requests; you don't need "
+"to run a special external server. One thing that is a bit confusing with "
+"`cpu`: the desktop client is a file server; the remote server’s Linux kernel "
+"is a file client. `cpu` has to do a bit more work to accomplish its task."
+msgstr ""
+
+#: src/utilities/cpu.md:143
+#, fuzzy
+msgid ""
+"`cpu` will change your life. You can forget about moving files via `scp`: "
+"once you '`cpu` in', the `/home` directory on your  node is your home "
+"directory. You can `cd ~`and see all your files. You can pick any shell you "
+"want, since the shell binary comes from your desktop, not flash. You don't "
+"have to worry about fitting `zsh` into flash ever again!"
+msgstr ""
+"`cpu` 將改變你的生活。您可以忘記透過「scp」移動檔案：一旦您「進入」cpu，您節點上的「/home」目錄就是您的主目錄。您可以`cd "
+"~`查看所有文件。您可以選擇任何您想要的 shell，因為 shell 二進位檔案來自您的桌面，而不是快閃記憶體。您不必再擔心將“zsh”裝入 "
+"flash！"
+
+#: src/utilities/cpu.md:149
+#, fuzzy
+msgid ""
+"At Google we can now run `chipsec`, which imports 20M of Python libraries, "
+"because we have `cpu` and we can redirect `chipsec` output to files in our "
+"home directory."
+msgstr ""
+"在 Google，我們現在可以運行“chipsec”，它導入了 20M 的 Python "
+"庫，因為我們有“cpu”，並且我們可以將“chipsec”輸出重定向到我們的主目錄中的檔案。"
+
+#: src/utilities/cpu.md:153
+#, fuzzy
+msgid "Here is an example session:"
+msgstr "以下是一個範例會話："
+
+#: src/utilities/cpu.md:155
+msgid ""
+"In this command, we `cpu` to a PC Engines APU2. We have built a kernel and "
+"u-root initramfs containing just one daemon -- the `cpu` daemon -- into the "
+"flash image. The APU2 does not even need a disk; it starts running as a "
+"“`cpu` appliance.”"
+msgstr ""
+
+#: src/utilities/cpu.md:160
+msgid ""
+"The `bash` is not on the `cpu` node; it will come from our desktop via the "
+"9p mount."
+msgstr ""
+
+#: src/utilities/cpu.md:172
+msgid ""
+"The `bash` and `ls` command, and the shared libraries they need, do not "
+"exist on the apu2; `cpu` makes sure that the client provides them to the "
+"`cpu` server. The home directory is, similarly, made available to the remote "
+"machine from the local machine."
+msgstr ""
+
+#: src/utilities/cpu.md:177
+#, fuzzy
+msgid ""
+"A big benefit of `cpu` is that, as long as the network works, users can "
+"create very minimal flash images, containing just the `cpu` daemon, just "
+"enough to get the network going. Once the network is up, users can `'cpu` "
+"in', and everything they need is there. It actually looks like they are "
+"still logged in to their desktop, except, of course, truly local file "
+"systems such as `/proc` and `/sys` will come from the machine they are on, "
+"not their desktop."
+msgstr ""
+"`cpu` 的一個很大的好處是，只要網路運作，使用者就可以建立非常小的 flash 映像，其中只包含 `cpu` "
+"守護進程，足以讓網路運作。一旦網路啟動，用戶就可以「進入」CPU，他們需要的一切都在那裡。實際上看起來他們仍然登入他們的桌面，當然，真正的本機檔案系統（如“/proc”和“/sys”）將來自他們所在的機器，而不是他們的桌面。"
+
+#: src/utilities/cpu.md:184
+#, fuzzy
+msgid "An easy overview of how `cpu` works"
+msgstr "簡單概述 `cpu` 的工作原理"
+
+#: src/utilities/cpu.md:186
+#, fuzzy
+msgid ""
+"`cpu`, as mentioned, consists of a client and a server. The client is on "
+"your desktop (or laptop), and the server is on the remote system. Both "
+"client and server use an `ssh` transport, meaning that the “wire” protocol "
+"is `ssh`. In this way, `cpu` is just like `ssh`."
+msgstr ""
+"如同所提到的，`cpu` 由客戶端和伺服器組成。用戶端位於您的桌上型電腦（或筆記型電腦）上，伺服器位於遠端系統上。客戶端和伺服器都使用 `ssh` "
+"傳輸，這表示「連線」協定是 `ssh`。這樣一來，`cpu` 就跟 `ssh` 一樣了。"
+
+#: src/utilities/cpu.md:191
+msgid ""
+"As mentioned above, the situation for `cpu` is a bit more complicated than "
+"for `ssh`. `cpu` provides resource sharing, but not from the server to the "
+"client, but rather from the client to the server. The `cpu` client is a file "
+"server; the `cpu` server connects the kernel on the server machine to the "
+"file server in the client, as shown below. Things to note:"
+msgstr ""
+
+#: src/utilities/cpu.md:197
+#, fuzzy
+msgid ""
+"`cpud`, on the remote or server machine, sets up a “private name space "
+"mount” of `/tmp` for the program. “Private name space mount” just means that "
+"only that program, and its children, can see what is in its private `/tmp`. "
+"Other, external programs continue to use `/tmp`, but they are _different_ "
+"instantiations of `/tmp`."
+msgstr ""
+"遠端或伺服器電腦上的“cpud”為程式設定了“/tmp”的“私有名稱空間掛載”。 "
+"「私有名稱空間掛載」只是表示只有該程式及其子程式才能看到其私有「/tmp」中的內容。其他外部程式繼續使用“/tmp”，但它們是“/tmp”的不同實例。"
+
+#: src/utilities/cpu.md:202
+#, fuzzy
+msgid ""
+"The private name space mount of `/tmp` is on a filesystem in RAM. The data "
+"stored in `/tmp` is not visible to other processes, and not persistent."
+msgstr "“/tmp” 的私有名稱空間掛載位於 RAM 中的檔案系統上。儲存在“/tmp”中的資料對於其他進程來說是不可見的，並且不是持久的。"
+
+#: src/utilities/cpu.md:204
+msgid ""
+"`cpud` creates a directory, `cpu`, in the private `/tmp`; and mounts the "
+"server on it. This mount point is also invisible outside the process and its "
+"children."
+msgstr ""
+
+#: src/utilities/cpu.md:207
+#, fuzzy
+msgid ""
+"To make sure that names like `/bin/bash`, and `/usr/lib/libc.so` work, "
+"`cpud` sets up _bind mounts_ from, e.g., `/tmp/cpu/bin` to `/bin`. These are "
+"also private mounts, and do not affect any program outside the one `cpud` "
+"starts. Anytime the program and its children access files in `/bin`, `/lib`, "
+"`/usr`, `/home/$USER`, and so on, they are accessing files from the client "
+"machine via the built-in client file server."
+msgstr ""
+"為了確保像“/bin/bash”和“/usr/lib/libc.so”這樣的名字能夠起作用，“cpud”設定了_bind "
+"mounts_，例如從“/tmp/cpu/bin”到“/bin”。這些也是私有掛載，並且不會影響「cpud」啟動之外的任何程式。任何時候程式及其子程式存取「/bin」、「/lib」、「/usr」、「/home/$USER」等目錄中的檔案時，它們都是透過內建客戶端檔案伺服器從客戶端電腦存取檔案。"
+
+#: src/utilities/cpu.md:213
+#, fuzzy
+msgid ""
+"The client `cpu` program passes the full environment from the client machine "
+"to `cpud`. When the client program requests that, e.g., `bash` be run, the "
+"`cpud` uses the PATH environment variable to locate `bash`. Because of the "
+"private name space mounts and binds, `bash` will be found in `/bin/bash`, "
+"and its libraries will be found in their usual place. This is an essential "
+"property of `cpu`, that the names used on the user’s machine work the same "
+"way on the remote machine. An overview of the process is shown below."
+msgstr ""
+"客戶端“cpu”程式將完整的環境從客戶端機器傳遞到“cpud”。當客戶端程式請求執行“bash”時，“cpud”使用PATH環境變數來定位“bash”。由於私有名稱空間的掛載和綁定，「bash」將在「/bin/bash」中找到，並且其庫將在其通常的位置找到。這是 "
+"`cpu` 的基本屬性，即使用者機器上使用的名稱與遠端機器上的名稱相同。過程的概述如下所示。"
+
+#: src/utilities/cpu.md:223
+#, fuzzy
+msgid "`cpu` startup"
+msgstr "`cpu` 啟動"
+
+#: src/utilities/cpu.md:225
+#, fuzzy
+msgid ""
+"The startup proceeds in several steps. Every session begins with an initial "
+"contact from the `cpu` client to the `cpu` server."
+msgstr "啟動過程分為幾個步驟進行。每個會話都以從“cpu”客戶端到“cpu”伺服器的初始聯繫開始。"
+
+#: src/utilities/cpu.md:230
+#, fuzzy
+msgid ""
+"The first step the `cpud` does is set up the mounts back to the client. It "
+"then sets up the bind mounts such as `/bin` to `/tmp/cpu/bin`. In the "
+"following figure, we compress the Linux kernel mount and bind mounts shown "
+"above into a smaller box called “name space.”"
+msgstr ""
+"`cpud` 執行的第一步是將掛載設定回客戶端。然後，它會設定綁定掛載，例如將“/bin”設定為“/tmp/cpu/bin”。在下圖中，我們將上面顯示的 "
+"Linux 核心掛載和綁定掛載壓縮到一個名為「命名空間」的較小的框中。"
+
+#: src/utilities/cpu.md:237
+#, fuzzy
+msgid "Next, `cpu` and the `cpud` set up the terminal management."
+msgstr "接下來，`cpu`和`cpud`設定終端管理。"
+
+#: src/utilities/cpu.md:241
+#, fuzzy
+msgid ""
+"Finally, `cpud` sets up the program to run. Because the PATH variable has "
+"been transferred to `cpud`, and the name space includes `/bin` and `/lib`, "
+"the `cpud` can do a standard Linux `exec` system call without having to "
+"locate where everything is. Native kernel mechanisms create requests as "
+"files are referenced, and the `cpu` file server support does the rest."
+msgstr ""
+"最後，“cpud”設定程式運行。由於 PATH 變數已轉移到 `cpud`，且名稱空間包括 `/bin` 和 `/lib`，因此 `cpud` "
+"可以執行標準 Linux `exec` "
+"系統調用，而無需定位所有內容的位置。當檔案被引用時，本機核心機制會建立請求，而「cpu」檔案伺服器支援會完成其餘工作。"
+
+#: src/utilities/cpu.md:249
+#, fuzzy
+msgid ""
+"Why do we only show one program instead of many? From the point of view of "
+"`cpud`, it only starts one program. From the point of view of users, there "
+"can be many. But if there is more than one program to start, _that is not "
+"the responsibility of `cpud`_. If more than one program is run, they will be "
+"started by the program that `cpud` started, i.e., a command interpreter like "
+"the shell. Or it could be as simple as a one-off command like `date`. From "
+"the point of view of `cpud`, it’s all the same. `cpud` will wait until the "
+"process it started, and all its children, have exited. But `cpud`’s "
+"responsibilities to start a program ends with that first program."
+msgstr ""
+"為什麼我們只展示一個節目而不是多個？從`cpud`的角度來看，它只啟動一個程式。從使用者的角度來看，可以有很多。但是如果有多個程式需要啟動，那就不是 "
+"`cpud` "
+"的責任了。如果執行多個程序，它們將由「cpud」啟動的程式啟動，也就是像shell這樣的命令解釋器。或者它可以像“date”這樣的一次性命令一樣簡單。從 "
+"`cpud` 的角度來看，都是一樣的。 `cpud` 將等待，直到它啟動的進程及其所有子進程都退出。但是 `cpud` "
+"啟動程序的職責隨著第一個程式的啟動而結束。"
+
+#: src/utilities/cpu.md:259
+#, fuzzy
+msgid ""
+"But what happens when `cpud` runs that first program? Here is where it gets "
+"interesting, and, depending on your point of view, either magical, "
+"confounding, or counter-intuitive. We’ll go with magical."
+msgstr ""
+"但是當“cpud”運行第一個程式時會發生什麼？這就是事情變得有趣的地方，而且，取決於你的觀點，它可能是神奇的、令人困惑的、或違反直覺的。我們將充滿魔力。"
+
+#: src/utilities/cpu.md:263
+#, fuzzy
+msgid "Starting that first program"
+msgstr "啟動第一個程序"
+
+#: src/utilities/cpu.md:265
+#, fuzzy
+msgid ""
+"As mentioned above, `cpud` sets up mounts for a name space, and calls the "
+"Linux `exec()` call to start the program."
+msgstr "如上所述，`cpud` 為命名空間設定掛載，並呼叫 Linux `exec()` 呼叫來啟動程式。"
+
+#: src/utilities/cpu.md:268
+msgid ""
+"We can actually watch all the `cpu` file server operations. The file server "
+"protocol is called 9P2000. We are going to present a filtered version of the "
+"file I/O from running a remote `date`; in practice, you can watch all the "
+"opens, reads, writes, and closes the remote process performs."
+msgstr ""
+
+#: src/utilities/cpu.md:273
+#, fuzzy
+msgid ""
+"The trace for running `date` starts right when the remote program has called "
+"`exec`, and the kernel is starting to find the program to run[^1]. The file "
+"opens look like this, on a user’s system:"
+msgstr "當遠端程式呼叫「exec」時，執行「date」的追蹤就開始了，核心開始尋找要執行的程式[^1]。在使用者係統上，檔案開啟後如下所示："
+
+#: src/utilities/cpu.md:286
+#, fuzzy
+msgid ""
+"The kernel opened `/bin/date`, determined what libraries (files ending in "
+"`.so`) it needed, and opened them as well."
+msgstr "核心打開“/bin/date”，確定它需要什麼庫（以“.so”結尾的檔案），並打開它們。"
+
+#: src/utilities/cpu.md:289
+#, fuzzy
+msgid "We can compare this with a local execution:"
+msgstr "我們可以將其與本地執行進行比較："
+
+#: src/utilities/cpu.md:302
+msgid ""
+"Note that several files do not show up in our trace; they are in `/etc`, and "
+"the `cpud` does not set up a bind mount over `/etc`. But the other files "
+"look very similar. You might wonder why the local version opens "
+"`/etc/localtime`, and the remote version opens "
+"`/usr/share/zoneinfo/America/Los_Angeles`."
+msgstr ""
+
+#: src/utilities/cpu.md:307
+#, fuzzy
+msgid "The reason is that `etc/localtime` is a symlink:"
+msgstr "原因是 `etc/localtime` 是一個符號連結："
+
+#: src/utilities/cpu.md:313
+msgid ""
+"The access to `/etc/localtime` does not get handled by the server; but the "
+"access to `/usr/share/zoneinfo/America/Los_Angeles`does."
+msgstr ""
+
+#: src/utilities/cpu.md:316
+#, fuzzy
+msgid ""
+"What about different architectures? What if we are using an x86 but want to "
+"`cpu` to an ARM processor?"
+msgstr "那麼不同的架構又如何呢？如果我們使用的是 x86 但想要將「cpu」轉換為 ARM 處理器該怎麼辦？"
+
+#: src/utilities/cpu.md:319
+#, fuzzy
+msgid ""
+"We can set the local `cpu` up to talk to a remote `cpu` that needs different "
+"binaries. We might have an entire ARM file system tree in `~/arm`, for "
+"example. We would then invoke `cpu` as follows:"
+msgstr ""
+"我們可以設定本機「cpu」來與需要不同二進位檔案的遠端「cpu」進行通訊。例如，我們可能在“~/arm”中有一個完整的 ARM "
+"檔案系統樹。然後我們將按如下方式調用“cpu”："
+
+#: src/utilities/cpu.md:327
+#, fuzzy
+msgid ""
+"And the remote `cpud`, running on an ARM, would be provided with ARM "
+"binaries."
+msgstr "並且在 ARM 上運行的遠端“cpud”將提供 ARM 二進位檔案。"
+
+#: src/utilities/cpu.md:329
+#, fuzzy
+msgid "Learning how to use `cpu`"
+msgstr "學習如何使用“cpu”"
+
+#: src/utilities/cpu.md:331
+msgid ""
+"`Cpu` can be a hard thing to learn, not because it is difficult, but because "
+"it is different. To paraphrase Yoda, you have to unlearn what you have "
+"learned. Forget about copying files from here to there; when you `cpu` "
+"there, it looks like your files are waiting for you."
+msgstr ""
+
+#: src/utilities/cpu.md:336
+#, fuzzy
+msgid ""
+"You can start experimenting and learning about `cpu` by just running it "
+"locally."
+msgstr "您只需在本地運行它即可開始實驗和了解“cpu”。"
+
+#: src/utilities/cpu.md:338
+#, fuzzy
+msgid "A set of binaries for you to try"
+msgstr "一組二進位檔案供您嘗試"
+
+#: src/utilities/cpu.md:340
+#, fuzzy
+msgid ""
+"In order for you to try it out, start by working with the set of `cpu` "
+"binaries at "
+"[https://github.com/u-root/cpubinaries](https://github.com/u-root/cpubinaries). "
+"With them, you can create a bootable, mountable USB image that you can "
+"download. The image contains a `cpu` client that runs on Linux, a private "
+"key, and, when booted, it starts a `cpu` daemon and waits to serve `cpu` "
+"clients. The `cpu` client is statically linked and hence should run on any "
+"Linux from the last 10 years or so."
+msgstr ""
+"為了讓您嘗試一下，請先使用 "
+"[https://github.com/u-root/cpubinaries](https://github.com/u-root/cpubinaries) "
+"上的一組 `cpu` 二進位檔案。使用它們，您可以建立可啟動、可安裝且可下載的 USB 映像。該映像包含一個在 Linux "
+"上執行的「cpu」用戶端、一個私鑰，並且在啟動時，它會啟動一個「cpu」守護程式並等待為「cpu」用戶端提供服務。 "
+"「cpu」用戶端是靜態連結的，因此應該可以在過去 10 年左右的任何 Linux 上運行。"
+
+#: src/utilities/cpu.md:349
+#, fuzzy
+msgid "The binaries include:"
+msgstr "二進位檔案包括："
+
+#: src/utilities/cpu.md:351
+#, fuzzy
+msgid ""
+"A kernel (`cpukernel`) with a built-in initramfs containing `cpud`, as well "
+"as a public key. Also included, should you want to build your own, is the "
+"config file (`cpu.config`)."
+msgstr ""
+"一個核心（`cpukernel`）帶有一個內建的 "
+"initramfs，其中包含`cpud`，以及一個公鑰。如果您想建立自己的設定檔（`cpu.config`），其中還包括設定檔。"
+
+#: src/utilities/cpu.md:354
+#, fuzzy
+msgid ""
+"A binary client program, `cpu`, as well as the private key to use. You can "
+"place this key in `~/.ssh` or specify it via the `-key` option to `cpu`."
+msgstr "一個二進位客戶端程式、`cpu`以及要使用的私鑰。您可以將此金鑰放在 `~/.ssh` 中或透過 `-key` 選項將其指定給 `cpu`。"
+
+#: src/utilities/cpu.md:356
+msgid ""
+"A script to run the USB stick via `qemu` (`TESTQEMU`); and a script to run a "
+"`cpu` command (`EXAMPLE`)."
+msgstr ""
+
+#: src/utilities/cpu.md:358
+#, fuzzy
+msgid "The `extlinux.conf` used for the USB stick."
+msgstr "用於 USB 記憶棒的「extlinux.conf」。"
+
+#: src/utilities/cpu.md:360
+#, fuzzy
+msgid ""
+"`usbstick.xz` is a compressed USB stick image that is bootable. It will "
+"uncompress to about 7GB. You can use the `TESTQEMU` script to try it out, or "
+"use `dd` to write it to a USB stick and boot that stick on an x86 system."
+msgstr ""
+"`usbstick.xz` 是一個可啟動的壓縮 USB 棒映像。解壓縮後大小約 "
+"7GB。您可以使用「TESTQEMU」腳本進行嘗試，或使用「dd」將其寫入 USB 記憶棒並在 x86 系統上啟動該記憶棒。"
+
+#: src/utilities/cpu.md:364
+msgid ""
+"Be careful how you use the keys; they're public. You should really only use "
+"them as part of the demo."
+msgstr ""
+
+#: src/utilities/cpu.md:367
+#, fuzzy
+msgid ""
+"The `cpukernel` was built using the `github.com:/mainboards` repo. If you "
+"clone this repo, the following commands will rebuild the kernel:"
+msgstr "`cpukernel` 是使用 `github.com:/mainboards` repo 建構的。如果您克隆此 repo，以下命令將重建內核："
+
+#: src/utilities/cpu.md:370
+#, fuzzy
+msgid "`cd mainboards/intel/generic`"
+msgstr "`cd 主機板/intel/generic`"
+
+#: src/utilities/cpu.md:371
+#, fuzzy
+msgid "`make fetch`"
+msgstr "`獲取`"
+
+#: src/utilities/cpu.md:372
+#, fuzzy
+msgid "`make cpukernel`"
+msgstr "`製作 CPU 核心`"
+
+#: src/utilities/cpu.md:374
+#, fuzzy
+msgid "How to use the cpu binaries"
+msgstr "如何使用 CPU 二進位檔案"
+
+#: src/utilities/cpu.md:376
+#, fuzzy
+msgid ""
+"You’ll first need to start the server, and we show the entire sequence "
+"below, including unpacking the image:"
+msgstr "您首先需要啟動伺服器，我們在下面展示整個序列，包括解壓縮影像："
+
+#: src/utilities/cpu.md:383
+#, fuzzy
+msgid ""
+"How you run `qemu` depends on whether you want graphics or not: if you are "
+"not in a windowing environment, add `-nographic` to the command below. In "
+"any event, at the `boot:` prompt, you can hit return or wait:"
+msgstr ""
+"如何運行“qemu”取決於您是否需要圖形：如果您不在視窗環境中，請在下面的命令中添加“-nographic”。無論如何，在 `boot:` "
+"提示字元下，您可以按回車鍵或等待："
+
+#: src/utilities/cpu.md:403
+#, fuzzy
+msgid ""
+"At this point, the `cpu` daemon is running, and you can try the `cpu` "
+"command:"
+msgstr "此時，`cpu` 守護程式正在執行，您可以嘗試 `cpu` 指令："
+
+#: src/utilities/cpu.md:410
+#, fuzzy
+msgid "You can log in and notice that things are the same:"
+msgstr "您可以登入並注意到情況是一樣的："
+
+#: src/utilities/cpu.md:422
+msgid ""
+"Note that you end up in the same directory on the remote node that you are "
+"in on the host; all the files are there. We can run any program on the "
+"remote node that we have on the host:"
+msgstr ""
+
+#: src/utilities/cpu.md:450
+#, fuzzy
+msgid ""
+"As you can see, `/tmp/cpu` is mounted via 9p back to the `cpu` client "
+"(recall that the `cpu` client is a 9p server, so your files are visible on "
+"the remote node). Further, you can see mounts on `/usr`, `/bin`, `/etc`, and "
+"so on. For this reason, we can run `date` and it will find its needed "
+"libraries in `/usr`, as the `ldd` command demonstrates."
+msgstr ""
+"如您所見，`/tmp/cpu` 透過 9p 安裝回 `cpu` 用戶端（回想一下，`cpu` 用戶端是 9p "
+"伺服器，因此您的檔案在遠端節點上可見）。此外，您還可以看到「/usr」、「/bin」、「/etc」等上的掛載。因此，我們可以運行“date”，它將在“/usr”中找到所需的庫，如“ldd”命令所示。"
+
+#: src/utilities/cpu.md:456
+#, fuzzy
+msgid "Making cpu easier to use"
+msgstr "讓 CPU 更易於使用"
+
+#: src/utilities/cpu.md:458
+msgid ""
+"If you get tired of typing `-keys`, do the following: put your own `cpu_rsa` "
+"in `~/.ssh`; and copy the `cpu` binary to `bin` (or build a new one)."
+msgstr ""
+
+#: src/utilities/cpu.md:461
+#, fuzzy
+msgid ""
+"Warning! The `cpu` keys we provide in the repo are only to be used for this "
+"demo. You should not use them for any other purpose, as they are in a Github "
+"repo and hence open to the world."
+msgstr ""
+"警告！我們在 repo 中提供的 `cpu` 鍵僅用於此演示。您不應將它們用於任何其他目的，因為它們位於 Github 儲存庫中，因此向全世界開放。"
+
+#: src/utilities/cpu.md:465
+#, fuzzy
+msgid "Using some of the namespace"
+msgstr "使用一些命名空間"
+
+#: src/utilities/cpu.md:467
+#, fuzzy
+msgid ""
+"Sometimes, you don’t want all the `/usr` and `/bin` directories to be "
+"replaced with those from your machine. You might, for example, `cpu` into an "
+"ARM system, and hence only need a `/home`, but nothing else."
+msgstr ""
+"有時，您不希望所有“/usr”和“/bin”目錄都被您機器上的目錄取代。例如，您可以將“cpu”放入 ARM "
+"系統中，因此只需要“/home”，而不需要其他任何東西。"
+
+#: src/utilities/cpu.md:471
+#, fuzzy
+msgid ""
+"The `-namespace` switch lets you control the namespace. It is structured "
+"somewhat like a path variable, with `:`\\-separated components. The default "
+"value is `/lib:/lib64:/usr:/bin:/etc:/home`. You can modify it or even force "
+"it to be empty: `-namespace=\"\"`, for example. If it is empty, `cpud` will "
+"only mount the 9p server on `/tmp/cpu`."
+msgstr ""
+"`-namespace` 開關可讓您控制命名空間。它的結構有點像路徑變量，由 `:`\\ "
+"分隔的組件組成。預設值是“/lib:/lib64:/usr:/bin:/etc:/home”。您可以修改它，甚至強制它為空：例如`-namespace=\"\"`。如果為空，`cpud` "
+"將僅將 9p 伺服器掛載在 `/tmp/cpu` 上。"
+
+#: src/utilities/cpu.md:477
+#, fuzzy
+msgid ""
+"This following example will cpu to an ARM64 host, sharing /home, but nothing "
+"else."
+msgstr "以下範例將 CPU 連接到 ARM64 主機，共用 /home，但不共用其他任何內容。"
+
+#: src/utilities/cpu.md:483
+#, fuzzy
+msgid ""
+"For an different architecture system, we might want to specify that the "
+"/bin, /lib, and other directories have a different path on the remote than "
+"they have locally. The -namespace switch allows this via an = sign:"
+msgstr ""
+"對於不同的架構系統，我們可能想要指定 /bin、/lib 和其他目錄在遠端上的路徑與本機的路徑不同。 -namespace 開關透過 = 符號允許這樣做："
+
+#: src/utilities/cpu.md:491
+#, fuzzy
+msgid ""
+"In this case, `/bin`, `/usr`, and `/lib` on the remote system are supplied "
+"by `/arm/bin`, `/arm/lib`, and `/arm/usr` locally."
+msgstr "在這種情況下，遠端系統上的“/bin”、“/usr”和“/lib”由本地的“/arm/bin”、“/arm/lib”和“/arm/usr”提供。"
+
+#: src/utilities/cpu.md:494
+#, fuzzy
+msgid ""
+"If we need to test `cpu` without doing bind mounts, we can specify a `PWD` "
+"that requires no mounts and an empty namespace:"
+msgstr "如果我們需要在不進行綁定掛載的情況下測試“cpu”，我們可以指定不需要掛載和空命名空間的“PWD”："
+
+#: src/utilities/cpu.md:511
+#, fuzzy
+msgid ""
+"There is a bit of a subtlety about the interaction of the namespace and 9p "
+"switches, which we are still discussing: the -namespace value can override "
+"the -9p switch."
+msgstr "命名空間和 9p 開關的交互作用有一點微妙，我們仍在討論：-namespace 值可以覆蓋 -9p 開關。"
+
+#: src/utilities/cpu.md:514
+#, fuzzy
+msgid ""
+"If you set -9p=false but have a non-empty namespace variable, then 9p will "
+"be set to true. So in this example, the -9p switch has no effect:"
+msgstr "如果您設定 -9p=false 但有一個非空的命名空間變量，那麼 9p 將設為 true。因此在這個例子中，-9p 開關沒有任何效果："
+
+#: src/utilities/cpu.md:521
+msgid ""
+"Why is this? Because the default value of -namespace is non-empty. The open "
+"question: should -9p=false force the namespace to be empty; or should a "
+"none-empty namespace for -9p to be true? For now, we have chosen the latter "
+"approach."
+msgstr ""
+
+#: src/utilities/cpu.md:526
+#, fuzzy
+msgid ""
+"Another possible approach is to log conflicting settings of these two "
+"switches and exit:"
+msgstr "另一種可能的方法是記錄這兩個開關的衝突設定並退出："
+
+#: src/utilities/cpu.md:531
+#, fuzzy
+msgid "\"\""
+msgstr "“”"
+
+#: src/utilities/cpu.md:534
+#, fuzzy
+msgid "We welcome comments on this issue."
+msgstr "我們歡迎對此問題發表評論。"
+
+#: src/utilities/cpu.md:536
+#, fuzzy
+msgid "cpu and Docker"
+msgstr "CPU和Docker"
+
+#: src/utilities/cpu.md:538
+#, fuzzy
+msgid ""
+"Maintaining file system images is inconvenient. We can use Docker containers "
+"on remote hosts instead. We can take a standard Docker container and, with "
+"suitable options, use docker to start the container with `cpu` as the first "
+"program it runs."
+msgstr ""
+"維護檔案系統映像不方便。我們可以在遠端主機上使用 Docker 容器。我們可以採用標準的 Docker 容器，並使用合適的選項，使用 docker "
+"啟動容器，並以「cpu」作為其運行的第一個程式。"
+
+#: src/utilities/cpu.md:543
+msgid ""
+"That means we can use any Docker image, on any architecture, at any time; "
+"and we can even run more than one at a time, since the namespaces are "
+"private."
+msgstr ""
+
+#: src/utilities/cpu.md:546
+#, fuzzy
+msgid "In this example, we are starting a standard Ubuntu image:"
+msgstr "在這個範例中，我們啟動一個標準的 Ubuntu 映像："
+
+#: src/utilities/cpu.md:550
+#, fuzzy
+msgid ""
+"'ubuntu@sha256:073e060cec31fed4a86fcd45ad6f80b1f135109ac2c0b57272f01909c9626486'"
+msgstr ""
+"'ubuntu@sha256:073e060cec31fed4a86fcd45ad6f80b1f135109ac2c0b57272f01909c9626486'"
+
+#: src/utilities/cpu.md:555
+#, fuzzy
+msgid ""
+"'s platform (linux/arm64/v8) does not match the detected host platform "
+"(linux/amd64) and no specific platform was requested\n"
+"1970/01/01 21:37:32 CPUD:Warning: mounting /tmp/cpu/lib64 on /lib64 failed: "
+"no such file or directory\n"
+"$ ls\n"
+"bbin  buildbin  env  go    init     lib    proc  tcz  ubin  var\n"
+"bin   dev       etc  home  key.pub  lib64  sys   tmp  usr\n"
+msgstr ""
+"的平台（linux/arm64/v8）與偵測到的主機平台（linux/amd64）不匹配，並且沒有要求特定平台\n"
+"1970/01/01 21:37:32 CPUD：警告：在 /lib64 上安裝 /tmp/cpu/lib64 失敗：沒有此檔案或目錄\n"
+"$ ls\n"
+"bbin buildbin env go init lib proc tcz ubin var\n"
+"bin dev etc home key.pub lib64 sys tmp usr"
+
+#: src/utilities/cpu.md:562
+#, fuzzy
+msgid ""
+"Note that the image was update and then started. The `/lib64` mount fails, "
+"because there is no `/lib64` directory in the image, but that is harmless."
+msgstr "請注意，圖像已更新，然後啟動。 `/lib64` 掛載失敗，因為鏡像中沒有 `/lib64` 目錄，但這是無害的。"
+
+#: src/utilities/cpu.md:565
+#, fuzzy
+msgid ""
+"On the local host, on which we ran docker, this image will show up in docker "
+"`ps`:"
+msgstr "在我們執行 docker 的本機主機上，此映像將顯示在 docker `ps` 中："
+
+#: src/utilities/cpu.md:570
+#, fuzzy
+msgid "\"/home/rminnich/go/b…\""
+msgstr "“/home/rminnich/go/b…”"
+
+#: src/utilities/cpu.md:573
+#, fuzzy
+msgid "Even though the binaries themselves are running on the remote ARM system."
+msgstr "即使二進位檔案本身在遠端 ARM 系統上運行。"
+
+#: src/utilities/cpu.md:575
+#, fuzzy
+msgid "cpu and virtiofs"
+msgstr "CPU 和 virtiofs"
+
+#: src/utilities/cpu.md:577
+#, fuzzy
+msgid ""
+"While 9p is very general, because it is _transport-independent_, there are "
+"cases where we can get much better performance by using a less general file "
+"system. One such case is with virtofs."
+msgstr "雖然 9p 非常通用，因為它與傳輸無關，但在某些情況下，我們可以透過使用不太通用的檔案系統來獲得更好的效能。其中一個案例是 virtofs。"
+
+#: src/utilities/cpu.md:581
+#, fuzzy
+msgid ""
+"Because virtiofs is purely from guest kernel vfs to host kernel vfs, via "
+"virtio transport, it has been measured to run at up to 100 times faster."
+msgstr "由於 virtiofs 純粹是從客戶核心 vfs 到主機核心 vfs，透過 virtio 傳輸，因此經測量運行速度最高可提高 100 倍。"
+
+#: src/utilities/cpu.md:584
+#, fuzzy
+msgid ""
+"We can use virtiofs by specifying virtiofs mounts. cpud will look for an "
+"environemnt variable, `CPU_FSTAB`, which is in `fstab(5)` format. The client "
+"can specify an fstab in one of two ways. Either via the `-fstab` switch, in "
+"which case the client will populate the `CPU_FSTAB` variable with the "
+"contents of the file or by passing the `CPU_FSTAB` environment variable, "
+"which happens by default."
+msgstr ""
+"我們可以透過指定 virtiofs 掛載來使用 virtiofs。 cpud "
+"將尋找環境變數“CPU_FSTAB”，其格式為“fstab(5)”。客戶端可以透過兩種方式之一指定 "
+"fstab。要么透過“-fstab”開關，在這種情況下客戶端將使用檔案的內容填充“CPU_FSTAB”變量，要么通過傳遞“CPU_FSTAB”環境變量，這是預設發生的。"
+
+#: src/utilities/cpu.md:591
+#, fuzzy
+msgid ""
+"On the client side, the file specified via the -fstab takes precedence over "
+"any value of the CPU_FSTAB environment variable. On the server side, cpud "
+"does not use the -fstab switch, only using the environment variable."
+msgstr ""
+"在客戶端，透過 -fstab 指定的檔案優先於 CPU_FSTAB 環境變數的任何值。在伺服器端，cpud 不使用 -fstab 開關，只使用環境變數。"
+
+#: src/utilities/cpu.md:595
+#, fuzzy
+msgid "Here is an example of using the CPU_FSTAB variable with one entry:"
+msgstr "以下是使用具有一個條目的 CPU_FSTAB 變數的範例："
+
+#: src/utilities/cpu.md:601
+#, fuzzy
+msgid ""
+"In this case, the virtiofs server had the name myfs, and on the remote side, "
+"virtiofs was mounted on /mnt."
+msgstr "在這種情況下，virtiofs 伺服器名為 myfs，而在遠端端，virtiofs 安裝在 /mnt 上。"
+
+#: src/utilities/cpu.md:604
+#, fuzzy
+msgid "For the fstab case, the command looks like this:"
+msgstr "對於 fstab 情況，命令如下所示："
+
+#: src/utilities/cpu.md:610
+#, fuzzy
+msgid "The fstab in this case would be"
+msgstr "在這種情況下，fstab 將是"
+
+#: src/utilities/cpu.md:616
+#, fuzzy
+msgid ""
+"Note that both the environment variable and the fstab can have more than one "
+"entry, but they entries must be separate by newlines. Hence, this will not "
+"work:"
+msgstr "請注意，環境變數和 fstab 都可以有多個條目，但它們的條目必須以換行符號分隔。因此，這是行不通的："
+
+#: src/utilities/cpu.md:624
+#, fuzzy
+msgid "as shells insist on converting newlines to spaces."
+msgstr "因為 shell 堅持將換行符號轉換為空格。"
+
+#: src/utilities/cpu.md:626
+msgid ""
+"The fstab can specify any file system. If there is a mount path to, e.g., "
+"Google drive, and it can be specified in fstab format, then cpu clients can "
+"use Google Drive files. Note, again, that these alternative mounts do not "
+"use the 9p server built in to the cpu client; they use the file systems "
+"provided on the cpu server machine."
+msgstr ""
+
+#: src/utilities/cpu.md:632
+#, fuzzy
+msgid "There are thus several choices for setting up the mounts"
+msgstr "因此，安裝支架有多種選擇"
+
+#: src/utilities/cpu.md:634
+#, fuzzy
+msgid "9p support by the cpu client"
+msgstr "CPU 用戶端支援 9p"
+
+#: src/utilities/cpu.md:635
+#, fuzzy
+msgid ""
+"9p supported by the cpu client, with additional mounts via -fstab or "
+"-namespace"
+msgstr "CPU 用戶端支援 9p，可透過 -fstab 或 -namespace 進行額外掛載"
+
+#: src/utilities/cpu.md:636
+msgid ""
+"9p _without_ any bind mounts, i.e. -9p=false -namespace \"\", in which case, "
+"on the remote machine, files from the client are visible in /tmp/cpu, but no "
+"bind mounts are done; with additional mounts provided by fstab mounts are "
+"provided"
+msgstr ""
+
+#: src/utilities/cpu.md:640
+msgid ""
+"no 9p mounts at all, when -namespace=\"\" -9p=false; with optional "
+"additional mounts via fstab"
+msgstr ""
+
+#: src/utilities/cpu.md:642
+#, fuzzy
+msgid "if there are no 9p mounts, and no fstab mounts, cpu is equivalent to ssh."
+msgstr "如果沒有 9p 掛載，也沒有 fstab 掛載，則 cpu 相當於 ssh。"
+
+#: src/utilities/cpu.md:644
+#, fuzzy
+msgid "For reference, the command we used: `cpu -dbg9p -d apu2 date`"
+msgstr "作為參考，我們使用的指令：`cpu -dbg9p -d apu2 date`"
+
+#: src/utilities/dut.md:1
+#, fuzzy
+msgid "DUT, a simple Device Under Test utility."
+msgstr "DUT，一個簡單的被測設備實用程式。"
+
+#: src/utilities/dut.md:3
+#, fuzzy
+msgid "Points of contact: [Ron Minnich](https://github.com/rminnich)"
+msgstr "聯絡人：[Ron Minnich](https://github.com/rminnich)"
+
+#: src/utilities/dut.md:5
+#, fuzzy
+msgid ""
+"DUT is a simple Device Under Test program that gives you control of a node. "
+"It is intended to make very fast startup and control easy."
+msgstr "DUT 是一個簡單的被測設備程序，可讓您控制節點。其目的是使快速啟動和控制變得簡單。"
+
+#: src/utilities/dut.md:8
+msgid ""
+"DUT is one program implementing three operations. The first, tester, is run "
+"on a test control system, such as your desktop; the second, called device, "
+"is run on the device; the third, called ssh and also run on the device, "
+"starts an ssh server assuming one is present."
+msgstr ""
+
+#: src/utilities/dut.md:12
+#, fuzzy
+msgid ""
+"DUT is intended to be very limited, with more sophisticated operations, "
+"should they be needed, being done over SSH."
+msgstr "DUT 的功能非常有限，如果需要的話，可以透過 SSH 進行更複雜的操作。"
+
+#: src/utilities/dut.md:15
+#, fuzzy
+msgid "DUT is found at github.com:linuxboot/dut."
+msgstr "DUT 位於 github.com:linuxboot/dut。"
+
+#: src/utilities/dut.md:17
+#, fuzzy
+msgid "This chapter describes how we build and use DUT."
+msgstr "本章介紹如何建置和使用 DUT。"
+
+#: src/utilities/dut.md:19 src/coreboot.u-root.systemboot/index.md:31
+#, fuzzy
+msgid "Components"
+msgstr "成分"
+
+#: src/utilities/dut.md:21
+#, fuzzy
+msgid "DUT is intended to be built into a u-root image. First one must fetch it:"
+msgstr "DUT 旨在建置到 u-root 映像中。首先必須取得它："
+
+#: src/utilities/dut.md:27
+#, fuzzy
+msgid ""
+"DUT source tree is structured such that a program called uinit is produced. "
+"This is convenient for u-root usage."
+msgstr "DUT 來源樹的結構使得產生一個名為 uinit 的程式。這對於 u-root 使用很方便。"
+
+#: src/utilities/dut.md:29
+#, fuzzy
+msgid "Building it into a u-root image is easy:"
+msgstr "將其建置到 u-root 映像中很容易："
+
+#: src/utilities/dut.md:34
+msgid ""
+"I almost always add an sshd to u-root; it's just too handy. U-root sshd does "
+"not support passwords, so you have to supply the public key:"
+msgstr ""
+
+#: src/utilities/dut.md:40
+#, fuzzy
+msgid "DUT on the device"
+msgstr "設備上的 DUT"
+
+#: src/utilities/dut.md:41
+#, fuzzy
+msgid ""
+"On boot, the standard init program will find dut, and run it. The standard "
+"mode on a device is device mode, and dut will bring up the ethernet, "
+"currently using 192.168.0.2, and assuming the tester is 192.168.0.1 (this "
+"should be fixed ...). It will then attempt to connect to a uinit running in "
+"'tester' mode on 192.168.0.1. Once connected, it functions as a server and "
+"waits for requests."
+msgstr ""
+"啟動時，標準 init 程式會找到 dut，並執行它。設備上的標準模式是設備模式，dut 將啟動以太網，目前使用 192.168.0.2，並假設測試儀是 "
+"192.168.0.1（這應該是固定的...）。然後它將嘗試連接到 192.168.0.1 上以「測試器」模式運行的 "
+"uinit。一旦連接，它就會作為伺服器運行並等待請求。"
+
+#: src/utilities/dut.md:47
+#, fuzzy
+msgid "DUT on the controller"
+msgstr "控制器上的 DUT"
+
+#: src/utilities/dut.md:48
+#, fuzzy
+msgid "Running on the controller is easy:"
+msgstr "在控制器上運行很容易："
+
+#: src/utilities/dut.md:53
+#, fuzzy
+msgid ""
+"On the controller, the program waits for a connection and then starts "
+"issuing commands to the device. The controller has the option of calling the "
+"following RPC functions:"
+msgstr "在控制器上，程式等待連接，然後開始向裝置發出命令。控制器可以選擇呼叫以下 RPC 函數："
+
+#: src/utilities/dut.md:63
+#, fuzzy
+msgid ""
+"Each of these RPCs takes arguments and returns a result, with Welcome being "
+"the most fun:"
+msgstr "每個 RPC 都接受參數並傳回結果，其中 Welcome 是最有趣的："
+
+#: src/utilities/dut.md:75
+#, fuzzy
+msgid ""
+"The current tester mode performs an RPC sequence I use for DXE cleaning, "
+"namely, a Welcome, followed by a Reboot, followed by a Welcome. This "
+"sequence verifies that I can get network going from power on, do a reboot, "
+"and reconnect after a reboot. It's been good for finding out if a particular "
+"DXE can be removed."
+msgstr ""
+"目前測試模式執行我用於 DXE 清理的 RPC "
+"序列，即歡迎，然後是重啟，然後是歡迎。此序列驗證我是否可以從開機開始運行網路、重新啟動並在重新啟動後重新連接。這對於找出是否可以刪除特定的 DXE "
+"很有幫助。"
+
+#: src/utilities/dut.md:79
+#, fuzzy
+msgid ""
+"Once the second Welcome has happened, if an sshd is installed, it will have "
+"been started, and you can do additional commands."
+msgstr "一旦出現第二個歡迎訊息，如果安裝了 sshd，它將啟動，您可以執行其他命令。"
+
+#: src/utilities/dut.md:81
+#, fuzzy
+msgid "Future work"
+msgstr "未來工作"
+
+#: src/utilities/dut.md:83
+#, fuzzy
+msgid ""
+"Obviously, much more can be done. But this is a useful foundation on which "
+"to build DUT environments."
+msgstr "顯然，我們還可以做更多。但這是建立 DUT 環境的有用基礎。"
+
+#: src/implementation.md:3
+#, fuzzy
+msgid ""
+"The aim of LinuxBoot is to reduce complexity and obscure firmware by moving "
+"that functionality into kernel and user-space."
+msgstr "LinuxBoot 的目標是透過將功能移入核心和使用者空間來降低複雜性和模糊韌體。"
+
+#: src/implementation.md:6
+#, fuzzy
+msgid ""
+"This chapter describes the procedures from a [LinuxBoot "
+"workshop](https://docs.google.com/presentation/d/1s9ka4v7leKeJa3116AQoNb9cv3OqmnW6pgn0ov9WiHo/edit?ts=5e2b227b#slide=id.g7ceec54197_4_163) "
+"where an Atomic Pi board with UEFI firmware was converted to run LinuxBoot. "
+"The build materials associated with this are found at "
+"[digitalloggers/atomicpi](https://github.com/linuxboot/mainboards/tree/master/digitalloggers/atomicpi)."
+msgstr ""
+"本章介紹了 [LinuxBoot "
+"研討會](https://docs.google.com/presentation/d/1s9ka4v7leKeJa3116AQoNb9cv3OqmnW6pgn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov9WiHo/edit?ts=5e2b227b#slide=id.ggn0ov954197)板轉換為運行 "
+"LinuxBoot。與此相關的建造材料可以在 "
+"[digitalloggers/atomicpi](https://github.com/linuxboot/mainboards/tree/master/digitalloggers/atomicpi) "
+"中找到。"
+
+#: src/implementation.md:12
+#, fuzzy
+msgid ""
+"Read the below and consult the Makefile for the details of how it was "
+"implemented."
+msgstr "閱讀下面的內容並查閱 Makefile 以了解其實現方式的詳細資訊。"
+
+#: src/implementation.md:15
+#, fuzzy
+msgid "A quick refresher on UEFI"
+msgstr "快速回顧一下 UEFI"
+
+#: src/implementation.md:17
+#, fuzzy
+msgid "UEFI has three sections:"
+msgstr "UEFI 有三個部分："
+
+#: src/implementation.md:19
+#, fuzzy
+msgid "SEC (\"Boot\")"
+msgstr "SEC（「啟動」）"
+
+#: src/implementation.md:20
+#, fuzzy
+msgid "PEI (\"Very early chip setup and DRAM programming\")"
+msgstr "PEI（「非常早期的晶片設定和 DRAM 編程」）"
+
+#: src/implementation.md:21
+#, fuzzy
+msgid "DXE (\"DRAM code\")"
+msgstr "DXE（“DRAM代碼”）"
+
+#: src/implementation.md:23
+msgid "DXE process is very complex; some systems have 750 DXEs."
+msgstr ""
+
+#: src/implementation.md:25
+#, fuzzy
+msgid ""
+"LinuxBoot replaces most of the UEFI software with Linux. LinuxBoot has an "
+"initramfs provided by [u-root](../u-root.md)."
+msgstr ""
+"LinuxBoot 用 Linux 取代了大部分 UEFI 軟體。 LinuxBoot 有一個由 [u-root](../u-root.md) 提供的 "
+"initramfs。"
+
+#: src/implementation.md:28
+#, fuzzy
+msgid ""
+"The above are stored inside a flash filesystem (FFS) inside a region of "
+"flash on your motherboard (the BIOS region). Another important region of "
+"flash is the ME region."
+msgstr "以上內容儲存在主機板快閃記憶體區域（BIOS 區域）內的快閃記憶體檔案系統（FFS）內。 Flash的另一個重要區域是ME區域。"
+
+#: src/implementation.md:32
+#, fuzzy
+msgid ""
+"The Management Engine (ME) is an x86 CPU embedded in the Intel Platform "
+"Controller Hub (PCH). It runs the Minix operating system which boots first "
+"and enables hardware such as clocks and GPIOs. ME checks the contents of "
+"flash memory and is used to implement \"BootGuard\". If you reflash and the "
+"ME is in \"BootGuard\" mode, your machine will be unusable. You need to run "
+"a tool called `me_cleaner` on the image to disable BootGuard."
+msgstr ""
+"管理引擎 (ME) 是嵌入在英特爾平台控制器中心 (PCH) 中的 x86 CPU。它運行 Minix 作業系統，該系統首先啟動並啟用時脈和 GPIO "
+"等硬體。 ME檢查快閃記憶體的內容，用於實現「BootGuard」。如果您重新刷新並且 ME "
+"處於“BootGuard”模式，您的機器將無法使用。您需要在映像上執行名為「me_cleaner」的工具來停用 BootGuard。"
+
+#: src/implementation.md:39
+#, fuzzy
+msgid "How do you get LinuxBoot on your hardware"
+msgstr "如何在你的硬體上安裝 LinuxBoot"
+
+#: src/implementation.md:41
+#, fuzzy
+msgid ""
+"Start with a board running standard UEFI and proceed from \"zero changes to "
+"FLASH\" to \"max changes\" in 4 steps:"
+msgstr "從執行標準 UEFI 的主機板開始，透過 4 個步驟從「對 FLASH 進行零更改」到「最大更改」："
+
+#: src/implementation.md:44
+#, fuzzy
+msgid "Boot from USB stick via UEFI shell command _or_ netboot (zero changes)"
+msgstr "透過 UEFI shell 指令或網路啟動從 USB 啟動（零變化）"
+
+#: src/implementation.md:45
+#, fuzzy
+msgid "Find a way to read flash and write flash"
+msgstr "找到讀取flash和寫入flash的方法"
+
+#: src/implementation.md:46
+#, fuzzy
+msgid "Understand the flash layout"
+msgstr "了解 Flash 佈局"
+
+#: src/implementation.md:47
+#, fuzzy
+msgid "Prepare linux kernel and initrd/initramfs payload."
+msgstr "準備 Linux 核心和 initrd/initramfs 有效負載。"
+
+#: src/implementation.md:48
+#, fuzzy
+msgid ""
+"Replace UEFI Shell code section with Linux kernel and associated initrd "
+"(change part of one thing)"
+msgstr "用 Linux 核心和相關的 initrd 取代 UEFI Shell 程式碼部分（更改一部分）"
+
+#: src/implementation.md:50
+#, fuzzy
+msgid "Remove as many DXEs as possible (change by removal). This change:"
+msgstr "刪除盡可能多的 DXE（透過刪除來改變）。此更改："
+
+#: src/implementation.md:51
+#, fuzzy
+msgid "Speeds boot"
+msgstr "加速啟動"
+
+#: src/implementation.md:52
+#, fuzzy
+msgid "Reduces panic possibilities"
+msgstr "減少恐慌的可能性"
+
+#: src/implementation.md:53
+#, fuzzy
+msgid "Removes exploits"
+msgstr "消除漏洞"
+
+#: src/implementation.md:54
+#, fuzzy
+msgid "In production, it has solved problems"
+msgstr "在生產中，它解決了問題"
+
+#: src/implementation.md:55
+#, fuzzy
+msgid "Clear ME region for initrd storage"
+msgstr "清除用於 initrd 儲存的 ME 區域"
+
+#: src/implementation.md:56
+#, fuzzy
+msgid "Replace some DXEs with open source components (change by replacement)"
+msgstr "用開源組件取代部分 DXE（透過替換進行更改）"
+
+#: src/implementation.md:58
+#, fuzzy
+msgid ""
+"One of the challenges in the above is in finding (or reclaiming) enough "
+"space in flash to shoehorn your kernel and initrd into."
+msgstr "上述挑戰之一是找到（或回收）快閃記憶體中的足夠空間來塞入核心和 initrd。"
+
+#: src/implementation.md:61
+#, fuzzy
+msgid "Tools of the trade"
+msgstr "產業工具"
+
+#: src/implementation.md:63
+#, fuzzy
+msgid ""
+"There are two tools you use when you modify the UEFI flash image: `utk` and "
+"`me_cleaner`."
+msgstr "修改 UEFI 快閃記憶體映像時需要使用兩個工具：「utk」和「me_cleaner」。"
+
+#: src/implementation.md:66
+#, fuzzy
+msgid "The ME Cleaner tool:"
+msgstr "ME Cleaner 工具："
+
+#: src/implementation.md:68
+#, fuzzy
+msgid "`/usr/bin/python2 me_cleaner.py -s` _imagefile.bin_"
+msgstr "`/usr/bin/python2 me_cleaner.py -s` _imagefile.bin_"
+
+#: src/implementation.md:70
+msgid ""
+"`me_cleaner` sets the high assurance platform (HAP) bit. HAP provides a way "
+"to disable a feature on Intel chips that does not allow us to modify the "
+"UEFI image and install LinuxBoot. Setting the bit with `me_cleaner` disables "
+"the \"feature\".  Note that this does not always work; check with the "
+"LinuxBoot community."
+msgstr ""
+
+#: src/implementation.md:76
+#, fuzzy
+msgid "When you run `me_cleaner`:"
+msgstr "當你執行“me_cleaner”時："
+
+#: src/implementation.md:82
+#, fuzzy
+msgid "you should see output similar to the following:"
+msgstr "您應該會看到類似以下內容的輸出："
+
+#: src/implementation.md:86
+#, fuzzy
+msgid "`Full image detected`"
+msgstr "`偵測到完整影像`"
+
+#: src/implementation.md:87
+#, fuzzy
+msgid "`Found FPT header at 0x1010`"
+msgstr "`在 0x1010 找到 FPT 標頭`"
+
+#: src/implementation.md:88
+#, fuzzy
+msgid "`Found 20 partition(s)`"
+msgstr "`找到 20 個分區`"
+
+#: src/implementation.md:89
+#, fuzzy
+msgid "`Found FTPR header: FTPR partition spans from 0x6f000 to 0xe700`"
+msgstr "`找到 FTPR 標頭：FTPR 分區範圍從 0x6f000 到 0xe700`"
+
+#: src/implementation.md:90
+#, fuzzy
+msgid "`ME/TXE firmware version 2.0.5.3112 (generation 2)`"
+msgstr "`ME/TXE 韌體版本 2.0.5.3112（第 2 代）`"
+
+#: src/implementation.md:91
+#, fuzzy
+msgid "`Public key match: Intel TXE, firmware versions 2.x.x.x`"
+msgstr "`公鑰匹配：Intel TXE，韌體版本 2.x.x.x`"
+
+#: src/implementation.md:92
+#, fuzzy
+msgid "`The AltMeDisable bit is SET`"
+msgstr "`AltMeDisable 位元已設定`"
+
+#: src/implementation.md:93
+#, fuzzy
+msgid "`Setting the AltMeDisable bit in PCHSTRP10 to disable Intel ME…`"
+msgstr "`設定 PCHSTRP10 中的 AltMeDisable 位元以停用 Intel ME...`"
+
+#: src/implementation.md:94
+#, fuzzy
+msgid "`Checking the FTPR RSA signature... VALID`"
+msgstr "`檢查 FTPR RSA 簽章...有效`"
+
+#: src/implementation.md:95
+#, fuzzy
+msgid "`Done! Good luck!`"
+msgstr "「完成了！」祝你好運！"
+
+#: src/implementation.md:97
+#, fuzzy
+msgid ""
+"By applying `me_cleaner`, it has been observed that almost 4M of flash ram "
+"can be reclaimed for use. That 4M is enough to store a reasonably full "
+"featured compressed initrd image."
+msgstr "透過應用“me_cleaner”，可以觀察到幾乎 4M 的快閃記憶體可以被回收使用。 4M 足以儲存功能相當齊全的壓縮 initrd 映像。"
+
+#: src/implementation.md:101
+#, fuzzy
+msgid "The `utk` tool can:"
+msgstr "`utk` 工具可以："
+
+#: src/implementation.md:103
+#, fuzzy
+msgid "Remove DXEs"
+msgstr "刪除 DXE"
+
+#: src/implementation.md:104
+#, fuzzy
+msgid "Insert new DXEs"
+msgstr "插入新的 DXE"
+
+#: src/implementation.md:105
+#, fuzzy
+msgid "Replace the binary code of a DXE with a kernel"
+msgstr "用核心替換 DXE 的二進位代碼"
+
+#: src/implementation.md:106
+#, fuzzy
+msgid "Reallocate space from the ME region to the BIOS region (\"tighten\")"
+msgstr "將空間從 ME 區域重新分配到 BIOS 區域（「收緊」）"
+
+#: src/implementation.md:108
+#, fuzzy
+msgid "LinuxBoot Implementation steps"
+msgstr "LinuxBoot實作步驟"
+
+#: src/implementation.md:110
+#, fuzzy
+msgid "Step 1: boot Linux via netboot / UEFI shell"
+msgstr "步驟 1：透過網路啟動/UEFI shell 啟動 Linux"
+
+#: src/implementation.md:112
+#, fuzzy
+msgid "netboot: standard BIOS-based PXE boot"
+msgstr "網路啟動：基於標準 BIOS 的 PXE 啟動"
+
+#: src/implementation.md:113
+#, fuzzy
+msgid "Netboot is probably the most common working boot method on UEFI"
+msgstr "網路啟動可能是 UEFI 上最常見的啟動方法"
+
+#: src/implementation.md:114
+#, fuzzy
+msgid "We have never seen a system that did not have a net boot"
+msgstr "我們從未見過沒有網路啟動的系統"
+
+#: src/implementation.md:115
+#, fuzzy
+msgid "UEFI Shell (mentioned only for completeness)"
+msgstr "UEFI Shell（僅為完整性而提及）"
+
+#: src/implementation.md:116
+#, fuzzy
+msgid ""
+"Install Linux on FAT-32 media with a name of your choice (e.g. \"kernel\")"
+msgstr "使用您選擇的名稱（例如“核心”）在 FAT-32 媒體上安裝 Linux"
+
+#: src/implementation.md:117
+#, fuzzy
+msgid "FAT-32, also known as MS-DOS file system"
+msgstr "FAT-32，也稱為 MS-DOS 檔案系統"
+
+#: src/implementation.md:118
+#, fuzzy
+msgid "Boot kernel at UEFI Shell prompt"
+msgstr "在 UEFI Shell 提示字元下啟動內核"
+
+#: src/implementation.md:119
+#, fuzzy
+msgid "We've run into a few systems that don't have a UEFI shell"
+msgstr "我們遇過一些沒有 UEFI shell 的系統"
+
+#: src/implementation.md:121
+#, fuzzy
+msgid "Working with a system that only has a net interface"
+msgstr "使用僅具有網路介面的系統"
+
+#: src/implementation.md:123
+#, fuzzy
+msgid ""
+"If the system only has a net interface, you use Dynamic Host Configuration "
+"Protocol (DHCP), using broadcast DISCOVER, and Trivial File Transfer "
+"Protocol (TFTP) to get the boot information you need."
+msgstr ""
+"如果系統只有網路接口，則可以使用動態主機設定協定 (DHCP)、使用廣播 DISCOVER 和簡單檔案傳輸協定 (TFTP) 來取得所需的啟動資訊。"
+
+#: src/implementation.md:127
+#, fuzzy
+msgid ""
+"Configuration information is provided by REPLY to a DHCP request. The REPLY "
+"returns an IP, server, and a configuration file name that provides:"
+msgstr "設定資訊由 DHCP 請求的回應提供。 REPLY 傳回 IP、伺服器和一個設定檔名，其中包含以下內容："
+
+#: src/implementation.md:130
+#, fuzzy
+msgid "Identity"
+msgstr "身分"
+
+#: src/implementation.md:131
+#, fuzzy
+msgid "What to boot"
+msgstr "啟動什麼"
+
+#: src/implementation.md:132
+#, fuzzy
+msgid "Where to get it"
+msgstr "在哪裡可以買到"
+
+#: src/implementation.md:134
+#, fuzzy
+msgid ""
+"Data is provided by TFTP. HTTP downloading takes a fraction of a second even "
+"for 16M kernels. With TFTP it's very slow and TFTP won't work with initramfs "
+"much large than 32MiB. Most LinuxBoot shops use or are transitioning to HTTP."
+msgstr ""
+"數據由TFTP提供。即使對於 16M 內核，HTTP 下載也只需幾分之一秒。使用 TFTP 非常慢，且 TFTP 無法與大於 32MiB 的 "
+"initramfs 一起工作。大多數 LinuxBoot 商店都使用或正在轉換為 HTTP。"
+
+#: src/implementation.md:138
+#, fuzzy
+msgid ""
+"Note: Boot images require a kernel(bzImage) + an initramfs + a command line. "
+"They can be loaded as three pieces or compiled and loaded as one piece, as "
+"described in this section."
+msgstr ""
+"注意：啟動映像需要一個核心（bzImage）+一個 initramfs "
+"+一個命令列。它們可以作為三個部分加載，也可以作為一個部分進行編譯和加載，如本節所述。"
+
+#: src/implementation.md:142
+#, fuzzy
+msgid "Step 2: read & write the flash"
+msgstr "第二步：讀寫快閃記憶體"
+
+#: src/implementation.md:144
+#, fuzzy
+msgid ""
+"There are two main ways to read and write the flash - hardware and software."
+msgstr "讀寫快閃記憶體主要有兩種方式－硬體和軟體。"
+
+#: src/implementation.md:146
+#, fuzzy
+msgid ""
+"Hardware: It is worth buying a Pomona 5250 SOIC Clip adapter to read "
+"directly by hardware to have something to roll back to if anything goes "
+"wrong. Avoid cheap SOIC clip adapters that don't allow you to use standard "
+"jumper leads. For a good example of using a Raspberry Pi 3/4 to read/write, "
+"see [Sakaki's EFI Install Guide/Disabling the Intel Management "
+"Engine](https://wiki.gentoo.org/wiki/Sakaki%27s_EFI_Install_Guide/Disabling_the_Intel_Management_Engine#imt_check)"
+msgstr ""
+"硬體：值得購買 Pomona 5250 SOIC Clip "
+"轉接器，以便透過硬體直接讀取，以便在出現任何問題時可以回溯。避免使用不允許您使用標準跳線的廉價 SOIC 夾子轉接器。有關使用 Raspberry Pi "
+"3/4 進行讀取/寫入的良好範例，請參閱 [Sakaki 的 EFI "
+"安裝指南/停用英特爾管理引擎](https://wiki.gentoo.org/wiki/Sakaki%27s_EFI_Install_Guide/Disabling_the_Intel_Management_Engine#imt_Install_Guide/Disabling_the_Intel_Management_Engine#imt_chch)"
+
+#: src/implementation.md:153
+#, fuzzy
+msgid ""
+"Software: With a working boot image, use flashrom to read an image of your "
+"flash. To write you may need to disable flash protections (look for \"ME "
+"Manufacturing mode\" jumpers on your motherboard). Figure on generally using "
+"software methods for reading & writing flash, but with hardware to drop back "
+"to."
+msgstr ""
+"軟體：使用有效的啟動映像，使用 flashrom 讀取快閃記憶體的映像。要寫入，您可能需要停用快閃記憶體保護（在主機板上尋找「ME "
+"製造模式」跳線）。圖中通常使用軟體方法讀取和寫入閃存，但使用硬體來回退。"
+
+#: src/implementation.md:159
+#, fuzzy
+msgid ""
+"Step 3: Familiarise yourself with the flash layout and identify free space"
+msgstr "步驟 3：熟悉快閃記憶體佈局並確定可用空間"
+
+#: src/implementation.md:161
+#, fuzzy
+msgid ""
+"Open your flash image with UEFITool, and locate the filesystem containing "
+"the DXE's (it will have the Shell or `Shell_Full` in it ). Check how much "
+"volume free space is in that filesystem - this will be an initial limit when "
+"you come to place your kernel and initramfs in it in step 5."
+msgstr ""
+"使用 UEFITool 開啟您的快閃記憶體映像，並找到包含 DXE 的檔案系統（它將包含 Shell "
+"或「Shell_Fu​​ll」）。檢查檔案系統中有多少磁碟區可用空間 - 當您在步驟 5 中將核心和 initramfs 放入其中時，這將是初始限制。"
+
+#: src/implementation.md:166
+#, fuzzy
+msgid "Step 4: Prepare linux/u-root payload"
+msgstr "步驟 4：準備 linux/u-root 有效載荷"
+
+#: src/implementation.md:168
+#, fuzzy
+msgid "Start small and work your way up."
+msgstr "從小事做起，逐步進步。"
+
+#: src/implementation.md:170
+#, fuzzy
+msgid ""
+"Use the tiny.config to configure your first kernel, and embed a small "
+"initramfs in-kernel (the u-root cpu payload is an excellent starting point)."
+msgstr ""
+"使用 tiny.config 配置您的第一個內核，並在內核中嵌入一個小型的 initramfs（u-root cpu 有效載荷是一個很好的起點）。"
+
+#: src/implementation.md:172
+#, fuzzy
+msgid "One can have a full kernel/initramfs in around 2M of flash."
+msgstr "大約 2M 的快閃記憶體中可以容納完整的核心/initramfs。"
+
+#: src/implementation.md:173
+#, fuzzy
+msgid ""
+"A more full featured kernel might consume 2M and a u-root bb distribution "
+"4M, which may well exceed the volume free space."
+msgstr "功能更齊全的核心可能消耗 2M，而 u-root bb 分佈可能消耗 4M，這很可能超出磁碟區的可用空間。"
+
+#: src/implementation.md:175
+#, fuzzy
+msgid ""
+"When there isn't enough space in this filesystem, one can either start "
+"removing unused DXE's (step 6), or use space formerly used by the ME Region "
+"(step 7)."
+msgstr "當此檔案系統中沒有足夠的空間時，可以開始刪除未使用的 DXE（步驟 6），或使用先前由 ME 區域使用的空間（步驟 7）。"
+
+#: src/implementation.md:179
+#, fuzzy
+msgid "Step 5: replace Shell binary section"
+msgstr "步驟5：替換 Shell 二進位部分"
+
+#: src/implementation.md:181
+#, fuzzy
+msgid "UEFI Shell is a DXE"
+msgstr "UEFI Shell 是一個 DXE"
+
+#: src/implementation.md:182
+#, fuzzy
+msgid "DXEs are Portable Executable 32-bit binaries (PE32)"
+msgstr "DXE 是可移植可執行 32 位元二進位檔案 (PE32)"
+
+#: src/implementation.md:183
+#, fuzzy
+msgid "They have multiple sections, one of them being binary code"
+msgstr "它們有多個部分，其中一個是二進位代碼"
+
+#: src/implementation.md:184
+#, fuzzy
+msgid ""
+"You need a flash image (in this case called _firmware.bin_). You can get it "
+"via vendor website, flashrom, or other mechanism."
+msgstr "您需要一個快閃記憶體映像（在本例中稱為_firmware.bin_）。您可以透過供應商網站、flashrom 或其他機制來取得它。"
+
+#: src/implementation.md:186
+#, fuzzy
+msgid ""
+"The following `utk` command replaces the Shell code section with a Linux "
+"kernel:"
+msgstr "以下“utk”指令用Linux核心取代Shell程式碼部分："
+
+#: src/implementation.md:188
+#, fuzzy
+msgid "`utk firmware.bin replace_pe32 Shell bzImage save` _new.bin_"
+msgstr "`utk 韌體.bin replace_pe32 Shell bzImage 保存` _new.bin_"
+
+#: src/implementation.md:189
+#, fuzzy
+msgid ""
+"Note: It's always a PE32, even for 64-bit kernels. _new.bin_ is a filename "
+"of your choosing."
+msgstr "注意：即使對於 64 位元內核，它始終是 PE32。 _new.bin_ 是您選擇的檔案名稱。"
+
+#: src/implementation.md:191
+#, fuzzy
+msgid "After running `utk`, you can reflash"
+msgstr "執行 `utk` 後，你可以重新刷新"
+
+#: src/implementation.md:193
+#, fuzzy
+msgid "Step 6a: remove as many DXEs as possible"
+msgstr "步驟 6a：刪除盡可能多的 DXE"
+
+#: src/implementation.md:195
+#, fuzzy
+msgid "You can do an initial mass removal based on your current knowledge"
+msgstr "您可以根據目前的知識進行初步的品質去除"
+
+#: src/implementation.md:196
+#, fuzzy
+msgid "`utk` automates removing DXEs: this is the DXE cleaner"
+msgstr "`utk` 自動刪除 DXE：這是 DXE 清潔器"
+
+#: src/implementation.md:197
+#, fuzzy
+msgid ""
+"`utk` removes a DXE, reflashes, checks if it boots, repeat This part should "
+"be easy: DXE can have a dependency section. In practice, it's hard: because "
+"dependency sections are full of errors and omissions. A lot of UEFI code "
+"does not check for failed DXE loads."
+msgstr ""
+"`utk` 刪除 DXE，重新刷新，檢查它是否啟動，重複這部分應該很簡單：DXE 可以有一個依賴部分。實際上，這很難：因為依賴部分充滿了錯誤和遺漏。許多 "
+"UEFI 程式碼不會檢查失敗的 DXE 載入。"
+
+#: src/implementation.md:202
+#, fuzzy
+msgid "Step 6b: place your initramfs in me_cleaned region"
+msgstr "步驟 6b：將你的 initramfs 放入 me_cleaned 區域"
+
+#: src/implementation.md:204
+#, fuzzy
+msgid ""
+"Run `me_cleaner` and then utk tighten on the source image, then inspect the "
+"image using UEFITool. If successful, there will now be padding at the "
+"beginning of the BIOS region of a substantial size."
+msgstr ""
+"執行“me_cleaner”，然後在來源映像上執行 utk 收緊，然後使用 UEFITool 檢查映像。如果成功，BIOS 區域的開頭將會有相當大的填滿。"
+
+#: src/implementation.md:207
+#, fuzzy
+msgid ""
+"This padding space can be used, without the filesystem's knowledge, to stash "
+"an initramfs. The kernel is informed of the location this initramfs as an "
+"initrd kernel parameter."
+msgstr "無需檔案系統的知情，即可使用此填充空間來儲存 initramfs。核心透過 initrd 核心參數獲知此 initramfs 的位置。"
+
+#: src/implementation.md:210
+#, fuzzy
+msgid ""
+"Use the base address of this padding region to calculate the offset in the "
+"flash image where the initrd is stashed using dd."
+msgstr "使用此填滿區域的基底位址來計算快閃記憶體映像中 initrd 所儲存的偏移量（使用 dd）。"
+
+#: src/implementation.md:212
+#, fuzzy
+msgid ""
+"Use the address (not base address) as the initramfs location in memory to "
+"pass as a kernel parameter."
+msgstr "使用位址（不是基底位址）作為記憶體中的 initramfs 位置來傳遞核心參數。"
+
+#: src/implementation.md:215
+#, fuzzy
+msgid "Step 7: replace closed-source with open source"
+msgstr "步驟 7：用開源取代閉源"
+
+#: src/implementation.md:217
+msgid ""
+"If you can build a DXE from source, you can use `utk` to remove the "
+"proprietary one and replace it with one built from source. You can get DXE "
+"source from the tianocore/EDK2 source repo at github.com. The GitHub repo "
+"has a **_limited_** number of DXEs in source form; i.e., you can't build a "
+"full working image using it."
+msgstr ""
+
+#: src/implementation.md:222
+#, fuzzy
+msgid ""
+"There are scripts that let you compile individual DXEs, including the UEFI "
+"Shell and Boot Device Selection (BDS). These two DXEs have been compiled and "
+"are used in the Atomic Pi. Source-based BDS was needed to ensure the UEFI "
+"Shell was called."
+msgstr ""
+"有一些腳本可讓您編譯單一 DXE，包括 UEFI Shell 和啟動裝置選擇 (BDS)。這兩個 DXE 已經編譯完畢並用於 Atomic Pi "
+"中。需要基於來源的 BDS 來確保呼叫 UEFI Shell。"
+
+#: src/implementation.md:226
+#, fuzzy
+msgid "You only need the UEFI Shell built long enough to replace it with Linux."
+msgstr "你只需要建置夠長的 UEFI Shell 就可以用 Linux 取代它。"
+
+#: src/implementation.md:228
+#, fuzzy
+msgid "Final step: reflash the image"
+msgstr "最後一步：刷新鏡像"
+
+#: src/implementation.md:230
+#, fuzzy
+msgid ""
+"\"Native\" reflash: Boot the system whatever way is easiest: netboot, usb, "
+"local disk, and run `flashrom -p internal -w _filename.bin_` where "
+"_filename.bin_ is a filename of your choosing."
+msgstr ""
+"「本機」重新刷新：以最簡單的方式啟動系統：網路啟動、USB、本機磁碟，然後執行“flashrom -p internal -w "
+"_filename.bin_”，其中 _filename.bin_ 是您選擇的檔案名稱。"
+
+#: src/implementation.md:233
+#, fuzzy
+msgid ""
+"Run `flashrom` with an external device such as an sf100. There may be a "
+"header on the board, or you might have to use a clip. `flashrom -p "
+"dediprog:voltage=1.8 -w _filename.bin_`"
+msgstr ""
+"使用外部設備（例如 sf100）運行“flashrom”。板上可能有一個標題，或者您可能需要使用夾子。 `flashrom -p "
+"dediprog:電壓=1.8 -w _filename.bin_`"
+
+#: src/implementation.md:237
+#, fuzzy
+msgid "The voltage option is required for the Atomic Pi."
+msgstr "Atomic Pi 需要電壓選項。"
+
+#: src/coreboot.u-root.systemboot/index.md:3
+#, fuzzy
+msgid ""
+"Points of contact: [Andrea Barberio](https://github.com/insomniacslk), "
+"[David Hendricks](https://github.com/dhendrix)"
+msgstr ""
+"聯絡人：[Andrea Barberio](https://github.com/insomniacslk)、[David "
+"Hendricks](https://github.com/dhendrix)"
+
+#: src/coreboot.u-root.systemboot/index.md:7
+#, fuzzy
+msgid ""
+"This chapter describes how to build a LinuxBoot firmware based on coreboot, "
+"u-root and systemboot.  The examples will focus on `x86_64`, and the "
+"coreboot builds will cover virtual and physical OCP hardware."
+msgstr ""
+"本章介紹如何基於 coreboot、u-root 和 systemboot 建構 LinuxBoot 韌體。  這些範例將集中在「x86_64」上，並且 "
+"coreboot 建置將涵蓋虛擬和實體 OCP 硬體。"
+
+#: src/coreboot.u-root.systemboot/index.md:11
+#, fuzzy
+msgid "Quick Start with coreboot"
+msgstr "使用 coreboot 快速入門"
+
+#: src/coreboot.u-root.systemboot/index.md:13
+msgid ""
+"Run these commands in a directory you create or in `/tmp`; do so because it "
+"creates some files and directories:"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:22
+#, fuzzy
+msgid ""
+"This produces a coreboot image in coreboot-4.9/build/coreboot.rom You can "
+"now run this ROM image:"
+msgstr "這會在 coreboot-4.9/build/coreboot.rom 中產生一個 coreboot 映像，您現在可以執行此 ROM 映像："
+
+#: src/coreboot.u-root.systemboot/index.md:29
+#, fuzzy
+msgid "And see how it looks when you put this in a coreboot ROM image."
+msgstr "當您將其放入 coreboot ROM 映像中時，請看看它看起來如何。"
+
+#: src/coreboot.u-root.systemboot/index.md:33
+#, fuzzy
+msgid "The final image is built on top of multiple open-source components:"
+msgstr "最終的圖像建立在多個開源元件之上："
+
+#: src/coreboot.u-root.systemboot/index.md:35
+#, fuzzy
+msgid ""
+"[coreboot](https://coreboot.org), used for the platform initialization. "
+"Silicon and DRAM initialization are done here."
+msgstr "[coreboot](https://coreboot.org)，用於平台初始化。矽片和 DRAM 初始化在這裡完成。"
+
+#: src/coreboot.u-root.systemboot/index.md:37
+msgid ""
+"[Linux](https://kernel.org), used to initialize peripherals and various "
+"device drivers like file systems, storage and network devices; network "
+"stack; a multiuser and multitasking environment."
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:40
+#, fuzzy
+msgid ""
+"[u-root](https://github.com/u-root/u-root), an user-space environment that "
+"provides basic libraries and utilities to work in a Linux environment."
+msgstr "u-root 是一個使用者空間環境，提供在 Linux 環境中工作所需的基本函式庫和實用程式。"
+
+#: src/coreboot.u-root.systemboot/index.md:42
+#, fuzzy
+msgid ""
+"~~[systemboot](https://systemboot.org), an additional set of libraries and "
+"tools on top of u-root, that provide a bootloader behaviour for various "
+"booting scenarios.~~ systemboot was merged into u-root."
+msgstr ""
+"~~[systemboot](https://systemboot.org)，u-root 之上的一組附加程式庫和工具，為各種啟動場景提供引導程式行為。 "
+"~~ systemboot 已合併到 u-root 中。"
+
+#: src/coreboot.u-root.systemboot/index.md:46
+#, fuzzy
+msgid ""
+"These components are built in reverse order. `u-root` and `systemboot` are "
+"built together in a single step."
+msgstr "這些組件是按相反的順序建構的。 `u-root` 和 `systemboot` 在一個步驟中一起建置。"
+
+#: src/coreboot.u-root.systemboot/index.md:49
+#, fuzzy
+msgid "Building u-root"
+msgstr "建構 u-root"
+
+#: src/coreboot.u-root.systemboot/index.md:51
+#, fuzzy
+msgid ""
+"The first step is building the initramfs. This is done using the `u-root` "
+"ramfs builder, with additional tools and libraries from `systemboot`."
+msgstr "第一步是建置 initramfs。這是使用“u-root”ramfs 建構器以及來自“systemboot”的附加工具和庫完成的。"
+
+#: src/coreboot.u-root.systemboot/index.md:54
+#, fuzzy
+msgid ""
+"u-root is written in Go. We recommend using a relatively recent version of "
+"the Go toolchain. At the time of writing the latest is 1.11, and we "
+"recommend using at least version 1.10. Previous versions may not be fully "
+"supported."
+msgstr ""
+"u-root 是用 Go 寫的。我們建議使用相對較新的 Go 工具鏈版本。在撰寫本文時最新版本為 1.11，我們建議至少使用 1.10 "
+"版本。以前的版本可能不完全受支援。"
+
+#: src/coreboot.u-root.systemboot/index.md:58
+#, fuzzy
+msgid ""
+"Adjust your `PATH` to include `${GOPATH}/bin`, in order to find the `u-root` "
+"command that we will use in the next steps."
+msgstr "調整您的“PATH”以包含“${GOPATH}/bin”，以便找到我們將在下一步中使用的“u-root”命令。"
+
+#: src/coreboot.u-root.systemboot/index.md:61
+#, fuzzy
+msgid "Then, fetch `u-root` and its dependencies:"
+msgstr "然後，取得“u-root”及其相依性："
+
+#: src/coreboot.u-root.systemboot/index.md:67
+#, fuzzy
+msgid ""
+"Then build the ramfs in busybox mode, and add fbnetboot, localboot, and a "
+"custom uinit to wrap everything together:"
+msgstr "然後在 busybox 模式下建立 ramfs，並添加 fbnetboot、localboot 和自訂 uinit 將所有內容包裝在一起："
+
+#: src/coreboot.u-root.systemboot/index.md:74
+#, fuzzy
+msgid ""
+"This command will generate a ramfs named "
+"`/tmp/initramfs_${os}_${arch}.cpio`, e.g. `/tmp/initramfs.linux_amd64.cpio`. "
+"You can specify an alternative output path with `-o`. Run `u-root -h` for "
+"additional command line parameters."
+msgstr ""
+"此指令將產生一個名為「/tmp/initramfs_${os}_${arch}.cpio」的 "
+"ramfs，例如`/tmp/initramfs.linux_amd64.cpio`。您可以使用“-o”指定備用輸出路徑。執行“u-root "
+"-h”以取得更多命令列參數。"
+
+#: src/coreboot.u-root.systemboot/index.md:78
+#, fuzzy
+msgid ""
+"Note: the above command will include only pure-Go commands from `u-root`. If "
+"you need to include other files or non-Go binaries, use the `-file` option "
+"in `u-root`.  For example, you may want to include static builds of `kexec` "
+"or `flashrom`, that we build on https://github.com/systemboot/binaries ."
+msgstr ""
+"注意：上述指令將僅包含來自「u-root」的純 Go 指令。如果需要包含其他檔案或非 Go 二進位文件，請使用「u-root」中的「-file」選項。  "
+"例如，您可能想要包含我們在 https://github.com/systemboot/binaries "
+"上建置的「kexec」或「flashrom」的靜態建置。"
+
+#: src/coreboot.u-root.systemboot/index.md:83
+#, fuzzy
+msgid ""
+"Then, the initramfs has to be compressed. This step is necessary to embed "
+"the initramfs in the kernel as explained below, in order to maintain the "
+"image size smaller. Linux has a limited XZ compressor, so the compression "
+"requires specific options:"
+msgstr ""
+"然後，必須壓縮 initramfs。如下所述，此步驟對於將 initramfs 嵌入核心是必要的，以便保持影像尺寸較小。 Linux 的 XZ "
+"壓縮器功能有限，因此壓縮需要特定的選項："
+
+#: src/coreboot.u-root.systemboot/index.md:92
+#, fuzzy
+msgid "which will produce the file `/tmp/initramfs.linux_amd64.cpio.xz`."
+msgstr "這將產生檔案“/tmp/initramfs.linux_amd64.cpio.xz”。"
+
+#: src/coreboot.u-root.systemboot/index.md:94
+#, fuzzy
+msgid ""
+"The kernel compression requirements are documented under "
+"[Documentation/xz.txt](https://www.kernel.org/doc/Documentation/xz.txt) "
+"(last checked 2018-12-03) in the kernel docs."
+msgstr ""
+"內核壓縮要求記錄在內核文件中的 "
+"[Documentation/xz.txt](https://www.kernel.org/doc/Documentation/xz.txt) "
+"下（最後檢查時間為 2018-12-03）。"
+
+#: src/coreboot.u-root.systemboot/index.md:98
+#, fuzzy
+msgid "Building a suitable Linux kernel"
+msgstr "建構合適的Linux內核"
+
+#: src/coreboot.u-root.systemboot/index.md:100
+#, fuzzy
+msgid ""
+"A sample config to use with QEMU can be downloaded here: "
+"[linux-4.19.6-linuxboot.config](linux-4.19.6-linuxboot.config)."
+msgstr ""
+"可以在此處下載與 QEMU "
+"一起使用的範例設定：[linux-4.19.6-linuxboot.config](linux-4.19.6-linuxboot.config)。"
+
+#: src/coreboot.u-root.systemboot/index.md:103
+#, fuzzy
+msgid ""
+"You need a relatively recent kernel. Ideally a kernel 4.16, to have support "
+"for VPD variables, but a 4.11 can do the job too, if you don't care about "
+"boot entries and want \"brute-force\" booting only."
+msgstr ""
+"您需要一個相對較新的核心。理想情況下，核心 4.16 可以支援 VPD 變量，但如果您不關心啟動條目並且只想要「強力」啟動，那麼 4.11 "
+"也可以完成這項工作。"
+
+#: src/coreboot.u-root.systemboot/index.md:107
+#, fuzzy
+msgid "We will build a kernel with the following properties:"
+msgstr "我們將建立具有以下屬性的核心："
+
+#: src/coreboot.u-root.systemboot/index.md:109
+#, fuzzy
+msgid ""
+"small enough to fit most flash chips, and with some fundamental kernel "
+"features"
+msgstr "足夠小，適合大多數閃存晶片，並具有一些基本的內核功能"
+
+#: src/coreboot.u-root.systemboot/index.md:110
+#, fuzzy
+msgid "that can run Go programs (mainly futex and epoll support)"
+msgstr "可以運行 Go 程式（主要支援 futex 和 epoll）"
+
+#: src/coreboot.u-root.systemboot/index.md:111
+#, fuzzy
+msgid "with the relevant storage and network stack and drivers"
+msgstr "與相關的儲存和網路堆疊和驅動程式"
+
+#: src/coreboot.u-root.systemboot/index.md:112
+#, fuzzy
+msgid "with kexec support, so it can boot a new kernel"
+msgstr "具有 kexec 支持，因此它可以啟動新內核"
+
+#: src/coreboot.u-root.systemboot/index.md:113
+#, fuzzy
+msgid "with kexec signature verification disabled (optional)"
+msgstr "停用 kexec 簽章驗證（可選）"
+
+#: src/coreboot.u-root.systemboot/index.md:114
+#, fuzzy
+msgid "with devtmpfs enabled, since we don't use udev"
+msgstr "啟用 devtmpfs，因為我們不使用 udev"
+
+#: src/coreboot.u-root.systemboot/index.md:115
+#, fuzzy
+msgid "XZ support to decompress the embedded initramfs"
+msgstr "XZ 支援解壓縮嵌入式 initramfs"
+
+#: src/coreboot.u-root.systemboot/index.md:116
+#, fuzzy
+msgid "VPD (Vital Product Data) (optional)"
+msgstr "VPD（重要產品資料）（可選）"
+
+#: src/coreboot.u-root.systemboot/index.md:117
+#, fuzzy
+msgid "TPM support (optional)"
+msgstr "TPM 支援（可選）"
+
+#: src/coreboot.u-root.systemboot/index.md:118
+#, fuzzy
+msgid "embed the u-root initramfs"
+msgstr "嵌入 u-root initramfs"
+
+#: src/coreboot.u-root.systemboot/index.md:119
+#, fuzzy
+msgid "and last but not least, \"linuxboot\" as default host name :)"
+msgstr "最後但同樣重要的是，「linuxboot」作為預設主機名稱:)"
+
+#: src/coreboot.u-root.systemboot/index.md:121
+#, fuzzy
+msgid "Download kernel sources"
+msgstr "下載核心原始碼"
+
+#: src/coreboot.u-root.systemboot/index.md:123
+#, fuzzy
+msgid ""
+"You can either download a tarball from kernel.org, or get it via git and use "
+"a version tag. We recommend at least a kernel 4.16, in order to have VPD "
+"variables support."
+msgstr ""
+"您可以從 kernel.org 下載 tarball，或透過 git 取得它並使用版本標籤。我們建議至少使用內核 4.16，以便獲得 VPD 變數支援。"
+
+#: src/coreboot.u-root.systemboot/index.md:127
+msgid ""
+"```\n"
+"# download the kernel tarball. Replace 4.19.6` with whatever kernel version "
+"you want\n"
+"wget https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-4.19.6.tar.xz\n"
+"tar xvJf linux-4.19.6.tar.xz\n"
+"cd linux-4.19.6\n"
+"make tinyconfig\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:135
+#, fuzzy
+msgid ""
+"You can also check out the `linux-stable` branch, that will point to the "
+"latest stable commit. You need to download it via `git` as follows:"
+msgstr "您也可以查看“linux-stable”分支，它將指向最新的穩定提交。您需要透過 `git` 下載它，如下所示："
+
+#: src/coreboot.u-root.systemboot/index.md:138
+msgid ""
+"```\n"
+"git clone --depth 1 -b linux-stable\n"
+"git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git\n"
+"cd linux-stable\n"
+"make tinyconfig\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:145
+#, fuzzy
+msgid ""
+"Some more information about tiny configs can be found at "
+"https://tiny.wiki.kernel.org (last checked 2018-12-01)."
+msgstr "有關微小配置的更多資訊可以在 https://tiny.wiki.kernel.org 上找到（最後檢查時間為 2018-12-01）。"
+
+#: src/coreboot.u-root.systemboot/index.md:148
+#, fuzzy
+msgid "A few fundamental features"
+msgstr "一些基本特徵"
+
+#: src/coreboot.u-root.systemboot/index.md:150
+#, fuzzy
+msgid "Assuming we are running on `x86_64`, some basic features to enable are:"
+msgstr "假設我們在 `x86_64` 上運行，需要啟用的一些基本功能是："
+
+#: src/coreboot.u-root.systemboot/index.md:152
+#, fuzzy
+msgid "`64-bit kernel`"
+msgstr "`64 位元核心`"
+
+#: src/coreboot.u-root.systemboot/index.md:153
+#, fuzzy
+msgid ""
+"`General setup` → `Configure standard kernel features` → `Enable support for "
+"printk`"
+msgstr "`常規設定` → `配置標準核心功能` → `啟用對 printk 的支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:155
+#, fuzzy
+msgid ""
+"`General setup` → `Configure standard kernel features` → `Multiple users, "
+"groups and capabilities support` (this is not strictly required on LinuxBoot)"
+msgstr "`常規設定` → `配置標準核心功能` → `多重使用者、群組和功能支援`（這在 LinuxBoot 上不是嚴格要求的）"
+
+#: src/coreboot.u-root.systemboot/index.md:158
+#, fuzzy
+msgid ""
+"`Processor type and features` → `Built-in kernel command line` (customize "
+"your command line here if needed, e.g. `earlyprintk=serial,ttyS0,57600 "
+"console=ttyS0,57600`)"
+msgstr ""
+"`處理器類型和功能` → `內建核心命令列`（如果需要，可以在此處自訂命令行，例如`earlyprintk=serial,ttyS0,57600 "
+"console=ttyS0,57600`）"
+
+#: src/coreboot.u-root.systemboot/index.md:161
+#, fuzzy
+msgid ""
+"`Executable file formats / Emulations` → `Kernel support for ELF binaries` "
+"(you may want to enable more formats)"
+msgstr "`可執行檔格式/模擬` → `核心對 ELF 二進位檔案的支援`（您可能想要啟用更多格式）"
+
+#: src/coreboot.u-root.systemboot/index.md:163
+#, fuzzy
+msgid "`Networking support` → `Networking options` → `TCP/IP networking`"
+msgstr "`網路支援` → `網路選項` → `TCP/IP 網路`"
+
+#: src/coreboot.u-root.systemboot/index.md:164
+#, fuzzy
+msgid "`Networking support` → `Networking options` → `The IPv6 protocol`"
+msgstr "`網路支援` → `網路選項` → `IPv6 協定`"
+
+#: src/coreboot.u-root.systemboot/index.md:165
+#, fuzzy
+msgid "`Device Drivers` → `Character devices` → `Enable TTY`"
+msgstr "`裝置驅動程式` → `字元裝置` → `啟用 TTY`"
+
+#: src/coreboot.u-root.systemboot/index.md:166
+#, fuzzy
+msgid ""
+"`Device Drivers` → `Character devices` → `Serial drivers` → `8250/16550 and "
+"compatible serial support`"
+msgstr "`裝置驅動程式` → `字元裝置` → `序列驅動程式` → `8250/16550 及相容序列支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:168
+#, fuzzy
+msgid ""
+"`Device Drivers` → `Character devices` → `Serial drivers` → `Console on "
+"8250/16550 and compatible serial port`"
+msgstr "`裝置驅動程式` → `字元裝置` → `序列驅動程式` → `8250/16550 及相容序列埠上的控制台`"
+
+#: src/coreboot.u-root.systemboot/index.md:170
+#, fuzzy
+msgid "`File systems` → `Pseudo filesystems` → `/proc file system support`"
+msgstr "`檔案系統` → `偽檔案系統` → `/proc 檔案系統支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:171
+#, fuzzy
+msgid "`File systems` → `Pseudo filesystems` → `sysfs file system support`"
+msgstr "`檔案系統` → `偽檔案系統` → `sysfs 檔案系統支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:173
+#, fuzzy
+msgid "Requirements for Go 1.11"
+msgstr "Go 1.11 的要求"
+
+#: src/coreboot.u-root.systemboot/index.md:175
+#, fuzzy
+msgid ""
+"`Go` requires a few kernel features to work properly. At the time of "
+"writing, you need to enable `CONFIG_FUTEX` in your kernel config. Older "
+"versions of Go may require `CONFIG_EPOLL`."
+msgstr ""
+"`Go` 需要一些核心功能才能正常運作。在撰寫本文時，您需要在核心配置中啟用「CONFIG_FUTEX」。舊版的 Go "
+"可能需要「CONFIG_EPOLL」。"
+
+#: src/coreboot.u-root.systemboot/index.md:179
+#: src/coreboot.u-root.systemboot/index.md:199
+#: src/coreboot.u-root.systemboot/index.md:232
+#: src/coreboot.u-root.systemboot/index.md:249
+#: src/coreboot.u-root.systemboot/index.md:259
+#: src/coreboot.u-root.systemboot/index.md:274
+#: src/coreboot.u-root.systemboot/index.md:289
+#, fuzzy
+msgid "In menuconfig:"
+msgstr "在 menuconfig 中："
+
+#: src/coreboot.u-root.systemboot/index.md:181
+#, fuzzy
+msgid ""
+"`General setup` → `Configure standard kernel features (expert users)` → "
+"`Enable futex support`"
+msgstr "`常規設定` → `設定標準核心功能（專家使用者）` → `啟用 futex 支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:183
+#, fuzzy
+msgid ""
+"`General setup` → `Configure standard kernel features (expert users)` → "
+"`Enable eventpoll support`"
+msgstr "`常規設定` → `配置標準核心功能（專家使用者）` → `啟用 eventpoll 支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:186
+#, fuzzy
+msgid ""
+"Additional information about Go's minimum requirements can be found at "
+"https://github.com/golang/go/wiki/MinimumRequirements (last checked "
+"2018-12-01)."
+msgstr ""
+"有關 Go 最低要求的更多信息，請參閱 "
+"https://github.com/golang/go/wiki/MinimumRequirements（最後檢查時間為 2018-12-01）。"
+
+#: src/coreboot.u-root.systemboot/index.md:190
+#, fuzzy
+msgid "Enable devtmpfs"
+msgstr "啟用 devtmpfs"
+
+#: src/coreboot.u-root.systemboot/index.md:192
+#, fuzzy
+msgid ""
+"Our system firmware uses u-root, which does not have (intentionally) an "
+"`udev` equivalent. Therefore, to have `/dev/` automatically populated at "
+"boot time you should enable devtmps."
+msgstr "我們的系統韌體使用 u-root，它沒有（故意）等效的“udev”。因此，為了在啟動時自動填入“/dev/”，您應該啟用 devtmps。"
+
+#: src/coreboot.u-root.systemboot/index.md:196
+#, fuzzy
+msgid ""
+"Simply enable `CONFIG_DEVTMPFS` and `CONFIG_DEVTMPFS_MOUNT` in your kernel "
+"config."
+msgstr "只需在核心配置中啟用“CONFIG_DEVTMPFS”和“CONFIG_DEVTMPFS_MOUNT”即可。"
+
+#: src/coreboot.u-root.systemboot/index.md:201
+#, fuzzy
+msgid ""
+"`Device drivers` → `Generic Driver Options` → `Maintain a devtmpfs "
+"filesystem to mount at /dev`"
+msgstr "`裝置驅動程式` → `通用驅動程式選項` → `維護一個 devtmpfs 檔案系統以掛載在 /dev`"
+
+#: src/coreboot.u-root.systemboot/index.md:203
+#, fuzzy
+msgid ""
+"`Device drivers` → `Generic Driver Options` → `Automount devtmpfs at /dev, "
+"after the kernel mounted the rootfs`"
+msgstr "`裝置驅動程式` → `通用驅動程式選項` → `在核心掛載 rootfs 後，在 /dev 自動掛載 devtmpfs`"
+
+#: src/coreboot.u-root.systemboot/index.md:206
+#, fuzzy
+msgid "Additional drivers"
+msgstr "附加驅動程式"
+
+#: src/coreboot.u-root.systemboot/index.md:208
+#, fuzzy
+msgid ""
+"This really depends on your hardware. You may want to add all the relevant "
+"drivers for the platforms you plan to run LinuxBoot on. For example you may "
+"need to include NIC drivers, file system drivers, and any other device that "
+"you need at boot time."
+msgstr ""
+"這實際上取決於您的硬體。您可能想要為計劃運行 LinuxBoot 的平台添加所有相關的驅動程式。例如，您可能需要包含 NIC "
+"驅動程式、檔案系統驅動程式以及啟動時所需的任何其他裝置。"
+
+#: src/coreboot.u-root.systemboot/index.md:213
+#, fuzzy
+msgid ""
+"For example, enable SCSI disk, SATA drivers, EXT4, and e1000 NIC driver. In "
+"menuconfig:"
+msgstr "例如，啟用 SCSI 磁碟、SATA 驅動程式、EXT4 和 e1000 NIC 驅動程式。在 menuconfig 中："
+
+#: src/coreboot.u-root.systemboot/index.md:216
+#, fuzzy
+msgid "`Bus options` → `PCI support`"
+msgstr "`總線選項` → `PCI 支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:217
+#, fuzzy
+msgid "`Enable the block layer`"
+msgstr "`啟用區塊層`"
+
+#: src/coreboot.u-root.systemboot/index.md:218
+#, fuzzy
+msgid "`Device drivers` → `Block devices` (required for SCSI and SATA)"
+msgstr "`裝置驅動程式` → `區塊裝置`（SCSI 和 SATA 所需）"
+
+#: src/coreboot.u-root.systemboot/index.md:219
+#, fuzzy
+msgid "`Device drivers` → `SCSI device support` → `SCSI disk support`"
+msgstr "`裝置驅動程式` → `SCSI 裝置支援` → `SCSI 磁碟支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:220
+#, fuzzy
+msgid "`Device drivers` → `Serial ATA and Parallel ATA drivers`"
+msgstr "`裝置驅動程式` → `串列 ATA 和並行 ATA 驅動程式`"
+
+#: src/coreboot.u-root.systemboot/index.md:221
+#, fuzzy
+msgid "`File systems` → `The Extended 4 (ext4) filesystem`"
+msgstr "`檔案系統` → `擴充 4 (ext4) 檔案系統`"
+
+#: src/coreboot.u-root.systemboot/index.md:222
+#, fuzzy
+msgid "`Networking support` (required for e1000)"
+msgstr "`網路支援`（e1000 必需）"
+
+#: src/coreboot.u-root.systemboot/index.md:223
+#, fuzzy
+msgid ""
+"`Device drivers` → `Network device support` → `Ethernet driver support` → "
+"`Intel(R) PRO/1000 Gigabit Ethernet support`"
+msgstr "`裝置驅動程式` → `網路裝置支援` → `乙太網路驅動程式支援` → `英特爾(R) PRO/1000 千兆乙太網路支援`"
+
+#: src/coreboot.u-root.systemboot/index.md:226
+#, fuzzy
+msgid "Enable XZ kernel and initramfs compression support"
+msgstr "啟用 XZ 核心和 initramfs 壓縮支持"
+
+#: src/coreboot.u-root.systemboot/index.md:228
+#, fuzzy
+msgid ""
+"The `u-root`\\-based RAMFS will be compressed with XZ and embedded in the "
+"kernel. Hence you need to enable XZ compression support. Make sure to have "
+"at least `CONFIG_HAVE_KERNEL_XZ`, `CONFIG_KERNEL_XZ`, `CONFIG_DECOMPRESS_XZ`."
+msgstr ""
+"基於 `u-root`\\ 的 RAMFS 將使用 XZ 壓縮並嵌入到核心中。因此您需要啟用 XZ "
+"壓縮支援。確保至少具有“CONFIG_HAVE_KERNEL_XZ”、“CONFIG_KERNEL_XZ”和“CONFIG_DECOMPRESS_XZ”。"
+
+#: src/coreboot.u-root.systemboot/index.md:234
+#, fuzzy
+msgid "`General setup` → `Kernel compression mode` → `XZ`"
+msgstr "`常規設定` → `核心壓縮模式` → `XZ`"
+
+#: src/coreboot.u-root.systemboot/index.md:235
+#, fuzzy
+msgid ""
+"`General setup` → `Initial RAM filesystem and RAM disk (initramfs/initrd) "
+"support` → `Support initial ramdisk/ramfs compressed using XZ`"
+msgstr ""
+"`常規設定` → `初始 RAM 檔案系統和 RAM 磁碟 (initramfs/initrd) 支援` → `支援使用 XZ 壓縮的初始 "
+"ramdisk/ramfs`"
+
+#: src/coreboot.u-root.systemboot/index.md:239
+#, fuzzy
+msgid "Enable VPD"
+msgstr "啟用 VPD"
+
+#: src/coreboot.u-root.systemboot/index.md:241
+#, fuzzy
+msgid ""
+"VPD stands for [Vital Product "
+"Data](https://chromium.googlesource.com/chromiumos/platform/vpd/+/1c1806d8df4bb5976eed71a2e2bf156c36ccdce2/README.md). "
+"We use VPD to store boot configuration for `localboot` and `fbnetboot`, "
+"similarly to UEFI's boot variables. Linux supports VPD out of the box, but "
+"you need at least a kernel 4.16."
+msgstr ""
+"VPD "
+"代表[重要產品資料](https://chromium.googlesource.com/chromiumos/platform/vpd/+/1c1806d8df4bb5976eed71a2e2bf156c36ccdce2/README.md)。我們使用 "
+"VPD 來儲存「localboot」和「fbnetboot」的啟動配置，類似於 UEFI 的啟動變數。 Linux 開箱即用支援 "
+"VPD，但您至少需要核心 4.16。"
+
+#: src/coreboot.u-root.systemboot/index.md:247
+#, fuzzy
+msgid "Make sure to have `CONFIG_GOOGLE_VPD` enabled in your kernel config."
+msgstr "確保在核心配置中啟用了“CONFIG_GOOGLE_VPD”。"
+
+#: src/coreboot.u-root.systemboot/index.md:251
+#, fuzzy
+msgid ""
+"`Firmware drivers` → `Google Firmware Drivers` → `Coreboot Table Access - "
+"ACPI` → `Vital Product Data`"
+msgstr "`韌體驅動程式` → `Google 韌體驅動程式` → `Coreboot 表格存取 - ACPI` → `重要產品資料`"
+
+#: src/coreboot.u-root.systemboot/index.md:254
+#, fuzzy
+msgid "TPM support"
+msgstr "TPM 支援"
+
+#: src/coreboot.u-root.systemboot/index.md:256
+#, fuzzy
+msgid ""
+"This also depends on your needs. If you plan to use TPM, and this is "
+"supported by your platform, make sure to enable `CONFIG_TCG_TPM`."
+msgstr "這也取決於您的需求。如果您打算使用 TPM，並且您的平台支援它，請確保啟用「CONFIG_TCG_TPM」。"
+
+#: src/coreboot.u-root.systemboot/index.md:261
+#, fuzzy
+msgid ""
+"`Device drivers` → `Character devices` → `TPM Hardware Support` → (enable "
+"the relevant drivers)"
+msgstr "`裝置驅動程式` → `字元裝置` → `TPM 硬體支援` → （啟用相關驅動程式）"
+
+#: src/coreboot.u-root.systemboot/index.md:264
+#, fuzzy
+msgid "Include the initramfs"
+msgstr "包含 initramfs"
+
+#: src/coreboot.u-root.systemboot/index.md:266
+#, fuzzy
+msgid ""
+"As mentioned above, the kernel will embed the compressed initramfs image. "
+"Your kernel configuration should point to the appropriate file using the "
+"`CONFIG_INITRAMFS_SOURCE` directive. E.g."
+msgstr ""
+"如上所述，核心將嵌入壓縮的 initramfs 映像。您的核心設定應該使用“CONFIG_INITRAMFS_SOURCE”指令指向適當的檔案。例如。"
+
+#: src/coreboot.u-root.systemboot/index.md:270
+msgid ""
+"```\n"
+"CONFIG_INITRAMFS_SOURCE=\"/path/to/initramfs_linux.x86_64.cpio.xz\"\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:276
+#, fuzzy
+msgid ""
+"`General setup` → `Initial RAM filesystem and RAM disk (initramfs/initrd) "
+"support` → `Initramfs source file(s)`"
+msgstr "`常規設定` → `初始 RAM 檔案系統和 RAM 磁碟 (initramfs/initrd) 支援` → `Initramfs 來源檔案`"
+
+#: src/coreboot.u-root.systemboot/index.md:279
+#, fuzzy
+msgid "Default hostname"
+msgstr "預設主機名"
+
+#: src/coreboot.u-root.systemboot/index.md:281
+#, fuzzy
+msgid ""
+"We use \"linuxboot\" as the default hostname. You may want to adjust it to a "
+"different value. You need to set `CONFIG_DEFAULT_HOSTNAME` for the purpose. "
+"For example:"
+msgstr ""
+"我們使用“linuxboot”作為預設主機名稱。您可能想要將其調整為不同的值。您需要為此目的設定“CONFIG_DEFAULT_HOSTNAME”。例如："
+
+#: src/coreboot.u-root.systemboot/index.md:285
+msgid ""
+"```\n"
+"CONFIG_DEFAULT_HOSTNAME=\"linuxboot\"\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:291
+#, fuzzy
+msgid "`General setup` → `Default hostname`"
+msgstr "`常規設定` → `預設主機名稱`"
+
+#: src/coreboot.u-root.systemboot/index.md:293
+#, fuzzy
+msgid "Build the kernel"
+msgstr "建構核心"
+
+#: src/coreboot.u-root.systemboot/index.md:295
+#, fuzzy
+msgid "Once your configuration is ready, build the kernel as usual:"
+msgstr "配置準備好後，照常建構核心："
+
+#: src/coreboot.u-root.systemboot/index.md:301
+#, fuzzy
+msgid ""
+"The image will be located under `arch/${ARCH}/boot/bzImage` if your "
+"architecture supports bzImage (e.g. x86)."
+msgstr "如果您的架構支援 bzImage（例如 x86），則該圖像將位於「arch/${ARCH}/boot/bzImage」下。"
+
+#: src/coreboot.u-root.systemboot/index.md:304
+#, fuzzy
+msgid ""
+"For more details on how to build a kernel, see "
+"https://kernelnewbies.org/KernelBuild (last checked 2018-12-01)."
+msgstr ""
+"有關如何建立內核的更多詳細信息，請參閱 https://kernelnewbies.org/KernelBuild（最後檢查時間為 "
+"2018-12-01）。"
+
+#: src/coreboot.u-root.systemboot/index.md:307
+#, fuzzy
+msgid "Building coreboot"
+msgstr "建構 coreboot"
+
+#: src/coreboot.u-root.systemboot/index.md:309
+#, fuzzy
+msgid ""
+"In this step we will build `coreboot` using the Linux kernel image that we "
+"built at the previous step as payload. This build is for a Qemu x86 target, "
+"the process may be somehow different for other platforms."
+msgstr ""
+"在此步驟中，我們將使用上一步建立的 Linux 核心映像作為有效載荷來建立「coreboot」。此建置針對的是 Qemu x86 "
+"目標，對於其他平台，該過程可能有所不同。"
+
+#: src/coreboot.u-root.systemboot/index.md:313
+#, fuzzy
+msgid "Steps overview:"
+msgstr "步驟概述："
+
+#: src/coreboot.u-root.systemboot/index.md:315
+#, fuzzy
+msgid "download coreboot from the git repo"
+msgstr "從 git repo 下載 coreboot"
+
+#: src/coreboot.u-root.systemboot/index.md:316
+#, fuzzy
+msgid "build the compiler toolchain"
+msgstr "建構編譯器工具鏈"
+
+#: src/coreboot.u-root.systemboot/index.md:317
+#, fuzzy
+msgid "configure coreboot for Qemu, and to use our `bzImage` as payload"
+msgstr "為 Qemu 配置 coreboot，並使用我們的 `bzImage` 作為有效載荷"
+
+#: src/coreboot.u-root.systemboot/index.md:318
+#, fuzzy
+msgid "build `coreboot.rom`"
+msgstr "建構`coreboot.rom`"
+
+#: src/coreboot.u-root.systemboot/index.md:320
+#, fuzzy
+msgid "Download coreboot"
+msgstr "下載 coreboot"
+
+#: src/coreboot.u-root.systemboot/index.md:322
+#, fuzzy
+msgid "Our preferred method is to download coreboot from the git repository:"
+msgstr "我們的首選方法是從 git 儲存庫下載 coreboot："
+
+#: src/coreboot.u-root.systemboot/index.md:324
+msgid ""
+"```\n"
+"git clone https://review.coreboot.org/coreboot.git\n"
+"cd coreboot\n"
+"```"
+msgstr ""
+
+#: src/coreboot.u-root.systemboot/index.md:329
+#, fuzzy
+msgid "Build the compiler toolchain"
+msgstr "建構編譯器工具鏈"
+
+#: src/coreboot.u-root.systemboot/index.md:331
+#, fuzzy
+msgid ""
+"This step is required to have, among other things, reproducible builds, and "
+"a compiler toolchain that is known to work with coreboot."
+msgstr "除其他事項外，此步驟還需要具有可重複的建置以及已知可與 coreboot 一起使用的編譯器工具鏈。"
+
+#: src/coreboot.u-root.systemboot/index.md:338
+#, fuzzy
+msgid ""
+"The step above may ask you to install a few additional libraries or headers, "
+"do so as requested, with the exception of gcc-gnat, that we won't need."
+msgstr "上述步驟可能會要求您安裝一些額外的庫或頭文件，請按照要求進行操作，但我們不需要 gcc-gnat。"
+
+#: src/coreboot.u-root.systemboot/index.md:341
+#, fuzzy
+msgid "Configure coreboot for Qemu and our payload"
+msgstr "為 Qemu 和我們的有效載荷配置 coreboot"
+
+#: src/coreboot.u-root.systemboot/index.md:343
+#, fuzzy
+msgid "Run `make menuconfig` to enter the coreboot configuration menus. Then:"
+msgstr "執行“make menuconfig”進入coreboot配置選單。然後："
+
+#: src/coreboot.u-root.systemboot/index.md:345
+#, fuzzy
+msgid "Specify the platform we will run on:"
+msgstr "指定我們將運行的平台："
+
+#: src/coreboot.u-root.systemboot/index.md:347
+#, fuzzy
+msgid "`Mainboard` → `Mainboard vendor` → `Emulation`"
+msgstr "`主機板` → `主機板供應商` → `仿真`"
+
+#: src/coreboot.u-root.systemboot/index.md:348
+#, fuzzy
+msgid ""
+"`Mainboard` → `Mainboard Model` → `QEMU x86 q35/ich9 (aka qemu -M q35, since "
+"v1.4)`"
+msgstr "`主機板` → `主機板型號` → `QEMU x86 q35/ich9（又稱 qemu -M q35，自 v1.4 起）`"
+
+#: src/coreboot.u-root.systemboot/index.md:351
+#, fuzzy
+msgid "Specify a large enough flash chip and CBFS size:"
+msgstr "指定足夠大的快閃記憶體晶片和 CBFS 大小："
+
+#: src/coreboot.u-root.systemboot/index.md:353
+#, fuzzy
+msgid "`Mainboard` → `ROM chip size` → `16 MB`"
+msgstr "`主機板` → `ROM 晶片大小` → `16 MB`"
+
+#: src/coreboot.u-root.systemboot/index.md:354
+#, fuzzy
+msgid "`Mainboard` → `Size of CBFS filesystem in ROM` → `0x1000000`"
+msgstr "`主機板` → `ROM 中 CBFS 檔案系統的大小` → `0x1000000`"
+
+#: src/coreboot.u-root.systemboot/index.md:356
+#, fuzzy
+msgid "Specify our payload:"
+msgstr "指定我們的有效載荷："
+
+#: src/coreboot.u-root.systemboot/index.md:358
+#, fuzzy
+msgid "`Payload` → `Add a payload` → `A Linux payload`"
+msgstr "`Payload` → `加payload` → `Linuxpayload`"
+
+#: src/coreboot.u-root.systemboot/index.md:359
+#, fuzzy
+msgid "`Payload` → `Linux path and filename` → path to your bzImage"
+msgstr "`Payload` → `Linux 路徑與檔名` → bzImage 的路徑"
+
+#: src/coreboot.u-root.systemboot/index.md:361
+#, fuzzy
+msgid "Then save your configuration and exit menuconfig."
+msgstr "然後儲存您的設定並退出 menuconfig。"
+
+#: src/coreboot.u-root.systemboot/index.md:363
+#, fuzzy
+msgid "Build coreboot"
+msgstr "建構 coreboot"
+
+#: src/coreboot.u-root.systemboot/index.md:365
+#, fuzzy
+msgid "This is done with a simple"
+msgstr "這可以透過一個簡單的"
+
+#: src/coreboot.u-root.systemboot/index.md:371
+#, fuzzy
+msgid ""
+"The coreboot build system will clone the relevant submodules, if it was not "
+"done already, and will build a coreboot ROM file that will contain the "
+"initialization code, and our bzImage payload. The output file is at "
+"`build/coreboot.rom`."
+msgstr ""
+"如果尚未完成，coreboot 建置系統將克隆相關子模組，並將建置一個包含初始化程式碼和我們的 bzImage 有效負載的 coreboot ROM "
+"檔案。輸出檔位於“build/coreboot.rom”。"
+
+#: src/coreboot.u-root.systemboot/index.md:375
+#, fuzzy
+msgid ""
+"If everything works correctly you will get an output similar to the "
+"following:"
+msgstr "如果一切正常，您將獲得類似以下內容的輸出："
+
+#: src/coreboot.u-root.systemboot/index.md:402
+#, fuzzy
+msgid "Putting everything together"
+msgstr "把所有東西放在一起"
+
+#: src/coreboot.u-root.systemboot/index.md:406
+#, fuzzy
+msgid "Defining boot entries"
+msgstr "定義啟動項"
+
+#: src/coreboot.u-root.systemboot/index.md:410
+#, fuzzy
+msgid "Running on a virtual machine"
+msgstr "在虛擬機器上運行"
+
+#: src/coreboot.u-root.systemboot/index.md:412
+#, fuzzy
+msgid ""
+"The image built with the above steps can run on a QEMU virtual machine, "
+"using the machine type `q35`, as specified in the coreboot mainboard "
+"section. Assuming that your coreboot image is located at "
+"`build/coreboot.rom`, you can run the following command:"
+msgstr ""
+"透過上述步驟建構的映像可以在 QEMU 虛擬機器上運行，使用機器類型“q35”，如 coreboot 主機板部分所指定。假設您的 coreboot "
+"映像位於“build/coreboot.rom”，您可以執行下列命令："
+
+#: src/coreboot.u-root.systemboot/index.md:428
+#, fuzzy
+msgid ""
+"If everything has been done correctly you should see, in order, the output "
+"from `coreboot`, `linux`, `u-root`, and `systemboot`. You can press `ctrl-c` "
+"when Systemboot instructs you to do so, to enter the `u-root` shell."
+msgstr ""
+"如果所有操作都正確完成，您應該會依序看到「coreboot」、「linux」、「u-root」和「systemboot」的輸出。當 Systemboot "
+"指示您這樣做時，您可以按「ctrl-c」進入「u-root」shell。"
+
+#: src/coreboot.u-root.systemboot/index.md:432
+#, fuzzy
+msgid "Running on real OCP hardware"
+msgstr "在真實的 OCP 硬體上運行"
+
+#: src/glossary.md:3
+#, fuzzy
+msgid ""
+"_**BIOS**_: Originally, BIOS was the software built into computers to send "
+"simple instructions to the hardware, allowing input and output before the "
+"operating system was loaded. It was a binary blob with no standardized "
+"structure that was responsible for initializing CPU and memory, and jumping "
+"to a hard-coded position on the master block of the first disk drive. BIOS "
+"has been largely replaced by UEFI. Many UEFI implementations still offer a "
+"\"BIOS compatibility mode\" which makes it behave like an old BIOS, with its "
+"features."
+msgstr ""
+"BIOS：最初，BIOS 是電腦內建的軟體，用於在作業系統載入之前向硬體發送簡單指令，允許輸入和輸出。它是一個沒有標準化結構的二進位 "
+"blob，負責初始化 CPU 和內存，並跳到第一個磁碟機主區塊上的硬編碼位置。 BIOS 已基本被 UEFI 取代。許多 UEFI "
+"實作仍然提供“BIOS 相容模式”，使其能夠像舊 BIOS 一樣運作並具有其功能。"
+
+#: src/glossary.md:11
+#, fuzzy
+msgid ""
+"_**busybox**_: Busybox is a single user-space binary which includes versions "
+"of a large number of system commands, including a shell. This package can be "
+"very useful for recovering from certain types of system failures, "
+"particularly those involving broken shared libraries. There are multiple "
+"implementations of busybox, such as git.busybox.net/busybox and "
+"github.com/u-root/u-root."
+msgstr ""
+"_**busybox**_：Busybox 是一個單一用戶空間二進位文件，其中包含大量系統命令的版本，包括一個 "
+"shell。該軟體包對於恢復某些類型的系統故障非常有用，特別是涉及損壞的共享庫的故障。 busybox 有多個實現，例如 "
+"git.busybox.net/busybox 和 github.com/u-root/u-root。"
+
+#: src/glossary.md:17
+#, fuzzy
+msgid ""
+"[_**coreboot**_](https://doc.coreboot.org/): A project to develop open "
+"source boot firmware for various architectures. Its design philosophy is to "
+"do the bare minimum necessary to ensure that hardware is usable and then "
+"pass control to a different program called the payload. The payload can then "
+"provide user interfaces, file system drivers, various policies etc. to load "
+"the OS."
+msgstr ""
+"[_**coreboot**_](https://doc.coreboot.org/)：為各種架構開發開源啟動韌體的專案。其設計理念是盡可能少確保硬體可用，然後將控制權傳遞給稱為有效載荷的另一個程式。然後，有效載荷可以提供使用者介面、檔案系統驅動程式、各種策略等來載入作業系統。"
+
+#: src/glossary.md:23
+#, fuzzy
+msgid ""
+"_**DHCP**_: A networking protocol that runs on a DHCP server and that "
+"automatically assigns an IP address from a pre-configured pool to any "
+"machine that queries it on boot up."
+msgstr "DHCP：一種在 DHCP 伺服器上執行的網路協議，它會自動從預先配置的池中為啟動時查詢它的任何機器分配一個 IP 位址。"
+
+#: src/glossary.md:26
+#, fuzzy
+msgid ""
+"[_**EDK II**_](https://github.com/tianocore/edk2): An open source reference "
+"implementation of an UEFI-compliant firmware, originally developed by Intel"
+msgstr "EDK II：UEFI 相容韌體的開源參考實現，最初由英特爾開發"
+
+#: src/glossary.md:28
+#, fuzzy
+msgid ""
+"_**firmware**_: A specific class of computer software that provides "
+"low-level control for a device's specific hardware. It is installed at the "
+"time of manufacturing and is the first program that runs when a computer is "
+"turned on. It checks to see what hardware components the computing device "
+"has, wakes the components up, and hands them over to the operating system "
+"that is to be installed on the machine. The current x86 firmware is based on "
+"Intel’s Universal Extensible Firmware Interface (UEFI)."
+msgstr ""
+"韌體：一種特定類別的電腦軟體，為設備的特定硬體提供低階控制。它在製造時安裝，並且是電腦啟動時運行的第一個程式。它檢查計算設備有哪些硬體組件，喚醒這些組件，並將它們交給機器上要安裝的作業系統。目前的 "
+"x86 韌體是基於英特爾的通用可擴展韌體介面 (UEFI)。"
+
+#: src/glossary.md:35
+#, fuzzy
+msgid ""
+"_**flashkernel**_: A small Linux kernel that is stored in flash and used as "
+"a boot stage (e.g. the kernel used in LinuxBoot). Debian and Ubuntu maintain "
+"a `flash-kernel` script to install the kernel and initramfs in a special "
+"location for embedded devices that can not boot the kernel and initramfs "
+"using the normal `/boot` mechanism"
+msgstr ""
+"_**flashkernel**_：儲存在快閃記憶體中並用作啟動階段的小型 Linux 核心（例如 LinuxBoot 中使用的核心）。 Debian "
+"和 Ubuntu 維護一個 `flash-kernel` 腳本，用於將核心和 initramfs 安裝到特殊位置，用於無法使用正常 `/boot` "
+"機制啟動核心和 initramfs 的嵌入式設備"
+
+#: src/glossary.md:40
+#, fuzzy
+msgid ""
+"[_**Heads**_](https://github.com/linuxboot/heads): An open source firmware "
+"for laptops and servers, aimed at strong platform security. Developed by "
+"Trammell Hudson, based on stripped UEFI plus Linux, and BusyBox instead of "
+"u-root."
+msgstr ""
+"[_**Heads**_](https://github.com/linuxboot/heads)：筆記型電腦和伺服器的開源固件，旨在實現強大的平台安全性。由 "
+"Trammell Hudson 開發，基於剝離的 UEFI 加 Linux，並使用 BusyBox 代替 u-root。"
+
+#: src/glossary.md:44
+#, fuzzy
+msgid ""
+"_**iSCSI**_: A protocol that provides a way to make network-attached storage "
+"appear to be a local device to the hosts using it, allowing it to be (among "
+"other things) mounted as a regular local file system."
+msgstr ""
+"_**iSCSI**_：一種協議，它提供了一種方法，使網路附加儲存對於使用它的主機來說看起來像是一個本地設備，從而允許它（除其他功能外）作為常規本地檔案系統安裝。"
+
+#: src/glossary.md:47
+#, fuzzy
+msgid ""
+"_**kexec**_: A system call that enables you to load and boot into another "
+"kernel from the currently running kernel. kexec performs the function of the "
+"boot loader from within the kernel."
+msgstr "_**kexec**_：一種系統調用，可讓您從目前正在運行的核心載入並啟動到另一個核心。 kexec 在核心中執行引導程式的功能。"
+
+#: src/glossary.md:50
+#, fuzzy
+msgid ""
+"_**LinuxBIOS**_: A project originated in 1999 from Ron Minnich, Stefan "
+"Reinauer and others. It was an experiment in the idea of running Linux as "
+"firmware. At that time Linux was not mature enough for a hardware "
+"initialization project, and while LinuxBIOS was successful in several "
+"performance-and-reliability critical environments, it didn't see mass "
+"adoption. It later became coreboot."
+msgstr ""
+"_**LinuxBIOS**_：由 Ron Minnich、Stefan Reinauer 和其他人於 1999 年發起的一個專案。這是將 Linux "
+"作為韌體運行的實驗。當時，Linux 對於硬體初始化專案來說還不夠成熟，儘管 LinuxBIOS "
+"在多個效能和可用性關鍵環境中取得了成功，但並未大規模採用。後來它變成了 coreboot。"
+
+#: src/glossary.md:56
+#, fuzzy
+msgid ""
+"_**LinuxBoot**_: LinuxBoot is not a product, but rather a concept. It's the "
+"idea of booting Linux (OS) with Linux (system firmware). In a way, the same "
+"concept pioneered by LinuxBIOS. It is like a Linux distribution, but for "
+"firmware. It is a collection of various open source components, combined to "
+"work as a consistent firmware OS."
+msgstr ""
+"_**LinuxBoot**_：LinuxBoot "
+"不是一個產品，而是一個概念。這就是用Linux（系統韌體）啟動Linux（作業系統）的想法。從某種程度上來說，這與 LinuxBIOS "
+"開創的概念相同。它就像一個 Linux 發行版，但用於韌體。它是各種開源元件的集合，組合起來作為一致的韌體作業系統運作。"
+
+#: src/glossary.md:61
+#, fuzzy
+msgid ""
+"_**NERF**_: The original name for the LinuxBoot project composed of stripped "
+"UEFI plus Linux plus u-root. The name stands for Non-Extensible Reduced "
+"Firmware, as opposed to UEFI's Unified Extensible Firmware Interface. NERF "
+"is an UEFI replacement that is more compact and less extensible. While "
+"extensibility is nice and often desirable, too much extensibility can make a "
+"complex project very hard to maintain and keep secure."
+msgstr ""
+"__NERF__：由剝離的 UEFI 加上 Linux 加上 u-root 組成的 LinuxBoot 專案的原始名稱。此名稱代表不可擴展的精簡固件，與 "
+"UEFI 的統一可擴展固件介面相對。 NERF 是 UEFI "
+"的替代品，更緊湊，擴展性更差。雖然可擴展性很好且通常是可取的，但過多的可擴展性會使複雜的專案很難維護和保持安全。"
+
+#: src/glossary.md:67
+#, fuzzy
+msgid ""
+"_**Open Source Firmware**_: OSF can be used to refer to Open Source Firmware "
+"or Open System Firmware depending on the context."
+msgstr "_**開源韌體**_：根據上下文，OSF 可用於指涉開源韌體或開放系統韌體。"
+
+#: src/glossary.md:69
+#, fuzzy
+msgid ""
+"_**Open System Firmware (OSF)**_: An official subproject of the Open Compute "
+"Project (OCP). OSF has been developed in the open, by various members of OCP "
+"that were interested in having open source system firmware. OSF defines a "
+"set of guidelines with contributions from Microsoft, Google, Facebook, "
+"Intel, 9elements, TwoSigma, and several other companies."
+msgstr ""
+"開放系統韌體 (OSF)：開放計算項目 (OCP) 的官方子項目。 OSF 是由對開源系統韌體感興趣的 OCP 各成員公開開發的。 OSF "
+"在微軟、Google、Facebook、英特爾、9elements、TwoSigma 和其他幾家公司的貢獻下定義了一套指導方針。"
+
+#: src/glossary.md:74
+#, fuzzy
+msgid ""
+"_**OVMF**_: Open Virtual Machine Firmware. Open Virtual Machine Firmware is "
+"a build of EDK II for virtual machines. It includes full support for UEFI, "
+"including Secure Boot, allowing use of UEFI in place of a traditional BIOS "
+"in your EFI Initialization (PEI)|UEFI stage which runs before RAM is "
+"initialized, from cache and ROM. PEI is mostly C-code running in 32-bit "
+"protected flat mode.  The main goal of the PEI stage is to detect RAM. As "
+"soon as RAM is detected and configured, PEI stage give control to the DXE "
+"through DXE Initial Program Load (IPL) driver"
+msgstr ""
+"OVMF：開啟虛擬機器韌體。開放虛擬機器韌體是 EDK II 為虛擬機構建造的版本。它包括對 UEFI 的完全支持，包括安全啟動，允許在 EFI 初始化 "
+"(PEI)|UEFI 階段使用 UEFI 代替傳統 BIOS，該階段在 RAM 初始化之前從快取和 ROM 運行。 PEI 主要是在 32 "
+"位元保護平面模式下運行的 C 代碼。  PEI 階段的主要目標是偵測 RAM。一旦偵測到並配置了 RAM，PEI 階段就會透過 DXE 初始程式載入 "
+"(IPL) 驅動程式將控制權交給 DXE"
+
+#: src/glossary.md:82
+msgid ""
+"_**production kernel**_: LinuxBoot is not intended to be a runtime "
+"production kernel; rather, it is meant to replace specific UEFI "
+"functionality using Linux kernel capabilities and then boot the actual "
+"production kernel (prodkernel) on the machine. Kernel configuration files "
+"specific to LinuxBoot provide the needed Linux kernel capabilities without "
+"bloating the size of the BIOS with unnecessary drivers."
+msgstr ""
+
+#: src/glossary.md:88
+#, fuzzy
+msgid ""
+"_**PureBoot**_: A combination of disabling IME, coreboot, a TPM, Heads and "
+"the Librem Key (see [Trusted Boot (Anti-Evil-Maid, Heads, and "
+"PureBoot)](https://tech.michaelaltfield.net/2023/02/16/evil-maid-heads-pureboot/#pureboot))"
+msgstr ""
+"PureBoot：停用 IME、coreboot、TPM、Heads 和 Librem Key 的組合（請參閱 Trusted Boot "
+"(Anti-Evil-Maid、Heads 和 PureBoot)）"
+
+#: src/glossary.md:91
+#, fuzzy
+msgid ""
+"_**QEMU**_: An emulator that performs hardware virtualization. QEMU is a "
+"hosted virtual machine monitor."
+msgstr "_**QEMU**_：執行硬體虛擬化的模擬器。 QEMU 是一個託管虛擬機器監視器。"
+
+#: src/glossary.md:93
+#, fuzzy
+msgid ""
+"_**Secure Boot Preverifier (SEC)**_: In UEFI, the SEC stage initializes the "
+"CPU cache-as-RAM (CAR) and gives control to the PEI dispatcher. It is 99.9% "
+"assembly code (32-bit protected mode)."
+msgstr ""
+"安全啟動預驗證器 (SEC)：在 UEFI 中，SEC 階段初始化 CPU 快取作為 RAM (CAR) 並將控制權交給 PEI 調度程序。它是 "
+"99.9％ 的彙編代碼（32 位元保護模式）。"
+
+#: src/glossary.md:96
+#, fuzzy
+msgid ""
+"_**u-boot**_: A very popular open source firmware and bootloader. Not to be "
+"confused with u-root."
+msgstr "u-boot：一個非常流行的開源韌體和引導程式。不要與 u-root 混淆。"
+
+#: src/glossary.md:98
+#, fuzzy
+msgid ""
+"_**u-root**_: A modern, embedded user-space environment for Linux, with "
+"bootloader tools. See the section on u-root."
+msgstr "u-root：一個現代的、嵌入式的 Linux 使用者空間環境，附有引導程式工具。請參閱有關 u-root 的部分。"
+
+#: src/glossary.md:100
+#, fuzzy
+msgid ""
+"_**UEFI**_: Unified Extensible Firmware Interface. It is Intel’s "
+"specification of a standard for system firmware. UEFI defines everything "
+"from the layout on the flash chip, to how to interface to peripherals, "
+"enables boot from disk or from a network, defines how UEFI applications "
+"work, etc). It is not an implementation, it's a standard. EDK II and OpenEDK "
+"II are UEFI implementations. UEFI is not closed source per-se, but in "
+"practice most implementations are."
+msgstr ""
+"UEFI：統一可擴充韌體介面。這是英特爾對系統韌體標準的規範。 UEFI "
+"定義了從快閃記憶體晶片上的佈局到如何與週邊設備介面的所有內容，支援從磁碟或網路啟動，定義 UEFI 應用程式如何運作等。它不是一個實現，而是一個標準。 "
+"EDK II 和 OpenEDK II 是 UEFI 實作。 UEFI 本身並不是閉源的，但實際上大多數實作都是閉源的。"
+
+#: src/history.md:5
+#, fuzzy
+msgid ""
+"[BIOS](https://en.wikipedia.org/wiki/BIOS) is the good old, inscrutable way "
+"of initializing a hardware platform in the pre-UEFI days. It's a binary blob "
+"with no standardized structure, that is responsible for initializing CPU and "
+"memory, and jumping to a hard-coded position on the MBR of the first disk "
+"drive."
+msgstr ""
+"[BIOS](https://en.wikipedia.org/wiki/BIOS) 是 UEFI "
+"出現之前初始化硬體平台的一種古老而又難以捉摸的方式。它是一個沒有標準化結構的二進位 blob，負責初始化 CPU 和內存，並跳到第一個磁碟機的 MBR "
+"上的硬編碼位置。"
+
+#: src/history.md:10
+#, fuzzy
+msgid ""
+"Starting around 2000, BIOS has been largely replaced by the standardized "
+"[UEFI](https://en.wikipedia.org/wiki/UEFI). Many UEFI implementations still "
+"offer a BIOS compatibility mode called CSM (Compatibility Support Module), "
+"which makes it behave like an old BIOS."
+msgstr ""
+"從 2000 年左右開始，BIOS 已在很大程度上被標準化的 [UEFI](https://en.wikipedia.org/wiki/UEFI) "
+"所取代。許多 UEFI 實作仍然提供一種稱為 CSM（相容性支援模組）的 BIOS 相容模式，這使其行為類似於舊的 BIOS。"
+
+#: src/history.md:15
+#, fuzzy
+msgid ""
+"Note that the term \"BIOS\" is sometimes misused to refer to the general "
+"concept of _system firmware_, such as UEFI or even LinuxBoot. However, as "
+"\"BIOS\" refers to firmware with specific functionality, UEFI is definitely "
+"_not_ a BIOS, nor is LinuxBoot a BIOS in the original sense."
+msgstr ""
+"請注意，「BIOS」一詞有時會被誤用來指稱系統韌體的一般概念，例如 UEFI 甚至 "
+"LinuxBoot。但是，由於「BIOS」是指具有特定功能的固件，因此 UEFI 絕對不是 BIOS，LinuxBoot 也不是原始意義上的 BIOS。"
+
+#: src/history.md:20
+#, fuzzy
+msgid "LinuxBIOS"
+msgstr "Linux BIOS"
+
+#: src/history.md:22
+#, fuzzy
+msgid ""
+"The "
+"[LinuxBIOS](https://web.archive.org/web/20070430170020/http://www.linuxbios.org/Welcome_to_LinuxBIOS) "
+"project was created in 1999 by Ron Minnich, Stefan Reinauer and others. It "
+"is not much younger than UEFI, but they were already experimenting the idea "
+"of running Linux as firmware. Like many great ideas, it was way ahead of its "
+"time. At that time Linux was not mature enough to be used in a hardware "
+"initialization project, and while LinuxBIOS was successful in several "
+"performance-and-reliability critical environments, it didn't see mass "
+"adoption."
+msgstr ""
+"[LinuxBIOS](https://web.archive.org/web/20070430170020/http://www.linuxbios.org/Welcome_to_LinuxBIOS) "
+"計畫由 Ron Minnich、Stefan Reinauer 等人於 1999 年創立。它並不比 UEFI 年輕多少，但他們已經在嘗試將 Linux "
+"作為韌體運行的想法。就像許多偉大的想法一樣，它遠遠超越了它的時代。當時，Linux 還不夠成熟，無法用於硬體初始化項目，儘管 LinuxBIOS "
+"在多個效能和可用性關鍵環境中取得了成功，但並未大規模採用。"
+
+#: src/history.md:31
+#, fuzzy
+msgid "In 2008 LinuxBIOS became [coreboot](https://www.coreboot.org/)."
+msgstr "2008 年，LinuxBIOS 更名為 [coreboot](https://www.coreboot.org/)。"
+
+#: src/history.md:33
+#, fuzzy
+msgid "LinuxBoot"
+msgstr "Linux啟動"
+
+#: src/history.md:35
+#, fuzzy
+msgid "NERF"
+msgstr "削弱"
+
+#: src/history.md:37
+#, fuzzy
+msgid ""
+"This is the original name for the stripped UEFI, plus Linux, plus u-root. "
+"The name stands for Non-Extensible Reduced Firmware, as opposed to UEFI's "
+"Unified Extensible Firmware Interface. Basically, saying that NERF is an "
+"UEFI replacement that prefers to be more compact, less extensible, and a bit "
+"more opinionated. While extensibility is nice and often desirable, too much "
+"extensibility and too many \"yes\" can make a complex project very hard to "
+"maintain and keep secure."
+msgstr ""
+"這是剝離出來的UEFI的原名，加上Linux，加上u-root。此名稱代表不可擴展的精簡固件，與 UEFI 的統一可擴展固件介面相對。基本上，NERF "
+"是 UEFI "
+"的替代品，它更緊湊、擴展性更差，而且更有主見。雖然可擴展性很好並且常常是人們所希望的，但是過多的可擴展性和過多的“是”會使複雜的項目很難維護和保持安全。"
+
+#: src/history.md:45
+#, fuzzy
+msgid ""
+"NERF was created by Ron Minnich while at Google in 2017. The project grew "
+"and was maintained by Google's \"NERF team\"."
+msgstr "NERF 由 Ron Minnich 於 2017 年在谷歌任職期間創建。該項目由谷歌的“NERF 團隊”發展和維護。"
+
+#: src/history.md:48
+#, fuzzy
+msgid ""
+"NERF eventually became the "
+"[linuxboot](https://github.com/linuxboot/linuxboot/) build system."
+msgstr "NERF 最終成為了 [linuxboot](https://github.com/linuxboot/linuxboot/) 建置系統。"
+
+#: src/history.md:53
+#, fuzzy
+msgid ""
+"[Heads](https://github.com/linuxboot/heads) is an open source firmware for "
+"laptops and servers created by  Trammell Hudson (a.k.a. osreasrch), aimed at "
+"strong platform security. It is currently maintained by Thierry Laurion."
+msgstr ""
+"[Heads](https://github.com/linuxboot/heads) 是由 Trammell Hudson (又名 "
+"osreasrch) 創建的筆記型電腦和伺服器的開源固件，旨在增強平台安全性。它目前由 Thierry Laurion 維護。"
+
+#: src/history.md:57
+#, fuzzy
+msgid "See also"
+msgstr "參見"
+
+#: src/history.md:59
+#, fuzzy
+msgid "[osresearch.net](https://osresearch.net/)"
+msgstr "[osresearch.net](https://osresearch.net/)"
+
+#: src/history.md:60
+#, fuzzy
+msgid "[trmm.net/NERF](https://trmm.net/NERF/)"
+msgstr "[trmm.net/NERF](https://trmm.net/NERF/)"
+
+#: src/history.md:61
+#, fuzzy
+msgid ""
+"[NERF-Projekt statt "
+"UEFI](https://www.golem.de/news/freie-linux-firmware-google-will-server-ohne-intel-me-und-uefi-1710-130840-2.html)"
+msgstr ""
+"[NERF-Projekt statt "
+"UEFI](https://www.golem.de/news/freie-linux-firmware-google-will-server-ohne-intel-me-und-uefi-1710-130840-2.html)"
+
+#: src/history.md:62
+#, fuzzy
+msgid ""
+"[Bringing Linux back to the Server BIOS with "
+"LinuxBoot](https://www.twosigma.com/articles/bringing-linux-back-to-the-server-bios-with-linuxboot/)"
+msgstr "使用 LinuxBoot 將 Linux 重新引入伺服器 BIOS"
+
+#: src/history.md:63
+#, fuzzy
+msgid ""
+"[LinuxBoot: A Fast, Reliable Open Source Firmware for Linux "
+"Servers](https://www.twosigma.com/articles/linuxboot-a-fast-reliable-open-source-firmware-for-linux-servers/)"
+msgstr "LinuxBoot：一款快速、可靠的 Linux 伺服器開源韌體"
+
+#: src/history.md:64
+#, fuzzy
+msgid ""
+"[safeboot: Improving the Safety of Booting Linux on Normal "
+"Laptops](https://www.twosigma.com/articles/safeboot-improving-the-safety-of-booting-linux-on-normal-laptops/)"
+msgstr ""
+"[safeboot：提高一般筆記型電腦啟動 Linux "
+"的安全性](https://www.twosigma.com/articles/safeboot-improving-the-safety-of-booting-linux-on-normal-laptops/)"
+
+#: src/history.md:66
+#, fuzzy
+msgid "Open Platform Firmware"
+msgstr "開放平台韌體"
+
+#: src/history.md:68
+#, fuzzy
+msgid ""
+"[Open Platform "
+"Firmware](https://www.opencompute.org/projects/open-system-firmware) (OPF), "
+"formerly Open System Firmware (OSF), is an official subproject of the [Open "
+"Compute Project](https://www.opencompute.org) (OCP). OPF has been developed "
+"in the open, by various members of OCP that were interested in having open "
+"source system firmware. OPF defines a set of guidelines with contributions "
+"from Microsoft, Google, Facebook, Intel, 9elements, Two Sigma, and several "
+"other companies."
+msgstr ""
+"開放平台韌體 (OPF)，以前稱為開放系統韌體 (OSF)，是開放運算專案 (OCP) 的官方子專案。 OPF 是由對開源系統韌體感興趣的 OCP "
+"各成員公開開發的。 OPF 在微軟、Google、Facebook、英特爾、9elements、Two Sigma "
+"和其他幾家公司的貢獻下定義了一套指導方針。"
+
+#: src/history.md:77
+#, fuzzy
+msgid ""
+"The important thing to keep in mind is that **Open Platform Firmware is a "
+"project name**, not an implementation, nor an idea. An implementation (like "
+"LinuxBoot or OpenEDK2) can be OPF-compliant if it follows the aforementioned "
+"guidelines."
+msgstr ""
+"要記住的重要一點是，**開放平台韌體是一個專案名稱**，而不是一個實現，也不是一個想法。如果遵循上述準則，實作（如 LinuxBoot 或 "
+"OpenEDK2）可以符合 OPF 標準。"
+
+#: src/history.md:81
+#, fuzzy
+msgid "Currently, Open Platform Firmware has two work streams:"
+msgstr "目前，開放平台韌體有兩個工作流程："
+
+#: src/history.md:83
+#, fuzzy
+msgid ""
+"LinuxBoot, led by Google, Facebook, 9elements, ITRenew, TwoSigma, and others"
+msgstr "LinuxBoot，由 Google、Facebook、9elements、ITRenew、TwoSigma 等公司領導"
+
+#: src/history.md:84
+#, fuzzy
+msgid "OpenEDK II, led by Microsoft and Intel"
+msgstr "由微軟和英特爾領導的 OpenEDK II"
+
+#: src/case_studies/index.md:3
+#, fuzzy
+msgid "This chapter contains case studies for various solutions."
+msgstr "本章包含各種解決方案的案例研究。"
+
+#: src/case_studies/index.md:5
+#, fuzzy
+msgid "Table of Contents"
+msgstr "目錄"
+
+#: src/case_studies/index.md:7
+#, fuzzy
+msgid "[Ampere study](Ampere_study.md)"
+msgstr "安培研究"
+
+#: src/case_studies/index.md:8
+#, fuzzy
+msgid "[Google study](Google_study.md)"
+msgstr "[Google 研究](Google_study.md)"
+
+#: src/case_studies/index.md:9
+#, fuzzy
+msgid "[OCP TiogaPass](TiogaPass.md)"
+msgstr "[OCP TiogaPass](TiogaPass.md)"
+
+#: src/case_studies/Ampere_study.md:1
+#, fuzzy
+msgid "LinuxBoot on Ampere Mt. Jade Platform"
+msgstr "Ampere Mt. Jade 平台上的 LinuxBoot"
+
+#: src/case_studies/Ampere_study.md:3
+#, fuzzy
+msgid ""
+"The Ampere Altra Family processor based Mt. Jade platform is a "
+"high-performance ARM server platform, offering up to 256 processor cores in "
+"a dual socket configuration. The Tianocore EDK2 firmware for the Mt. Jade "
+"platform has been fully upstreamed to the tianocore/edk2-platforms "
+"repository, enabling the community to build and experiment with the "
+"platform's firmware using entirely open-source code. It also supports "
+"LinuxBoot, an open-source firmware framework that reduces boot time, "
+"enhances security, and increases flexibility compared to standard UEFI "
+"firmware."
+msgstr ""
+"基於 Ampere Altra 系列處理器的 Mt. Jade 平台是一款高效能 ARM 伺服器平台，在雙插槽配置中可提供多達 256 個處理器核心。 "
+"Mt. Jade 平台的 Tianocore EDK2 韌體已完全上傳至 tianocore/edk2-platforms "
+"儲存庫，使社群能夠使用完全開源程式碼建置和試驗該平台的韌體。它還支援 LinuxBoot，這是一個開源韌體框架，與標準 UEFI "
+"韌體相比，它可以縮短啟動時間、增強安全性並提高靈活性。"
+
+#: src/case_studies/Ampere_study.md:12
+#, fuzzy
+msgid ""
+"Mt. Jade has also achieved a significant milestone by becoming [the first "
+"server certified under the Arm SystemReady LS certification "
+"program](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-systemready-ls). "
+"SystemReady LS ensures compliance with standardized boot and runtime "
+"environments for Linux-based systems, enabling seamless deployment across "
+"diverse hardware.  This certification further emphasizes Mt. Jade's "
+"readiness for enterprise and cloud-scale adoption by providing assurance of "
+"compatibility, performance, and reliability."
+msgstr ""
+"Mt. Jade 也取得了一個重要的里程碑，成為 [第一個經過 Arm SystemReady LS "
+"認證計畫認證的伺服器](https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-systemready-ls)。 "
+"SystemReady LS 確保符合基於 Linux 的系統的標準化啟動和運行時環境，從而實現跨不同硬體的無縫部署。  "
+"該認證透過提供相容性、效能和可靠性的保證，進一步強調了 Mt. Jade 已為企業和雲端規模採用做好準備。"
+
+#: src/case_studies/Ampere_study.md:21
+#, fuzzy
+msgid ""
+"This case study explores the LinuxBoot implementation on the Ampere Mt. Jade "
+"platform, inspired by the approach used in [Google's LinuxBoot "
+"deployment](Google_study.md)."
+msgstr ""
+"本案例研究探討了 Ampere Mt. Jade 平台上的 LinuxBoot 實現，靈感來自於 [Google 的 LinuxBoot "
+"部署](Google_study.md) 中使用的方法。"
+
+#: src/case_studies/Ampere_study.md:25
+#, fuzzy
+msgid "Ampere EDK2-LinuxBoot Components"
+msgstr "Ampere EDK2-Linux啟動組件"
+
+#: src/case_studies/Ampere_study.md:27
+#, fuzzy
+msgid ""
+"The Mt. Jade platform embraces a hybrid firmware architecture, combining "
+"UEFI/EDK2 for hardware initialization and LinuxBoot for advanced boot "
+"functionalities. The platform aligns closely with step 6 in the LinuxBoot "
+"adoption model."
+msgstr ""
+"Mt. Jade 平台採用混合韌體架構，結合 UEFI/EDK2 進行硬體初始化，並結合 LinuxBoot 用於進階啟動功能。該平台與 "
+"LinuxBoot 採用模型中的第 6 步緊密結合。"
+
+#: src/case_studies/Ampere_study.md:34
+#, fuzzy
+msgid ""
+"The entire boot firmware stack for the Mt. Jade is open source and available "
+"in the Github."
+msgstr "Mt. Jade 的整個啟動韌體堆疊都是開源的，可以在 Github 上取得。"
+
+#: src/case_studies/Ampere_study.md:37
+#, fuzzy
+msgid ""
+"**EDK2**: The PEI and minimal (stripped-down) DXE drivers, including both "
+"common and platform code, are fully open source and resides in Tianocore "
+"edk2-platforms and edk2 repositories."
+msgstr ""
+"**EDK2**：PEI 和最小（精簡）DXE 驅動程式（包括通用程式碼和平台程式碼）都是完全開源的，位於 Tianocore edk2 平台和 "
+"edk2 儲存庫中。"
+
+#: src/case_studies/Ampere_study.md:40
+#, fuzzy
+msgid ""
+"**LinuxBoot**: The LinuxBoot binary ([flashkernel](../glossary.md)) for Mt. "
+"Jade is supported in the "
+"[linuxboot/linuxboot](https://github.com/linuxboot/linuxboot/tree/main/mainboards/ampere/jade) "
+"repository."
+msgstr ""
+"**LinuxBoot**：[linuxboot/linuxboot](https://github.com/linuxboot/linuxboot/tree/main/mainboards/ampere/jade) "
+"儲存庫支援 Mt. Jade 的 LinuxBoot 二進位檔案 ([flashkerary.md))。"
+
+#: src/case_studies/Ampere_study.md:45
+#, fuzzy
+msgid "Ampere Solution for LinuxBoot as a Boot Device Selection"
+msgstr "Ampere LinuxBoot 解決方案作為啟動裝置選擇"
+
+#: src/case_studies/Ampere_study.md:47
+#, fuzzy
+msgid ""
+"Ampere has implemented and successfully upstreamed a solution for "
+"integrating LinuxBoot as a Boot Device Selection (BDS) option into the "
+"TianoCore EDK2 framework, as seen in commit [ArmPkg: Implement "
+"PlatformBootManagerLib for "
+"LinuxBoot](https://github.com/tianocore/edk2/commit/62540372230ecb5318a9c8a40580a14beeb9ded0). "
+"This innovation simplifies the boot process for the Mt. Jade platform and "
+"aligns with LinuxBoot's goals of efficiency and flexibility."
+msgstr ""
+"Ampere 已實現並成功上游了一項解決方案，將 LinuxBoot 作為啟動設備選擇 (BDS) 選項整合到 TianoCore EDK2 "
+"框架中，如提交 [ArmPkg：為 LinuxBoot "
+"實現PlatformBootManagerLib](https://github.com/tianocore/edk2/commit/62540372230ecb5318a9c8a40580a14beeb9ded0) "
+"所示。這項創新簡化了 Mt. Jade 平台的啟動過程，並符合 LinuxBoot 的效率和靈活性目標。"
+
+#: src/case_studies/Ampere_study.md:55
+#, fuzzy
+msgid ""
+"Unlike the earlier practice that replaced the UEFI Shell with a LinuxBoot "
+"flashkernel, Ampere's solution introduces a custom BDS implementation that "
+"directly boots into the LinuxBoot environment as the active boot option. "
+"This approach bypasses the need to load the UEFI Shell or UiApp (UEFI Setup "
+"Menu), which depend on numerous unnecessary DXE drivers."
+msgstr ""
+"與早期以 LinuxBoot flashkernel 取代 UEFI Shell 的做法不同，Ampere 的解決方案引入了自訂的 BDS "
+"實現，可直接啟動到 LinuxBoot 環境作為主動啟動選項。這種方法無需載入 UEFI Shell 或 UiApp（UEFI "
+"設定選單），因為它們依賴大量不必要的 DXE 驅動程式。"
+
+#: src/case_studies/Ampere_study.md:61
+#, fuzzy
+msgid ""
+"To further enhance flexibility, Ampere introduced a new GUID specifically "
+"for the LinuxBoot binary, ensuring clear separation from the UEFI Shell "
+"GUID. This distinction allows precise identification of LinuxBoot components "
+"in the firmware."
+msgstr ""
+"為了進一步增強靈活性，Ampere 專門為 LinuxBoot 二進位檔案引入了一個新的 GUID，確保與 UEFI Shell GUID "
+"明確分離。這種區別可以精確識別韌體中的 LinuxBoot 元件。"
+
+#: src/case_studies/Ampere_study.md:66
+#, fuzzy
+msgid "Build Process"
+msgstr "建構過程"
+
+#: src/case_studies/Ampere_study.md:68
+#, fuzzy
+msgid ""
+"Building a flashable EDK2 firmware image with an integrated LinuxBoot "
+"flashkernel for the Ampere Mt. Jade platform involves two main steps: "
+"building the LinuxBoot flashkernel and integrating it into the EDK2 firmware "
+"build."
+msgstr ""
+"為 Ampere Mt. Jade 平台建立具有整合 LinuxBoot flashkernel 的可刷新 EDK2 韌體映像涉及兩個主要步驟：建立 "
+"LinuxBoot flashkernel 並將其整合到 EDK2 韌體建置中。"
+
+#: src/case_studies/Ampere_study.md:72
+#, fuzzy
+msgid "Step 1: Build the LinuxBoot Flashkernel"
+msgstr "步驟 1：建置 LinuxBoot Flashkernel"
+
+#: src/case_studies/Ampere_study.md:74
+#, fuzzy
+msgid "The LinuxBoot flash kernel is built as follows:"
+msgstr "LinuxBoot flash 核心建構如下："
+
+#: src/case_studies/Ampere_study.md:81
+#, fuzzy
+msgid ""
+"After the build process completes, the flash kernel will be located at: "
+"linuxboot/mainboards/ampere/jade/flashkernel"
+msgstr "建置過程完成後，flash 核心將位於：linuxboot/mainboards/ampere/jade/flashkernel"
+
+#: src/case_studies/Ampere_study.md:84
+#, fuzzy
+msgid "Step 2: Build the EDK2 Firmware Image with the Flash Kernel"
+msgstr "步驟 2：使用 Flash 核心建置 EDK2 韌體映像"
+
+#: src/case_studies/Ampere_study.md:86
+#, fuzzy
+msgid ""
+"The EDK2 firmware image is built with the LinuxBoot flashkernel integrated "
+"into the flash image using the following steps:"
+msgstr "EDK2 韌體映像是使用整合到快閃映像中的 LinuxBoot 快閃記憶體核心建構的，步驟如下："
+
+#: src/case_studies/Ampere_study.md:96
+#, fuzzy
+msgid ""
+"The `buildfw.sh` script automatically integrates the LinuxBoot flash kernel "
+"(provided via the -l option) as part of the final EDK2 firmware image."
+msgstr "`buildfw.sh` 腳本自動將 LinuxBoot 快閃記憶體核心（透過 -l 選項提供）集成為最終 EDK2 韌體映像的一部分。"
+
+#: src/case_studies/Ampere_study.md:99
+#, fuzzy
+msgid ""
+"This process generates a flashable EDK2 firmware image with embedded "
+"LinuxBoot, ready for deployment on the Ampere Mt. Jade platform."
+msgstr "此過程產生具有嵌入式 LinuxBoot 的可刷新 EDK2 韌體映像，準備在 Ampere Mt. Jade 平台上部署。"
+
+#: src/case_studies/Ampere_study.md:102
+#, fuzzy
+msgid "Booting with LinuxBoot"
+msgstr "使用 LinuxBoot 啟動"
+
+#: src/case_studies/Ampere_study.md:104
+#, fuzzy
+msgid ""
+"When powered on, the system will boot into the u-root and automatically "
+"kexec to the target OS."
+msgstr "開機後，系統將啟動到 u-root 並自動 kexec 到目標作業系統。"
+
+#: src/case_studies/Ampere_study.md:107
+msgid ""
+"```text\n"
+"Run /init as init process\n"
+"1970/01/01 00:00:10 Welcome to u-root!\n"
+"                              _\n"
+"   _   _      _ __ ___   ___ | |_\n"
+"  | | | |____| '__/ _ \\ / _ \\| __|\n"
+"  | |_| |____| | | (_) | (_) | |_\n"
+"   \\__,_|    |_|  \\___/ \\___/ \\__|\n"
+"\n"
+"cgroup: Unknown subsys name 'perf_event'\n"
+"init: 1970/01/01 00:00:10 Deprecation warning: use UROOT_NOHWRNG=1 on kernel "
+"cmdline instead of uroot.nohwrng\n"
+"1970/01/01 00:00:10 Booting from the following block devices: "
+"[BlockDevice(name=nvme0n1, fs_uuid=) BlockDevice(name=nvme0n1p1, "
+"fs_uuid=d6c6-6306) BlockDevice(name=nvme0n1p2, "
+"fs_uuid=63402158-6266-48fb-b602-5f83f26bd0b9) BlockDevice(name=nvme0n1p3, "
+"fs_uuid=) BlockDevice(name=nvme1n1, fs_uuid=) BlockDevice(name=nvme1n1p1, "
+"fs_uuid=525c-92fb)]\n"
+"1970/01/01 00:00:10 [grub] Got config file "
+"file:///tmp/u-root-mounts3457412855/nvme0n1p1/EFI/ubuntu/grub.cfg:\n"
+"search.fs_uuid 63402158-6266-48fb-b602-5f83f26bd0b9 root\n"
+"set prefix=($root)'/grub'\n"
+"configfile $prefix/grub.cfg\n"
+"\n"
+"1970/01/01 00:00:10 Warning: Grub parser could not parse [\"search\" "
+"\"--fs-uuid\" \"63402158-6266-48fb-b602-5f83f26bd0b9\" \"root\"]\n"
+"1970/01/01 00:00:10 [grub] Got config file "
+"file:///tmp/u-root-mounts3457412855/nvme0n1p2/grub/grub.cfg\n"
+"1970/01/01 00:00:10 Error: Expected 1 device with UUID "
+"\"1334d6c5-c16f-46ba-9120-5127ae43bf63\", found 0\n"
+"1970/01/01 00:00:10 Error: Expected 1 device with UUID "
+"\"1334d6c5-c16f-46ba-9120-5127ae43bf63\", found 0\n"
+"\n"
+"\n"
+"Welcome to LinuxBoot's Menu\n"
+"\n"
+"Enter a number to boot a kernel:\n"
+"\n"
+"1.  Ubuntu\n"
+"\n"
+"2.  Ubuntu, with Linux 6.8.0-49-generic\n"
+"\n"
+"3.  Ubuntu, with Linux 6.8.0-49-generic (recovery mode)\n"
+"\n"
+"4.  Ubuntu, with Linux 6.8.0-48-generic\n"
+"\n"
+"5.  Ubuntu, with Linux 6.8.0-48-generic (recovery mode)\n"
+"\n"
+"6.  Reboot\n"
+"\n"
+"7.  Enter a LinuxBoot shell\n"
+"\n"
+"\n"
+"Enter an option ('01' is the default, 'e' to edit kernel cmdline):\n"
+" > 07\n"
+"\n"
+"> dmidecode -t 4\n"
+"# dmidecode-go\n"
+"Reading SMBIOS/DMI data from sysfs.\n"
+"SMBIOS 3.3.0 present.\n"
+"\n"
+"Handle 0x0003, DMI type 4, 51 bytes\n"
+"Processor Information\n"
+"        Socket Designation: CPU01\n"
+"        Type: Central Processor\n"
+"        Family: ARMv8\n"
+"        Manufacturer: Ampere(R)\n"
+"        ID: 01 00 16 0A A1 00 00 00\n"
+"        Signature: Implementor 0x0a, Variant 0x1, Architecture 6, Part "
+"0x000, Revision 1\n"
+"        Version: Ampere(R) Altra(R) Processor\n"
+"        Voltage: 1.0 V\n"
+"        External Clock: 25 MHz\n"
+"        Max Speed: 3000 MHz\n"
+"        Current Speed: 3000 MHz\n"
+"        Status: Populated, Enabled\n"
+"        Upgrade: Unknown\n"
+"        L1 Cache Handle: 0x0001\n"
+"        L2 Cache Handle: 0x0002\n"
+"        L3 Cache Handle: Not Provided\n"
+"        Serial Number: 000000000000000002550904033865B4\n"
+"        Asset Tag: Not Set\n"
+"        Part Number: Q80-30\n"
+"        Core Count: 80\n"
+"        Core Enabled: 80\n"
+"        Thread Count: 80\n"
+"        Characteristics:\n"
+"                64-bit capable\n"
+"                Multi-Core\n"
+"                Execute Protection\n"
+"                Enhanced Virtualization\n"
+"                Power/Performance Control\n"
+"\n"
+"Handle 0x0007, DMI type 4, 51 bytes\n"
+"Processor Information\n"
+"        Socket Designation: CPU02\n"
+"        Type: Central Processor\n"
+"        Family: ARMv8\n"
+"        Manufacturer: Ampere(R)\n"
+"        ID: 01 00 16 0A A1 00 00 00\n"
+"        Signature: Implementor 0x0a, Variant 0x1, Architecture 6, Part "
+"0x000, Revision 1\n"
+"        Version: Ampere(R) Altra(R) Processor\n"
+"        Voltage: 1.0 V\n"
+"        External Clock: 25 MHz\n"
+"        Max Speed: 3000 MHz\n"
+"        Current Speed: 3000 MHz\n"
+"        Status: Populated, Enabled\n"
+"        Upgrade: Unknown\n"
+"        L1 Cache Handle: 0x0005\n"
+"        L2 Cache Handle: 0x0006\n"
+"        L3 Cache Handle: Not Provided\n"
+"        Serial Number: 000000000000000002560909033865B4\n"
+"        Asset Tag: Not Set\n"
+"        Part Number: Q80-30\n"
+"        Core Count: 80\n"
+"        Core Enabled: 80\n"
+"        Thread Count: 80\n"
+"        Characteristics:\n"
+"                64-bit capable\n"
+"                Multi-Core\n"
+"                Execute Protection\n"
+"                Enhanced Virtualization\n"
+"                Power/Performance Control\n"
+"\n"
+">\n"
+"M-? toggle key help • C-d erase/stop • C-c clear/cancel • C-r search hist …\n"
+"```"
+msgstr ""
+
+#: src/case_studies/Ampere_study.md:223
+#, fuzzy
+msgid "Future Work"
+msgstr "未來工作"
+
+#: src/case_studies/Ampere_study.md:225
+#, fuzzy
+msgid ""
+"While the LinuxBoot implementation on the Ampere Mt. Jade platform "
+"represents a significant milestone, several advanced features and "
+"improvements remain to be explored. These enhancements would extend the "
+"platform's capabilities, improve its usability, and reinforce its position "
+"as a leading open source firmware solution. Key areas for future development "
+"include:"
+msgstr ""
+"雖然 Ampere Mt. Jade 平台上的 LinuxBoot "
+"實作代表著一個重要的里程碑，但仍有一些高級功能和改進有待探索。這些增強功能將擴展平台的功能，提高其可用性，並鞏固其作為領先的開源韌體解決方案的地位。未來發展的重點領域包括："
+
+#: src/case_studies/Ampere_study.md:231
+#, fuzzy
+msgid "Secure Boot with LinuxBoot"
+msgstr "使用 LinuxBoot 進行安全啟動"
+
+#: src/case_studies/Ampere_study.md:233
+#, fuzzy
+msgid ""
+"One of the critical areas for future development is enabling secure boot "
+"verification for the target operating system. In the LinuxBoot environment, "
+"the target OS is typically booted using kexec. However, it is unclear how "
+"Secure Boot operates in this context, as kexec bypasses traditional "
+"firmware-controlled secure boot mechanisms. Future work should investigate "
+"how to extend Secure Boot principles to kexec, ensuring that the OS kernel "
+"and its components are verified and authenticated before execution. This may "
+"involve implementing signature checks and utilizing trusted certificate "
+"chains directly within the LinuxBoot environment to mimic the functionality "
+"of UEFI Secure Boot during the kexec process."
+msgstr ""
+"未來發展的關鍵領域之一是為目標作業系統實現安全啟動驗證。在 LinuxBoot 環境中，目標作業系統通常會使用 kexec 啟動。然而，由於 kexec "
+"繞過了傳統的韌體控制的安全啟動機制，因此尚不清楚安全啟動在這種情況下如何運作。未來的工作應該研究如何將安全啟動原則擴展到 "
+"kexec，確保在執行之前驗證和認證作業系統核心及其元件。這可能涉及在 LinuxBoot 環境中直接實作簽章檢查並利用受信任的憑證鏈來模擬 kexec "
+"過程中 UEFI 安全啟動的功能。"
+
+#: src/case_studies/Ampere_study.md:244
+#, fuzzy
+msgid "TPM Support"
+msgstr "TPM支援"
+
+#: src/case_studies/Ampere_study.md:246
+#, fuzzy
+msgid ""
+"The platform supports TPM, but its integration with LinuxBoot is yet to be "
+"defined. Future work could explore utilizing the TPM for secure boot "
+"measurements, and system integrity attestation."
+msgstr "該平台支援 TPM，但其與 LinuxBoot 的整合尚未確定。未來的工作可以探索利用 TPM 進行安全啟動測量和系統完整性證明。"
+
+#: src/case_studies/Ampere_study.md:250
+#, fuzzy
+msgid "Expanding Support for Additional Ampere Platforms"
+msgstr "擴展對其他 Ampere 平台的支持"
+
+#: src/case_studies/Ampere_study.md:252
+#, fuzzy
+msgid ""
+"Building on the success of LinuxBoot on Mt. Jade, future efforts should "
+"expand support to other Ampere platforms.  This would ensure broader "
+"adoption and usability across different hardware configurations."
+msgstr ""
+"基於 LinuxBoot 在 Mt. Jade 上取得成功，未來的努力應該擴大對其他 Ampere 平台的支援。  "
+"這將確保在不同硬體配置中更廣泛的採用和可用性。"
+
+#: src/case_studies/Ampere_study.md:256
+#, fuzzy
+msgid "Optimizing the Transition Between UEFI and LinuxBoot"
+msgstr "優化 UEFI 和 LinuxBoot 之間的轉換"
+
+#: src/case_studies/Ampere_study.md:258
+#, fuzzy
+msgid ""
+"Improving the efficiency of the handoff between UEFI and LinuxBoot could "
+"further reduce boot times.  This optimization would involve refining the "
+"initialization process and minimizing redundant operations during the "
+"handoff."
+msgstr ""
+"提高 UEFI 和 LinuxBoot 之間的切換效率可以進一步縮短啟動時間。  這種優化將涉及改進初始化過程並最大限度地減少切換期間的冗餘操作。"
+
+#: src/case_studies/Ampere_study.md:262
+#, fuzzy
+msgid "Advanced Diagnostics and Monitoring Tools"
+msgstr "進階診斷和監控工具"
+
+#: src/case_studies/Ampere_study.md:264
+#, fuzzy
+msgid ""
+"Adding more diagnostic and monitoring tools to the LinuxBoot u-root "
+"environment would enhance debugging and system management.  These tools "
+"could provide deeper insights into system performance and potential issues, "
+"improving reliability and maintainability."
+msgstr ""
+"在 LinuxBoot u-root 環境中新增更多診斷和監控工具將增強偵錯和系統管理。  "
+"這些工具可以更深入地了解系統效能和潛在問題，並提高可靠性和可維護性。"
+
+#: src/case_studies/Ampere_study.md:269
+#, fuzzy
+msgid "See Also"
+msgstr "參見"
+
+#: src/case_studies/Ampere_study.md:271
+#, fuzzy
+msgid ""
+"[LinuxBoot on Ampere Platforms: A new (old) approach to "
+"firmware](https://amperecomputing.com/blogs/linuxboot-on-ampere-platforms--a-new-old-approach-to-firmware)"
+msgstr ""
+"Ampere 平台上的 "
+"LinuxBoot：一種新的（舊）韌體方法](https://amperecomputing.com/blogs/linuxboot-on-ampere-platforms--a-new-old-approach-to-firmware)"
+
+#: src/case_studies/Google_study.md:1
+#, fuzzy
+msgid "The LinuxBoot project at Google"
+msgstr "Google 的 LinuxBoot 項目"
+
+#: src/case_studies/Google_study.md:3
+#, fuzzy
+msgid ""
+"Google runs workloads across a number of clusters each with up to tens of "
+"thousands of machines. Firmware runs on these machines when they first start "
+"up. Google is pushing the state-of-the-art in many places including "
+"firmware. The discussion here about Google's implementation of LinuxBoot is "
+"limited to replacing specific UEFI [firmware](../glossary.md) functionality "
+"with a Linux kernel and runtime. Over the years this project has grown to "
+"include various initiatives with the overarching goal of moving from "
+"obscure, complex firmware to simpler, open source firmware."
+msgstr ""
+"Google "
+"在多個叢集上運行工作負載，每個叢集包含多達數萬台機器。這些機器首次啟動時就會運行韌體。谷歌正在包括韌體在內的許多領域推動最先進的技術。這裡關於 "
+"Google 對 LinuxBoot 實作的討論僅限於用 Linux 核心和運行時取代特定的 UEFI [韌體](../glossary.md) "
+"功能。多年來，該專案不斷發展，涵蓋了各種舉措，其總體目標是從晦澀複雜的韌體轉變為更簡單的開源韌體。"
+
+#: src/case_studies/Google_study.md:12
+#, fuzzy
+msgid "Team"
+msgstr "團隊"
+
+#: src/case_studies/Google_study.md:14
+#, fuzzy
+msgid ""
+"There have been a number of contributors to the Google LinuxBoot project "
+"including:"
+msgstr "Google LinuxBoot 專案有許多貢獻者，其中包括："
+
+#: src/case_studies/Google_study.md:17
+#, fuzzy
+msgid "Ron Minnich (technical lead)"
+msgstr "Ron Minnich（技術主管）"
+
+#: src/case_studies/Google_study.md:18
+#, fuzzy
+msgid "Gan-shun Lim"
+msgstr "林幹順"
+
+#: src/case_studies/Google_study.md:19
+#, fuzzy
+msgid "Ryan O'Leary"
+msgstr "瑞安·奧利裡"
+
+#: src/case_studies/Google_study.md:20
+#, fuzzy
+msgid "Prachi Laud"
+msgstr "普拉奇·勞德"
+
+#: src/case_studies/Google_study.md:21
+#, fuzzy
+msgid "Chris Koch"
+msgstr "克里斯·科赫"
+
+#: src/case_studies/Google_study.md:22
+#, fuzzy
+msgid "Xuan Chen"
+msgstr "陳軒"
+
+#: src/case_studies/Google_study.md:23
+#, fuzzy
+msgid "Andrew Sun"
+msgstr "安德魯·孫"
+
+#: src/case_studies/Google_study.md:25
+#, fuzzy
+msgid ""
+"Ryan O'Leary is one of the Open Compute Platform Foundation [Open System "
+"Firmware project](https://www.opencompute.org/projects/open-system-firmware) "
+"volunteer leads and Ron Minnich is the Open Compute Platform Foundation "
+"Incubation Committee Representative."
+msgstr ""
+"Ryan O'Leary 是開放運算平台基金會 "
+"[開放系統韌體專案](https://www.opencompute.org/projects/open-system-firmware) "
+"的志工負責人之一，Ron Minnich 是開放運算平台基金會孵化委員會代表。"
+
+#: src/case_studies/Google_study.md:30
+#, fuzzy
+msgid "Goal"
+msgstr "目標"
+
+#: src/case_studies/Google_study.md:32
+#, fuzzy
+msgid ""
+"The primary goal of Google's LinuxBoot is to modernize the firmware by "
+"simplifying it to technologies engineers understand and trust. In UEFI "
+"systems, LinuxBoot consists of a \"full stack\" solution of stripped-down "
+"UEFI firmware, a Linux kernel, and an initramfs with tools written in Go. "
+"Although these components all make up one bundle stored in ROM, there are "
+"three parts: the closed-source EFI firmware, a Linux kernel, and "
+"[u-root](../u-root.md). The Linux kernel is an unmodified kernel.  The "
+"user-space initramfs image with Go tools for system booting is available as "
+"u-root. Due to this modularity, LinuxBoot can be used with a variety of "
+"systems. In many cases, for example, the same kernel and initramfs have been "
+"used, without recompilation, on both AMD and Intel x86 boards. The UEFI on "
+"these boards is always specific to the board, however."
+msgstr ""
+"Google LinuxBoot 的主要目標是透過簡化韌體使其符合工程師理解和信任的技術，從而使韌體現代化。在 UEFI 系統中，LinuxBoot "
+"由精簡的 UEFI 韌體、Linux 核心以及使用 Go 編寫的工具的 initramfs 組成，是一個「全端」解決方案。雖然這些元件都構成了儲存在 "
+"ROM 中的一個包，但實際上包含三個部分：閉源 EFI 韌體、Linux 核心和 [u-root](../u-root.md)。 Linux "
+"核心是未修改的核心。  具有用於系統啟動的 Go 工具的使用者空間 initramfs 映像可作為 u-root "
+"使用。由於這種模組化，LinuxBoot 可以與各種系統一起使用。例如，在許多情況下，AMD 和 Intel x86 主機板上都使用相同的核心和 "
+"initramfs，無需重新編譯。然而，這些主機板上的 UEFI 始終特定於主機板。"
+
+#: src/case_studies/Google_study.md:46
+#, fuzzy
+msgid "Converting a UEFI firmware image to use LinuxBoot"
+msgstr "將 UEFI 韌體映像轉換為使用 LinuxBoot"
+
+#: src/case_studies/Google_study.md:48
+#, fuzzy
+msgid ""
+"The conversion to LinuxBoot starts with generic UEFI. A UEFI computer boots "
+"in four main phases. The security phase (SEC) and the Pre-EFI Initialization "
+"Stage (PEI) are responsible for low-level operations to prepare the hardware "
+"and are usually specific to the hardware they are implemented for. After "
+"these two stages, the Driver Execution Environment (DXE) loads various "
+"drivers, and then the Boot Device Select (BDS) phase begins."
+msgstr ""
+"向 LinuxBoot 的轉換從通用 UEFI 開始。 UEFI 電腦啟動分為四個主要階段。安全階段 (SEC) 和 Pre-EFI 初始化階段 "
+"(PEI) "
+"負責準備硬體的低階操作，並且通常特定於它們所實現的硬體。經過這兩個階段後，驅動程式執行環境（DXE）會載入各種驅動程序，然後啟動裝置選擇（BDS）階段開始。"
+
+#: src/case_studies/Google_study.md:56
+msgid ""
+"It is not possible to modify the SEC and PEI stages, as their components are "
+"tightly coupled to the chips on the board; even small changes to the chips "
+"require new SEC and PEI stages. LinuxBoot starts during the DXE stage, "
+"resulting in most of the drivers (and their associated attack surface) not "
+"being loaded. Instead, a Linux kernel is loaded as if it were a driver. By "
+"loading during the DXE, LinuxBoot runs after the first two stages of the "
+"UEFI, but takes over after that point, replacing the UEFI drivers. It "
+"therefore completely replaces a large portion of the boot process."
+msgstr ""
+
+#: src/case_studies/Google_study.md:67
+#, fuzzy
+msgid "Phases of the project"
+msgstr "專案階段"
+
+#: src/case_studies/Google_study.md:69
+#, fuzzy
+msgid ""
+"Google's LinuxBoot project is focused on moving UEFI boot functionality into "
+"the kernel and user-space. That is, converting UEFI firmware to run "
+"LinuxBoot. The project has taken the standard UEFI boot process and "
+"converted it to LinuxBoot for production environments. The steps to reach "
+"this goal are described below."
+msgstr ""
+"Google 的 LinuxBoot 專案專注於將 UEFI 啟動功能移入核心和使用者空間。即轉換UEFI韌體來運行LinuxBoot。該專案採用了標準 "
+"UEFI 啟動流程，並將其轉換為適用於生產環境的 LinuxBoot。實現這一目標的步驟如下所述。"
+
+#: src/case_studies/Google_study.md:75
+#, fuzzy
+msgid "Step 1. Reduce or replace UEFI components"
+msgstr "步驟 1.減少或取代 UEFI 組件"
+
+#: src/case_studies/Google_study.md:77
+#, fuzzy
+msgid ""
+"UEFI contains proprietary, closed-source, vendor-supplied firmware drivers "
+"and firmware. LinuxBoot replaces many Driver Execution Environment (DXE) "
+"modules used by UEFI and other firmware, particularly the network stack and "
+"file system modules, with Linux applications."
+msgstr ""
+"UEFI 包含專有的、閉源的、供應商提供的韌體驅動程式和韌體。 LinuxBoot 以 Linux 應用程式取代了 UEFI "
+"和其他韌體使用的許多驅動程式執行環境 (DXE) 模組，特別是網路堆疊和檔案系統模組。"
+
+#: src/case_studies/Google_study.md:83
+#, fuzzy
+msgid ""
+"The following diagram shows the phases of the UEFI boot process. The items "
+"in <span style=\"color:red\">red</span> are components that are either "
+"reduced or eliminated with LinuxBoot. The <span style=\"color:blue\">dark "
+"blue</span> items on the left cannot be changed."
+msgstr ""
+"下圖顯示了 UEFI 啟動過程的各個階段。 <span style=\"color:red\">紅色</span>中的項目是使用 LinuxBoot "
+"減少或消除的元件。左側的<span style=\"color:blue\">深藍</span>項目無法更改。"
+
+#: src/case_studies/Google_study.md:91
+#, fuzzy
+msgid ""
+"In the real FLASH part, the SEC and PEI are actually only 10% of total, so "
+"we reduce the size of those boxes in this and following diagrams."
+msgstr "在真正的 FLASH 部分中，SEC 和 PEI 實際上只佔總量的 10%，因此我們在此圖和下圖中縮小了這些框的尺寸。"
+
+#: src/case_studies/Google_study.md:96
+#, fuzzy
+msgid ""
+"Another part of the conversion process was to modify the UEFI boot process "
+"to boot a LinuxBoot image as shown below."
+msgstr "轉換過程的另一部分是修改 UEFI 啟動過程以啟動 LinuxBoot 映像，如下所示。"
+
+#: src/case_studies/Google_study.md:101
+#, fuzzy
+msgid ""
+"Step 2. Delete or replace as many proprietary DXEs as required to make step "
+"3 work. In most cases, none need to be removed."
+msgstr "步驟 2. 刪除或取代盡可能多的專有 DXE，以使步驟 3 正常運作。大多數情況下，不需要刪除任何內容。"
+
+#: src/case_studies/Google_study.md:106
+#, fuzzy
+msgid "Step 3. Replace the UEFI shell with a Linux kernel + u-root"
+msgstr "步驟 3. 使用 Linux 核心 + u-root 取代 UEFI shell"
+
+#: src/case_studies/Google_study.md:110
+#, fuzzy
+msgid ""
+"When Linux boots it needs a root file system with utilities. LinuxBoot "
+"provides a file system based on u-root standard utilities written in Go."
+msgstr ""
+"當 Linux 啟動時，它需要一個具有實用程式的根檔案系統。 LinuxBoot 提供了一個基於用 Go 編寫的 u-root 標準實用程式的檔案系統。"
+
+#: src/case_studies/Google_study.md:114
+#, fuzzy
+msgid ""
+"Step 4. Through trial and error, continue to remove DXEs until you can't "
+"remove anymore."
+msgstr "步驟4.透過反覆試驗，繼續刪除DXE，直到無法再刪除為止。"
+
+#: src/case_studies/Google_study.md:117
+#, fuzzy
+msgid ""
+"The DXEs are delivered as binary blobs. There are three ways to handle them:"
+msgstr "DXE 以二進位 blob 形式交付。處理它們的方法有三種："
+
+#: src/case_studies/Google_study.md:120
+#, fuzzy
+msgid ""
+"The most desirable is to remove them and let Linux drivers take over what "
+"they did. This works well for USB, network, disk, and other drivers, as well "
+"as network protocols and file systems. In fact we have resolved many system "
+"reliability and performance issues just by removing DXEs!"
+msgstr ""
+"最理想的情況是刪除它們並讓 Linux 驅動程式接管它們所做的事情。這對於 "
+"USB、網路、磁碟和其他驅動程式以及網路協定和檔案系統非常有效。事實上，我們僅透過刪除 DXE 就解決了許多系統可靠性和效能問題！"
+
+#: src/case_studies/Google_study.md:125
+#, fuzzy
+msgid ""
+"The second way is to replace the DXE with an open source driver. This is "
+"less desirable, as the DXE environment is not as hardened as the Linux "
+"kernel environment."
+msgstr "第二種方法是用開源驅動程式取代 DXE。這並不是理想的情況，因為 DXE 環境並不像 Linux 核心環境那樣堅固。"
+
+#: src/case_studies/Google_study.md:128
+#, fuzzy
+msgid ""
+"The final, least desired option, is to continue to use the DXE. This is "
+"required if the DXE contains proprietary code that \"tweaks\" chipset "
+"settings, for example, memory timing or other controls, and there is no "
+"chance of ever bringing them to open source."
+msgstr ""
+"最後，也是最不受歡迎的選擇是繼續使用 DXE。如果 DXE "
+"包含「調整」晶片組設定（例如記憶體時序或其他控制）的專有程式碼，則需要這樣做，並且沒有機會將它們帶到開源。"
+
+#: src/case_studies/Google_study.md:136
+#, fuzzy
+msgid "Step 5. Replace closed source DXEs with open source"
+msgstr "步驟 5. 用開源 DXE 取代閉源 DXE"
+
+#: src/case_studies/Google_study.md:138
+#, fuzzy
+msgid "If we can build a DXE from source, we can use `utk` to:"
+msgstr "如果我們可以從原始碼建構 DXE，我們可以使用“utk”來："
+
+#: src/case_studies/Google_study.md:140
+#, fuzzy
+msgid "Remove the proprietary one"
+msgstr "刪除專有的"
+
+#: src/case_studies/Google_study.md:141
+#, fuzzy
+msgid "Replace it with one built from source"
+msgstr "用從源代碼構建的替換它"
+
+#: src/case_studies/Google_study.md:145
+#, fuzzy
+msgid "Step 6. Next steps: complete LinuxBoot"
+msgstr "步驟 6. 後續步驟：完成 LinuxBoot"
+
+#: src/case_studies/Google_study.md:147
+#, fuzzy
+msgid ""
+"LinuxBoot is currently in production, but the LinuxBoot project development "
+"continues to provide an open-source solution that does the following:"
+msgstr "LinuxBoot 目前正在生產中，但 LinuxBoot 專案開發繼續提供執行以下操作的開源解決方案："
+
+#: src/case_studies/Google_study.md:151
+#, fuzzy
+msgid ""
+"Brings up the Linux kernel as a DXE in flash ROM instead of the UEFI shell."
+msgstr "將 Linux 核心作為快閃 ROM 中的 DXE 而不是 UEFI shell 啟動。"
+
+#: src/case_studies/Google_study.md:152
+#, fuzzy
+msgid ""
+"Provides a Go based user-space that can then bring up the kernel that you "
+"want to run on the machine."
+msgstr "提供基於 Go 的使用者空間，然後可以啟動您想要在機器上運行的核心。"
+
+#: src/case_studies/Google_study.md:154
+#, fuzzy
+msgid ""
+"Enables writing traditional firmware applications such as bootloader, "
+"debugging, diagnosis, and error detection applications as cross-architecture "
+"and cross-platform portable Linux applications."
+msgstr "支援將傳統韌體應用程式（如引導程式、偵錯、診斷和錯誤檢測應用程式）編寫為跨架構和跨平台的可移植 Linux 應用程式。"
+
+#: src/case_studies/Google_study.md:158
+#, fuzzy
+msgid "The complete LinuxBoot solution is shown in the following diagram."
+msgstr "完整的LinuxBoot解決方案如下圖所示。"
+
+#: src/case_studies/TiogaPass.md:1
+#, fuzzy
+msgid "OCP TiogaPass Case Study"
+msgstr "OCP TiogaPass 案例研究"
+
+#: src/case_studies/TiogaPass.md:3
+#, fuzzy
+msgid ""
+"Points of contact: [Jonathan Zhang](https://github.com/jonzhang-fb), [Andrea "
+"Barberio](https://github.com/insomniacslk), [David "
+"Hendricks](https://github.com/dhendrix), "
+"[Adi](https://github.com/agangidi53), [Morgan "
+"Jang](https://github.com/morganjangwiwynn), [Johnny "
+"Lin](https://github.com/johnnylinwiwynn)"
+msgstr ""
+"聯絡人：[Jonathan Zhang](https://github.com/jonzhang-fb)、[Andrea "
+"Barberio](https://github.com/insomniacslk)、[David "
+"Hendricks](https://github.com/dhendrix)、[Adi](https://github.com/agangidi53)、[Morwinithwywy](https://github.com/agangidi53)、[Morangwemywonwemwionw'w'ndm）/Cemnemn;Kwwemwangwulwangwem​​yd "
+"Lin](https://github.com/johnnylinwiwynn)"
+
+#: src/case_studies/TiogaPass.md:11
+#, fuzzy
+msgid ""
+"This case study describes information for firmware development community to "
+"use [OCP](https://www.opencompute.org/) platform TiogaPass, made by [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr ""
+"本案例研究介紹了韌體開發社群使用由 [Wiwynn Corporation](http://www.wiwynn.com/english) 開發的 "
+"[OCP](https://www.opencompute.org/) 平台 TiogaPass 的資訊。"
+
+#: src/case_studies/TiogaPass.md:15
+#, fuzzy
+msgid "It contains following sections:"
+msgstr "它包含以下部分："
+
+#: src/case_studies/TiogaPass.md:17
+#, fuzzy
+msgid "[Quick Start](#Quick-Start)"
+msgstr "[快速入門](#快速入門)"
+
+#: src/case_studies/TiogaPass.md:18
+#, fuzzy
+msgid "[Details](#Details)"
+msgstr "[詳細資料](#詳細資料)"
+
+#: src/case_studies/TiogaPass.md:19
+#, fuzzy
+msgid "[How to build](#How-to-build)"
+msgstr "[如何建構](#如何建構)"
+
+#: src/case_studies/TiogaPass.md:20
+#, fuzzy
+msgid "[How to operate](#How-to-operate)"
+msgstr "[操作方法](#操作方法)"
+
+#: src/case_studies/TiogaPass.md:21
+#, fuzzy
+msgid "[Platform info](#Platform-info)"
+msgstr "[平台資訊](#Platform-info)"
+
+#: src/case_studies/TiogaPass.md:22
+#, fuzzy
+msgid "[Support](#Support)"
+msgstr "[支持](#支持)"
+
+#: src/case_studies/TiogaPass.md:23
+#, fuzzy
+msgid "[Hardware support](#Hardware-support)"
+msgstr "[硬體支援](#Hardware-support)"
+
+#: src/case_studies/TiogaPass.md:24
+#, fuzzy
+msgid "[Community support](#Community-support)"
+msgstr "[社群支持](#Community-support)"
+
+#: src/case_studies/TiogaPass.md:25
+#, fuzzy
+msgid "[Professional support](#Professional-support)"
+msgstr "[專業支援](#專業支援)"
+
+#: src/case_studies/TiogaPass.md:27
+#, fuzzy
+msgid "Quick Start"
+msgstr "快速入門"
+
+#: src/case_studies/TiogaPass.md:29
+#, fuzzy
+msgid ""
+"[Order the hardware](http://www.wiwynn.com/english) if you have not done so."
+msgstr "如果您還沒有訂購硬件，請立即訂購。"
+
+#: src/case_studies/TiogaPass.md:30
+#, fuzzy
+msgid ""
+"Download or build the firmware binary. The current solution is to boot "
+"embedded Linux kernel and initramfs as UEFI payload. Please contact Wiwynn "
+"to get a UEFI binary after ordering."
+msgstr ""
+"下載或建置韌體二進位檔。目前的解決方案是將嵌入式 Linux 核心和 initramfs 作為 UEFI 有效負載啟動。訂購後請聯絡 Wiwynn "
+"以取得 UEFI 二進位。"
+
+#: src/case_studies/TiogaPass.md:33
+#, fuzzy
+msgid "Flash the firmware."
+msgstr "刷新韌體。"
+
+#: src/case_studies/TiogaPass.md:34
+#, fuzzy
+msgid "Copy the downloaded firmware to OpenBMC."
+msgstr "將下載的韌體複製到 OpenBMC。"
+
+#: src/case_studies/TiogaPass.md:35 src/case_studies/TiogaPass.md:40
+#, fuzzy
+msgid "From OpenBMC"
+msgstr "來自 OpenBMC"
+
+#: src/case_studies/TiogaPass.md:39
+#, fuzzy
+msgid "Boot and enjoy."
+msgstr "啟動並享受。"
+
+#: src/case_studies/TiogaPass.md:46
+#, fuzzy
+msgid "Details"
+msgstr "細節"
+
+#: src/case_studies/TiogaPass.md:48
+#, fuzzy
+msgid "How to build"
+msgstr "如何建構"
+
+#: src/case_studies/TiogaPass.md:50
+#, fuzzy
+msgid ""
+"Follow [Build Details](#Build-Details) for details on how to get the source "
+"code, and how to build."
+msgstr "請按照[建置詳細資料](#Build-Details)了解如何取得原始程式碼以及如何建置的詳細資訊。"
+
+#: src/case_studies/TiogaPass.md:53
+#, fuzzy
+msgid ""
+"Boot flow of the current firmware solution is: Power on → minimized UEFI → "
+"LinuxBoot → target OS."
+msgstr "目前韌體解決方案的啟動流程為：開機→最小化UEFI→LinuxBoot→目標OS。"
+
+#: src/case_studies/TiogaPass.md:56
+#, fuzzy
+msgid ""
+"In near feature, the boot flow will be: power on → Coreboot → LinuxBoot → "
+"target OS."
+msgstr "在近期功能中，啟動流程將是：開機→Coreboot→LinuxBoot→目標作業系統。"
+
+#: src/case_studies/TiogaPass.md:59
+#, fuzzy
+msgid "Build Details"
+msgstr "建構詳細信息"
+
+#: src/case_studies/TiogaPass.md:61
+#, fuzzy
+msgid ""
+"Download the code from [linuxboot "
+"github](https://github.com/linuxboot/linuxboot)"
+msgstr "從[linuxboot github](https://github.com/linuxboot/linuxboot)下載程式碼"
+
+#: src/case_studies/TiogaPass.md:62
+msgid ""
+"```\n"
+"  git clone https://github.com/linuxboot/linuxboot.git\n"
+"```"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:65
+#, fuzzy
+msgid "You need to apply Wiwiynn's linuxboot patch for now"
+msgstr "現在您需要套用 Wiwiynn 的 linuxboot 補丁"
+
+#: src/case_studies/TiogaPass.md:66
+msgid ""
+"```\n"
+"cd linuxboot\n"
+"wget -O TiogaPass.patch "
+"https://github.com/johnnylinwiwynn/linuxboot/commit/28ae8450b3b05c6e6b8c74e29d0974ccf711d5e6.patch\n"
+"git am TiogaPass.patch\n"
+"```"
+msgstr ""
+
+#: src/case_studies/TiogaPass.md:71
+#, fuzzy
+msgid ""
+"Build the kernel bzImage (has embedded initramfs) for linuxboot, please "
+"reference [Building "
+"u-root](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemboot#building-u-root) "
+"and [Building a suitable Linux "
+"kernel](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemboot#building-a-suitable-linux-kernel) "
+"for how to build the bzImage. You can always customize your Linux kernel "
+"configuration to suit your needs, please reference Wiwynn's kernel "
+"configuration file as a sample [linux_config](linux_config)."
+msgstr ""
+"為 linuxboot 建立核心 bzImage（已嵌入 initramfs），有關如何建置 bzImage，請參考 [建置 "
+"u-root](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemb#building-u-oot) "
+"和 [設定合適的 "
+"Linux內核](https://github.com/linuxboot/book/tree/master/coreboot.u-root.systemboot#building-a-suitable-linux-kernel)。您隨時可以自訂 "
+"Linux 核心設定以滿足您的需求，請參考 Wiwynn 的核心設定檔作為範例 [linux_config](linux_config)。"
+
+#: src/case_studies/TiogaPass.md:77
+#, fuzzy
+msgid ""
+"Place the tioga.rom into linuxboot/boards/tioga which is provided from "
+"Wiwynn after ordering, and also put your bzImage to the root folder of "
+"linuxboot, and then make"
+msgstr ""
+"將 tioga.rom 放入 Wiwynn 訂購後提供的 linuxboot/boards/tioga 目錄下，並將您的 bzImage 放入 "
+"linuxboot 根目錄下，然後 make"
+
+#: src/case_studies/TiogaPass.md:86
+#, fuzzy
+msgid "You should see the built image at build/tioga/linuxboot.rom."
+msgstr "您應該在 build/tioga/linuxboot.rom 看到建立的圖像。"
+
+#: src/case_studies/TiogaPass.md:88
+#, fuzzy
+msgid "How to operate"
+msgstr "如何操作"
+
+#: src/case_studies/TiogaPass.md:90
+#, fuzzy
+msgid "Follow **TBD section** for details on:"
+msgstr "關注**TBD部分**了解詳細資訊："
+
+#: src/case_studies/TiogaPass.md:92
+#, fuzzy
+msgid ""
+"How to flash. The image can be flashed either out-of-band, or from LinuxBoot "
+"u-root shell, or from targetOS shell."
+msgstr "如何閃現。該圖像可以透過帶外、LinuxBoot u-root shell 或 targetOS shell 進行刷寫。"
+
+#: src/case_studies/TiogaPass.md:94
+#, fuzzy
+msgid "How to run LinuxBoot u-root shell commands."
+msgstr "如何運行 LinuxBoot u-root shell 命令。"
+
+#: src/case_studies/TiogaPass.md:96
+#, fuzzy
+msgid "Platform info"
+msgstr "平台資訊"
+
+#: src/case_studies/TiogaPass.md:98
+#, fuzzy
+msgid ""
+"The SKU contains TiogaPass board, a debug card, a VGA card, a power adapter. "
+"The details can be obtained from the [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr ""
+"SKU 包含 TiogaPass 板、調試卡、VGA 卡、電源適配器。詳情可向 [Wiwynn "
+"Corporation](http://www.wiwynn.com/english) 取得。"
+
+#: src/case_studies/TiogaPass.md:101
+#, fuzzy
+msgid ""
+"Platform design details (including the design spec and schematics) can be "
+"found on the [Open Compute Project UfiSpace product "
+"page](https://www.opencompute.org/products/108/wiwynn-tioga-pass-standard-sv7220g3-s-2u-ocp-server-up-to-768gb-8gb16gb32gb-ddr4-up-to-2666mts-12-dimm-slots)."
+msgstr ""
+"平台設計細節（包括設計規格和原理圖）可以在[開放運算專案 UfiSpace "
+"產品頁面](https://www.opencompute.org/products/108/wiwynn-tioga-pass-standard-sv7220g3-s-2u-ocp-server-up-to-768gb-8gb16gb32gb-ddr4-up-to-2666mts-12-dimm-slots)上找到。"
+
+#: src/case_studies/TiogaPass.md:105
+#, fuzzy
+msgid "Support"
+msgstr "支援"
+
+#: src/case_studies/TiogaPass.md:107
+#, fuzzy
+msgid "Hardware support"
+msgstr "硬體支援"
+
+#: src/case_studies/TiogaPass.md:109
+#, fuzzy
+msgid ""
+"Hardware support can be obtained from [Wiwynn "
+"Corporation](http://www.wiwynn.com/english)."
+msgstr "硬體可從 [Wiwynn Corporation](http://www.wiwynn.com/english) 取得硬體支援。"
+
+#: src/case_studies/TiogaPass.md:111
+#, fuzzy
+msgid "Community support"
+msgstr "社區支持"
+
+#: src/case_studies/TiogaPass.md:113
+#, fuzzy
+msgid ""
+"[OCP Open System "
+"Firmware](https://www.opencompute.org/projects/open-system-firmware) is "
+"where industry collaborates on how to move forward with OSF. The OCP OSF "
+"project has regular recorded meetings and a mailing list."
+msgstr ""
+"[OCP 開放系統韌體](https://www.opencompute.org/projects/open-system-firmware) "
+"是業界就如何推進 OSF 進行合作的地方。 OCP OSF 專案有定期記錄的會議和郵件清單。"
+
+#: src/case_studies/TiogaPass.md:117
+#, fuzzy
+msgid ""
+"[LinuxBoot open source community](https://www.linuxboot.org/) is the "
+"community you can ask any technical questions. LinuxBoot community has a "
+"slack channel, a IRC channel, a mailing list and regular meetings."
+msgstr ""
+"[LinuxBoot 開源社群](https://www.linuxboot.org/) 是您可以詢問任何技術問題的社群。 LinuxBoot "
+"社群有一個 slack 頻道、一個 IRC 頻道、一個郵件清單和定期會議。"
+
+#: src/case_studies/TiogaPass.md:121
+#, fuzzy
+msgid "Professional support"
+msgstr "專業支援"
+
+#: src/case_studies/TiogaPass.md:123
+#, fuzzy
+msgid "Following companies provides professional support services:"
+msgstr "以下公司提供專業的支援服務："
+
+#: src/case_studies/TiogaPass.md:125
+#, fuzzy
+msgid "\\** TBD **"
+msgstr "\\** 待定 **"
+
+#: src/faq.md:1
+#, fuzzy
+msgid "Frequently asked questions"
+msgstr "常見問題"
+
+#: src/faq.md:3
+#, fuzzy
+msgid "Troubleshooting"
+msgstr "故障排除"
+
+#: src/faq.md:5
+#, fuzzy
+msgid "**Why does the u-root DHCP client take ages?**"
+msgstr "**為什麼 u-root DHCP 用戶端需要很長時間？ **"
+
+#: src/faq.md:7
+#, fuzzy
+msgid ""
+"The problem is a lack of early entropy. If your platform has a hardware "
+"random number generator then enable it with `CONFIG_ARCH_RANDOM` and trust "
+"it with `CONFIG_RANDOM_TRUST_CPU`. Otherwise, add `uroot.nohwrng` to your "
+"kernel command line so u-root use a non-blocking random number generator "
+"implementation."
+msgstr ""
+"問題在於缺乏早期熵。如果您的平台有硬體隨機數產生器，請使用「CONFIG_ARCH_RANDOM」啟用它，並使用「CONFIG_RANDOM_TRUST_CPU」信任它。否則，將“uroot.nohwrng”新增至核心命令列，以便 "
+"u-root 使用非阻塞隨機數產生器實作。"
+
+msgid ""
+msgstr ""
+
+msgid ""
+msgstr ""
+
+msgid ""
+msgstr ""
+
+msgid ""
+msgstr ""
+

--- a/theme/css/language-picker.css
+++ b/theme/css/language-picker.css
@@ -1,0 +1,13 @@
+#language-list {
+    left: auto;
+    right: 10px;
+}
+
+[dir="rtl"] #language-list {
+    left: 10px;
+    right: auto;
+}
+
+#language-list a {
+    color: inherit;
+}

--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -1,0 +1,4 @@
+<script>
+    const mdbookPath = "{{ path }}";
+    const mdbookPathToRoot = "{{ path_to_root }}";
+</script>

--- a/theme/js/language-picker.js
+++ b/theme/js/language-picker.js
@@ -1,0 +1,44 @@
+(function addThemePicker() {
+    const rightButtonsElement = document.querySelector('.right-buttons');
+    rightButtonsElement.insertAdjacentHTML("afterbegin", `
+        <button id="language-toggle" class="icon-button" type="button"
+                title="Change language" aria-label="Change language"
+                aria-haspopup="true" aria-expanded="false"
+                aria-controls="language-list">
+            <i class="fa fa-globe"></i>
+        </button>
+        <ul id="language-list" class="theme-popup" aria-label="Languages" role="menu">
+          <li role="none"><button role="menuitem" class="theme">
+              <a id="en">English</a>
+          </button></li>
+          <li role="none"><button role="menuitem" class="theme">
+              <a id="zh-TW">正體中文</a>
+          </button></li>
+        </ul>
+    `);
+
+    const language = document.documentElement.getAttribute("lang");
+    let langToggle = document.getElementById("language-toggle");
+    let langList = document.getElementById("language-list");
+    langToggle.addEventListener("click", (event) => {
+        langList.style.display =
+            langList.style.display == "block" ? "none" : "block";
+    });
+    let selectedLang = document.getElementById(language);
+    if (selectedLang) {
+        selectedLang.parentNode.classList.add("theme-selected");
+    }
+
+    // The path to the root, taking the current language into account.
+    let full_path_to_root =
+        language == "en" ? `${mdbookPathToRoot}` : `${mdbookPathToRoot}../`;
+    // The page path (mdbook only gives us access to the path to the Markdown file).
+    let path = mdbookPath.replace(/\.md$/, ".html");
+    for (let lang of langList.querySelectorAll("a")) {
+        if (lang.id == "en") {
+            lang.href = `${full_path_to_root}${path}`;
+        } else {
+            lang.href = `${full_path_to_root}${lang.id}/${path}`;
+        }
+    }
+})();


### PR DESCRIPTION
Hi all,

This PR adds initial support for Traditional Chinese (`zh-TW`) and enables multilingual builds, based on the implementation in the [rust-by-example](https://github.com/rust-lang/rust-by-example) project.

### Changes:
- Add a language switcher (`language-picker.js`) to the theme
- Enable multilingual support (`en`, `zh-TW`) in the build pipeline
- Update GitHub Actions to build and deploy all translations
- Add machine-translated `zh-TW` content (to be progressively revised)
- Revise `SUMMARY.md` and `intro.md` to use natural Traditional Chinese and remove fuzzy flags

I will continue improving the Traditional Chinese translation in future commits.

Feedback welcome!
