### PR TITLE
CI: upgrade mdBook and plugins, switch to mdbook-linkcheck2

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,15 +19,15 @@ jobs:
 
       - name: Setup mdBook
         # https://github.com/jontze/action-mdbook
-        uses: jontze/action-mdbook@v4
+        uses: orangecms/action-mdbook@v4.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # mdbook-version: 'latest'
-          mdbook-version: "0.4.48"
+          mdbook-version: "0.5.3"
           use-mermaid: true
-          mermaid-version: "0.15.0"
+          mermaid-version: "0.17.0"
           use-linkcheck: true
-          linkcheck-version: "0.7.7"
+          linkcheck-version: "0.12.2"
 
       - name: Install mdbook-mermaid
         run: mdbook-mermaid install


### PR DESCRIPTION
Temporarily use my fork of the action, until the PR is merged upstream.