### PR TITLE
u-root: specify language for code blocks

### DIFF
--- a/src/u-root.md
+++ b/src/u-root.md
@@ -393,7 +393,7 @@ built in. Scripts run via the script command are not persistent.
 
 A basic hello builtin can be defined on the command line:
 
-```
+```sh
 builtin hello '{ fmt.Printf("Hello\n") }'
 ```
 
@@ -432,7 +432,7 @@ Go fragment and creates a standard shell builtin Go source file which conforms
 to the builtin pattern. This structure is easy to generate programmatically,
 building on the techniques used for the script command.
 
-```
+```sh
 script{ fmt.Printf("%v\n", os.Environ()) }
 ```
 


### PR DESCRIPTION
It won't pass `mdl` though due to false positives:

```
$ mdl src/u-root.md
src/u-root.md:489: MD011 Reversed link syntax
src/u-root.md:179: MD056 Table has inconsistent number of columns
src/u-root.md:223: MD056 Table has inconsistent number of columns
src/u-root.md:231: MD056 Table has inconsistent number of columns
src/u-root.md:275: MD056 Table has inconsistent number of columns
```
