### PR TITLE
Makefile: update i18n helpers, switch to linkcheck2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ run:
 	mdbook serve
 
 prepare_i18n:
-	cargo install mdbook-i18n-helpers --locked --version 0.3.4
+	cargo install mdbook-i18n-helpers --locked --version 0.4.0
 
 prepare: prepare_i18n
 	cargo install mdbook
 	cargo install mdbook-mermaid
 	mdbook-mermaid install
-	cargo install mdbook-linkcheck
+	cargo install mdbook-linkcheck2

--- a/book.toml
+++ b/book.toml
@@ -18,7 +18,7 @@ additional-js = [
 [build]
 extra-watch-dirs = ["po"]
 
-[output.linkcheck]
+[output.linkcheck2]
 
 [preprocessor]
 


### PR DESCRIPTION
The update is necessary to accomodate for mdbook 0.5.0. The fork is necessary for 0.5.0 as well, because the original is no longer maintained, as it seems.
TODO: Adjust GitHub CI, but that requires the Action to align. See: https://github.com/jontze/action-mdbook/issues/671